### PR TITLE
remove 'after CentOS 7.6 release' from README

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -16,8 +16,6 @@ This will produce an image named `centos/openjdk-8-centos7`
 
 ### CentOS JDK 11
 
-NOTE: This image will be available to build after CentOS 7.6 release.
-
 ```
 cekit --overrides-file=centos7-jdk11-overrides.yaml build
 ```


### PR DESCRIPTION
because CentOS 7.6 meanwhile *is* released

but note #59