### PR TITLE
Bump dogen version to enable tech preview builds

### DIFF
--- a/image.yaml
+++ b/image.yaml
@@ -232,7 +232,7 @@ cct:
           - cct_module.os-java-run:
                 - install_as_root:
 dogen:
-    version: 2.4.3
+    version: 2.4.4
     plugins:
         cct:
             verbose: true


### PR DESCRIPTION
New dogen (2.4.4) includes further changes for the preparation of
tech preview images.