### PR TITLE
bump JDK8/RHEL7 minor version to reflect label update

### DIFF
--- a/image.yaml
+++ b/image.yaml
@@ -5,7 +5,7 @@ schema_version: 1
 
 from: "rhel7:7-released"
 name: &name "redhat-openjdk-18/openjdk18-openshift"
-version: &version "1.7"
+version: &version "1.8"
 description: "Source To Image (S2I) image for Red Hat OpenShift providing OpenJDK 8"
 
 labels:


### PR DESCRIPTION
Use the same technique as used in the rhel8* YAML files to avoid writing
the version string twice.