### PR TITLE
[CLOUD-3362] image streams: "labels" → "metadata"

### DIFF
--- a/templates/image-streams.json
+++ b/templates/image-streams.json
@@ -18,10 +18,10 @@
                     "openshift.io/display-name": "Red Hat OpenJDK 8",
                     "openshift.io/provider-display-name": "Red Hat, Inc.",
                     "version": "1.4.17"
+                },
+                "labels": {
+                    "xpaas": "1.4.17"
                 }
-            },
-            "labels": {
-                "xpaas": "1.4.17"
             },
             "spec": {
                 "tags": [
@@ -177,10 +177,10 @@
                     "openshift.io/display-name": "Red Hat OpenJDK 11",
                     "openshift.io/provider-display-name": "Red Hat, Inc.",
                     "version": "1.4.17"
+                },
+                "labels": {
+                    "xpaas": "1.4.17"
                 }
-            },
-            "labels": {
-                "xpaas": "1.4.17"
             },
             "spec": {
                 "tags": [
@@ -216,10 +216,10 @@
                     "openshift.io/display-name": "Red Hat OpenJDK 1.8 (RHEL8)",
                     "openshift.io/provider-display-name": "Red Hat, Inc.",
                     "version": "1.4.17"
+                },
+                "labels": {
+                    "xpaas": "1.4.17"
                 }
-            },
-            "labels": {
-                "xpaas": "1.4.17"
             },
             "spec": {
                 "tags": [
@@ -254,10 +254,10 @@
                     "openshift.io/display-name": "Red Hat OpenJDK 11 (RHEL8)",
                     "openshift.io/provider-display-name": "Red Hat, Inc.",
                     "version": "1.4.17"
+                },
+                "labels": {
+                    "xpaas": "1.4.17"
                 }
-            },
-            "labels": {
-                "xpaas": "1.4.17"
             },
             "spec": {
                 "tags": [
@@ -292,10 +292,10 @@
                     "openshift.io/display-name": "Red Hat OpenJDK",
                     "openshift.io/provider-display-name": "Red Hat, Inc.",
                     "version": "1.4.17"
+                },
+                "labels": {
+                    "xpaas": "1.4.17"
                 }
-            },
-            "labels": {
-                "xpaas": "1.4.17"
             },
             "spec": {
                 "tags": [

--- a/templates/openjdk-web-basic-s2i.json
+++ b/templates/openjdk-web-basic-s2i.json
@@ -13,11 +13,11 @@
             "template.openshift.io/documentation-url": "https://access.redhat.com/documentation/en/",
             "template.openshift.io/support-url": "https://access.redhat.com"
         },
+        "labels": {
+            "template": "openjdk-web-basic-s2i",
+            "xpaas": "1.4.17"
+        },
         "name": "openjdk-web-basic-s2i"
-    },
-    "labels": {
-        "template": "openjdk-web-basic-s2i",
-        "xpaas": "1.4.17"
     },
     "message": "A new java application has been created in your project.",
     "parameters": [


### PR DESCRIPTION
Move the "labels" blocks inside the "metadata" block within Image
Streams.

https://issues.jboss.org/browse/CLOUD-3362