### PR TITLE
Adjust Jolokia test to pass for future Jolokia JAR

### DIFF
--- a/tests/features/java/jolokia.feature
+++ b/tests/features/java/jolokia.feature
@@ -5,4 +5,5 @@ Feature: Openshift OpenJDK Jolokia tests
 
   Scenario: Check Environment variable is correct
     Given s2i build https://github.com/jboss-openshift/openshift-quickstarts from undertow-servlet
-    Then run sh -c 'unzip -q -p /opt/jolokia/jolokia.jar META-INF/build.metadata | fgrep ${JOLOKIA_VERSION}' in container and check its output for build.version
+    Then run sh -c 'unzip -q -p /opt/jolokia/jolokia.jar META-INF/maven/org.jolokia/jolokia-jvm/pom.properties | grep -F ${JOLOKIA_VERSION}' in container and check its output for version=
+


### PR DESCRIPTION
This tweaked way of checking the version works with the current JAR
as well as the forthcoming 1.6.2
(see: <https://github.com/jboss-openshift/cct_module/pull/343>)