### PR TITLE
Fix maven installation for RHEL 7

### DIFF
--- a/rhel7-jdk11-overrides.yaml
+++ b/rhel7-jdk11-overrides.yaml
@@ -21,6 +21,8 @@ modules:
   install:
   - name: jboss.container.openjdk.jdk
     version: "11"
+  - name: jboss.container.maven.35.bash
+    version: "3.5scl"
 
 packages:
   content_sets_file: content_sets.yml

--- a/rhel7-jdk8-overrides.yaml
+++ b/rhel7-jdk8-overrides.yaml
@@ -16,6 +16,11 @@ envs:
 - name: "JBOSS_IMAGE_VERSION"
   value: "1.6"
 
+modules:
+  install:
+  - name: jboss.container.maven.35.bash
+    version: "3.5scl"
+
 packages:
   content_sets_file: content_sets.yml
 


### PR DESCRIPTION
Use version 3.5scl as override for the
jboss.container.maven.35.bash module as the default
for it is version 3.5. For some reason the cct_module
branch configured in image.yaml doesn't seem to matter
for branch "release". Even though it is configured to
use "sprint-35" versions get properly resolved.

Cekit mystery to me.

With this override, rh-maven35 (scl module) over plain
maven via gets installed on RHEL 7.