### PR TITLE
[CLOUD-2705] add usage label

### DIFF
--- a/image.yaml
+++ b/image.yaml
@@ -18,6 +18,8 @@ labels:
       value: "/tmp"
     - name: org.jboss.deployments-dir
       value: "/deployments"
+    - name: usage
+      value: "https://access.redhat.com/documentation/en-us/red_hat_jboss_middleware_for_openshift/3/html/red_hat_java_s2i_for_openshift/"
 from: "jboss/openjdk18-rhel7:1.1"
 envs:
     - name: PATH


### PR DESCRIPTION
this is to shadow rhel75's usage label which is not appropriate for this image; we point at the customer
documentation instead.

https://issues.jboss.org/browse/CLOUD-2705