### PR TITLE
CLOUD-3095 add test to catch failure of binary-only S2I mode

### DIFF
--- a/tests/features/java/java_s2i.feature
+++ b/tests/features/java/java_s2i.feature
@@ -299,8 +299,14 @@ Feature: Openshift OpenJDK S2I tests
     Then s2i build log should contain --batch-mode
     And s2i build log should not contain \r
 
+  # CLOUD-3095 - context dir should be recursively copied into the image
+  # "/target" suffix is important here; it triggers a different code-path (no source build)
+  Scenario: Ensure binary-only mode copies binaries into the target image
+    Given s2i build https://github.com/jboss-openshift/openshift-examples from spring-boot-sample-simple/target
+    Then s2i build log should not contain skipping directory .
+    And  run find /deployments in container and check its output for spring-boot-sample-simple-1.5.0.BUILD-SNAPSHOT.jar
+
   Scenario: Check java perf dir owned by jboss (CLOUD-2070)
     Given s2i build https://github.com/jboss-openshift/openshift-examples from spring-boot-sample-simple
     Then run sh -c 'pgrep -x java | xargs -I{} jstat -gc {} 1000 1' in container and check its output for S0C
     And run sh -c 'stat --printf="%U %G" /tmp/hsperfdata_jboss/' in container and check its output for jboss root
-


### PR DESCRIPTION
test to catch what is fixed in https://github.com/jboss-openshift/cct_module/pull/330

https://issues.jboss.org/browse/CLOUD-3095