### PR TITLE
[CLOUD-3329] Add s390 to content sets

### DIFF
--- a/content_sets.yml
+++ b/content_sets.yml
@@ -4,3 +4,6 @@ ppc64le:
 x86_64:
 - rhel-server-rhscl-7-rpms
 - rhel-7-server-rpms
+s390x:
+- rhel-7-for-system-z-rpms
+- rhel-7-server-for-system-z-rhscl-rpms

--- a/rhel8-jdk11-overrides.yaml
+++ b/rhel8-jdk11-overrides.yaml
@@ -45,3 +45,6 @@ packages:
     aarch64:
       - rhel-8-for-aarch64-baseos-rpms
       - rhel-8-for-aarch64-appstream-rpms
+    s390x:
+      - rhel-8-for-s390x-baseos-rpms
+      - rhel-8-for-s390x-appstream-rpms

--- a/rhel8-jdk8-overrides.yaml
+++ b/rhel8-jdk8-overrides.yaml
@@ -43,3 +43,6 @@ packages:
     aarch64:
       - rhel-8-for-aarch64-baseos-rpms
       - rhel-8-for-aarch64-appstream-rpms
+    s390x:
+      - rhel-8-for-s390x-baseos-rpms
+      - rhel-8-for-s390x-appstream-rpms


### PR DESCRIPTION
Add S390/System-Z architecture definitions to the content sets
definitions.

https://issues.jboss.org/browse/CLOUD-3329