### PR TITLE
Do not override from: for dev builds

### DIFF
--- a/override-dev.yaml
+++ b/override-dev.yaml
@@ -1,6 +1,3 @@
-# Use latest development image
-from: "jboss/openjdk18-rhel7:dev"
-
 # Use the correct development branch
 osbs:
   repository:


### PR DESCRIPTION
The base images are a special case and we don't want to build on top
of them for the dev OpenJDK image.

Signed-off-by: Jonathan Dowland <jdowland@redhat.com>