### PR TITLE
[CLOUD-2855] Overhaul the GC tests to be more robust

### DIFF
--- a/tests/features/java/gc.feature
+++ b/tests/features/java/gc.feature
@@ -3,40 +3,56 @@ Feature: Openshift OpenJDK GC tests
 
   Scenario: Check default GC configuration
     Given s2i build https://github.com/jboss-openshift/openshift-quickstarts from undertow-servlet
-    Then s2i build log should contain Setting MAVEN_OPTS to -XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap -XX:+UseParallelOldGC -XX:MinHeapFreeRatio=10 -XX:MaxHeapFreeRatio=20 -XX:GCTimeRatio=4 -XX:AdaptiveSizePolicyWeight=90 -XX:MaxMetaspaceSize=100m
-    And container log should contain -XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap -XX:+UseParallelOldGC -XX:MinHeapFreeRatio=10 -XX:MaxHeapFreeRatio=20 -XX:GCTimeRatio=4 -XX:AdaptiveSizePolicyWeight=90 -XX:MaxMetaspaceSize=100m
+    Then s2i build log should match regex Setting MAVEN_OPTS to.*-XX:\+UseParallelOldGC
+    And  s2i build log should match regex Setting MAVEN_OPTS to.*-XX:\+UnlockExperimentalVMOptions
+    And  s2i build log should match regex Setting MAVEN_OPTS to.*-XX:\+UseCGroupMemoryLimitForHeap
+    And  s2i build log should match regex Setting MAVEN_OPTS to.*-XX:MinHeapFreeRatio=10
+    And  s2i build log should match regex Setting MAVEN_OPTS to.*-XX:MaxHeapFreeRatio=20
+    And  s2i build log should match regex Setting MAVEN_OPTS to.*-XX:GCTimeRatio=4
+    And  s2i build log should match regex Setting MAVEN_OPTS to.*-XX:AdaptiveSizePolicyWeight=90
+    And  s2i build log should match regex Setting MAVEN_OPTS to.*-XX:MaxMetaspaceSize=100m
+    And  s2i build log should match regex Setting MAVEN_OPTS to.*-XX:\+ExitOnOutOfMemoryError
+    And  container log should contain -XX:+UseParallelOldGC
+    And  container log should contain -XX:+UnlockExperimentalVMOptions
+    And  container log should contain -XX:+UseCGroupMemoryLimitForHeap
+    And  container log should contain -XX:MinHeapFreeRatio=10
+    And  container log should contain -XX:MaxHeapFreeRatio=20
+    And  container log should contain -XX:GCTimeRatio=4
+    And  container log should contain -XX:AdaptiveSizePolicyWeight=90
+    And  container log should contain -XX:MaxMetaspaceSize=100m
+    And  container log should contain -XX:+ExitOnOutOfMemoryError
 
   Scenario: Check GC_MIN_HEAP_FREE_RATIO GC configuration
     Given s2i build https://github.com/jboss-openshift/openshift-quickstarts from undertow-servlet
        | variable                         | value  |
        | GC_MIN_HEAP_FREE_RATIO           | 5      |
-    Then s2i build log should contain Setting MAVEN_OPTS to -XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap -XX:+UseParallelOldGC -XX:MinHeapFreeRatio=5 -XX:MaxHeapFreeRatio=20 -XX:GCTimeRatio=4 -XX:AdaptiveSizePolicyWeight=90 -XX:MaxMetaspaceSize=100m
-    And container log should contain -XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap -XX:+UseParallelOldGC -XX:MinHeapFreeRatio=5 -XX:MaxHeapFreeRatio=20 -XX:GCTimeRatio=4 -XX:AdaptiveSizePolicyWeight=90 -XX:MaxMetaspaceSize=100m
+    Then s2i build log should match regex Setting MAVEN_OPTS to.*-XX:MinHeapFreeRatio=5
+    And  container log should contain -XX:MinHeapFreeRatio=5
 
   Scenario: Check GC_MAX_HEAP_FREE_RATIO GC configuration
     Given s2i build https://github.com/jboss-openshift/openshift-quickstarts from undertow-servlet
        | variable                         | value  |
        | GC_MAX_HEAP_FREE_RATIO           | 50     |
-    Then s2i build log should contain Setting MAVEN_OPTS to -XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap -XX:+UseParallelOldGC -XX:MinHeapFreeRatio=10 -XX:MaxHeapFreeRatio=50 -XX:GCTimeRatio=4 -XX:AdaptiveSizePolicyWeight=90 -XX:MaxMetaspaceSize=100m
-    And container log should contain -XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap -XX:+UseParallelOldGC -XX:MinHeapFreeRatio=10 -XX:MaxHeapFreeRatio=50 -XX:GCTimeRatio=4 -XX:AdaptiveSizePolicyWeight=90 -XX:MaxMetaspaceSize=100m
+    Then s2i build log should match regex Setting MAVEN_OPTS to.*-XX:MaxHeapFreeRatio=50
+    And  container log should contain -XX:MaxHeapFreeRatio=50
 
   Scenario: Check GC_TIME_RATIO GC configuration
     Given s2i build https://github.com/jboss-openshift/openshift-quickstarts from undertow-servlet
        | variable                         | value  |
        | GC_TIME_RATIO                    | 5      |
-    Then s2i build log should contain Setting MAVEN_OPTS to -XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap -XX:+UseParallelOldGC -XX:MinHeapFreeRatio=10 -XX:MaxHeapFreeRatio=20 -XX:GCTimeRatio=5 -XX:AdaptiveSizePolicyWeight=90 -XX:MaxMetaspaceSize=100m
-    And container log should contain -XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap -XX:+UseParallelOldGC -XX:MinHeapFreeRatio=10 -XX:MaxHeapFreeRatio=20 -XX:GCTimeRatio=5 -XX:AdaptiveSizePolicyWeight=90 -XX:MaxMetaspaceSize=100m
+    Then s2i build log should match regex Setting MAVEN_OPTS to.*-XX:GCTimeRatio=5
+    And  container log should contain -XX:GCTimeRatio=5
 
   Scenario: Check GC_ADAPTIVE_SIZE_POLICY_WEIGHT GC configuration
     Given s2i build https://github.com/jboss-openshift/openshift-quickstarts from undertow-servlet
        | variable                         | value  |
        | GC_ADAPTIVE_SIZE_POLICY_WEIGHT   | 80     |
-    Then s2i build log should contain Setting MAVEN_OPTS to -XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap -XX:+UseParallelOldGC -XX:MinHeapFreeRatio=10 -XX:MaxHeapFreeRatio=20 -XX:GCTimeRatio=4 -XX:AdaptiveSizePolicyWeight=80 -XX:MaxMetaspaceSize=100m
-    And container log should contain -XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap -XX:+UseParallelOldGC -XX:MinHeapFreeRatio=10 -XX:MaxHeapFreeRatio=20 -XX:GCTimeRatio=4 -XX:AdaptiveSizePolicyWeight=80 -XX:MaxMetaspaceSize=100m
+    Then s2i build log should match regex Setting MAVEN_OPTS to.*-XX:AdaptiveSizePolicyWeight=80
+    And  container log should contain -XX:AdaptiveSizePolicyWeight=80
 
   Scenario: Check GC_MAX_METASPACE_SIZE GC configuration
     Given s2i build https://github.com/jboss-openshift/openshift-quickstarts from undertow-servlet
        | variable                 | value  |
        | GC_MAX_METASPACE_SIZE    | 120    |
-    Then s2i build log should contain Setting MAVEN_OPTS to -XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap -XX:+UseParallelOldGC -XX:MinHeapFreeRatio=10 -XX:MaxHeapFreeRatio=20 -XX:GCTimeRatio=4 -XX:AdaptiveSizePolicyWeight=90 -XX:MaxMetaspaceSize=120m
-    And container log should contain -XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap -XX:+UseParallelOldGC -XX:MinHeapFreeRatio=10 -XX:MaxHeapFreeRatio=20 -XX:GCTimeRatio=4 -XX:AdaptiveSizePolicyWeight=90 -XX:MaxMetaspaceSize=120m
+    Then s2i build log should match regex Setting MAVEN_OPTS to.*-XX:MaxMetaspaceSize=120m
+    And  container log should contain -XX:MaxMetaspaceSize=120m


### PR DESCRIPTION
These test broke as a result of work in CLOUD-2286. Rework them to use
regular expressions to be less sensitive to re-ordering or unrelated
changes on the same line as the things we are concerned with.

https://issues.jboss.org/browse/CLOUD-2855

----

- [x] Pull Request title is properly formatted: `[CLOUD-XYA] Subject`
- [x] Pull Request contains link to the JIRA issue
- [x] Pull Request contains description of the issue
- [x] Pull Request does not include fixes for issues other than the main ticket
- [x] Attached commits represent units of work and are properly formatted
- [x] You have read and agreed to the Developer Certificate of Origin (DCO) (see `CONTRIBUTING.md`)
- [x] Every commit contains `Signed-off-by: Your Name <yourname@example.com>` - use `git commit -s`
