### PR TITLE
Rename image stream to the actual rhel-8 OpenJDK 8 image

### DIFF
--- a/templates/image-streams.json
+++ b/templates/image-streams.json
@@ -211,7 +211,7 @@
             "kind": "ImageStream",
             "apiVersion": "v1",
             "metadata": {
-                "name": "openjdk-1.8-rhel8",
+                "name": "openjdk-8-rhel8",
                 "annotations": {
                     "openshift.io/display-name": "Red Hat OpenJDK 1.8 (RHEL8)",
                     "openshift.io/provider-display-name": "Red Hat, Inc.",
@@ -239,7 +239,7 @@
                         },
                         "from": {
                             "kind": "DockerImage",
-                            "name": "registry.redhat.io/openjdk/openjdk-1.8-rhel8:1.0"
+                            "name": "registry.redhat.io/openjdk/openjdk-8-rhel8:1.0"
                         }
                     }
                 ]


### PR DESCRIPTION
Image in the Red Hat registry is:

openjdk/openjdk-8-rhel8

NOT:

openjdk/openjdk-1.8-rhel8

This yielded import errors (NotFount).

Signed-off-by: Severin Gehwolf <sgehwolf@redhat.com>