### PR TITLE
Pin cct_module version to latest tag

### DIFF
--- a/image.yaml
+++ b/image.yaml
@@ -36,7 +36,7 @@ modules:
   - name: cct_module
     git:
       url: https://github.com/jboss-openshift/cct_module.git
-      ref: master
+      ref: 0.37.0
   install:
   - name: jboss.container.openjdk.jdk
     version: "8"


### PR DESCRIPTION
If we're going to do the next build from the develop branch, we need
to be sure exactly which cct_module version we're getting.