### PR TITLE
[CLOUD-3358] Document the cekit version we are using

### DIFF
--- a/image.yaml
+++ b/image.yaml
@@ -1,3 +1,6 @@
+# This is an Image descriptor for Cekit
+# we are currently using Cekit 3.3.1
+
 schema_version: 1
 
 from: "centos:7"


### PR DESCRIPTION
Cekit is a fast-moving project. If you build the same image sources with two different versions of cekit you might get very different outputs when compared with e.g. diff or git diff. It's therefore helpful for us to document which version we are using at the present moment so we can manage the diff caused by tooling changes when we review newer versions of the tooling.

https://issues.jboss.org/browse/CLOUD-3358