### PR TITLE
Fix release branch for recent RCM changes

### DIFF
--- a/content_sets.yml
+++ b/content_sets.yml
@@ -4,3 +4,6 @@ ppc64le:
 x86_64:
 - rhel-server-rhscl-7-rpms
 - rhel-7-server-rpms
+s390x:
+- rhel-7-for-system-z-rpms
+- rhel-7-server-for-system-z-rhscl-rpms

--- a/rhel7-jdk11-overrides.yaml
+++ b/rhel7-jdk11-overrides.yaml
@@ -21,6 +21,8 @@ modules:
   install:
   - name: jboss.container.openjdk.jdk
     version: "11"
+  - name: jboss.container.maven.35.bash
+    version: "3.5scl"
 
 packages:
   content_sets_file: content_sets.yml

--- a/rhel7-jdk8-overrides.yaml
+++ b/rhel7-jdk8-overrides.yaml
@@ -16,6 +16,11 @@ envs:
 - name: "JBOSS_IMAGE_VERSION"
   value: "1.6"
 
+modules:
+  install:
+  - name: jboss.container.maven.35.bash
+    version: "3.5scl"
+
 packages:
   content_sets_file: content_sets.yml
 

--- a/rhel8-jdk1.8-overrides.yaml
+++ b/rhel8-jdk1.8-overrides.yaml
@@ -44,3 +44,6 @@ packages:
     aarch64:
       - rhel-8-for-aarch64-baseos-rpms
       - rhel-8-for-aarch64-appstream-rpms
+    s390x:
+      - rhel-8-for-s390x-baseos-rpms
+      - rhel-8-for-s390x-appstream-rpms

--- a/rhel8-jdk1.8-overrides.yaml
+++ b/rhel8-jdk1.8-overrides.yaml
@@ -41,3 +41,6 @@ packages:
     ppc64le:
       - rhel-8-for-ppc64le-baseos-rpms
       - rhel-8-for-ppc64le-appstream-rpms
+    aarch64:
+      - rhel-8-for-aarch64-baseos-rpms
+      - rhel-8-for-aarch64-appstream-rpms

--- a/rhel8-jdk11-overrides.yaml
+++ b/rhel8-jdk11-overrides.yaml
@@ -46,3 +46,6 @@ packages:
     aarch64:
       - rhel-8-for-aarch64-baseos-rpms
       - rhel-8-for-aarch64-appstream-rpms
+    s390x:
+      - rhel-8-for-s390x-baseos-rpms
+      - rhel-8-for-s390x-appstream-rpms

--- a/rhel8-jdk11-overrides.yaml
+++ b/rhel8-jdk11-overrides.yaml
@@ -43,3 +43,6 @@ packages:
     ppc64le:
       - rhel-8-for-ppc64le-baseos-rpms
       - rhel-8-for-ppc64le-appstream-rpms
+    aarch64:
+      - rhel-8-for-aarch64-baseos-rpms
+      - rhel-8-for-aarch64-appstream-rpms


### PR DESCRIPTION
Enabling s390 for the RCM branch configuration caused the release
branch to stop building since it lacks the content_sets definitions
for the new architecture. Additionally, Cekit's module-resolution
logic has begun to pick the wrong Maven module for RHEL 7 images.

Thanks Severin Gehwolf!