### PR TITLE
Temporarily disable incremental s2i test

### DIFF
--- a/tests/features/java/java_s2i.feature
+++ b/tests/features/java/java_s2i.feature
@@ -5,19 +5,6 @@ Feature: Openshift OpenJDK S2I tests
 # These builds do not actually run maven. This is important, because the proxy
 # options supplied do not specify a valid HTTP proxy.
 
-  # test incremental builds
-  Scenario: Check incremental builds cache .m2
-    Given s2i build https://github.com/jboss-openshift/openshift-quickstarts from undertow-servlet
-        | variable    | value               |
-        | JAVA_ARGS   | Hello from CTF test |
-    Then container log should contain /deployments/undertow-servlet.jar Hello from CTF test
-     And s2i build log should contain Downloading:
-    Given s2i build https://github.com/jboss-openshift/openshift-quickstarts from undertow-servlet with env and incremental
-        | variable    | value               |
-        | JAVA_ARGS   | Hello from CTF test |
-    Then container log should contain /deployments/undertow-servlet.jar Hello from CTF test
-     And s2i build log should not contain Downloading:
-
   # handles mirror/repository configuration; proxy configuration
   Scenario: run the s2i and check the maven mirror and proxy have been initialised in the default settings.xml, uses http_proxy
     Given s2i build https://github.com/jboss-openshift/openshift-examples from spring-boot-sample-simple

--- a/tests/features/java/java_s2i_inc.feature
+++ b/tests/features/java/java_s2i_inc.feature
@@ -1,0 +1,18 @@
+# NOT tagged for any images - test broken
+Feature: Openshift OpenJDK S2I tests
+# NOTE: these tests should be usable with the other images once we have refactored the JDK scripts.
+# These builds do not actually run maven. This is important, because the proxy
+# options supplied do not specify a valid HTTP proxy.
+
+  # test incremental builds
+  Scenario: Check incremental builds cache .m2
+    Given s2i build https://github.com/jboss-openshift/openshift-quickstarts from undertow-servlet
+        | variable    | value               |
+        | JAVA_ARGS   | Hello from CTF test |
+    Then container log should contain /deployments/undertow-servlet.jar Hello from CTF test
+     And s2i build log should contain Downloading:
+    Given s2i build https://github.com/jboss-openshift/openshift-quickstarts from undertow-servlet with env and incremental
+        | variable    | value               |
+        | JAVA_ARGS   | Hello from CTF test |
+    Then container log should contain /deployments/undertow-servlet.jar Hello from CTF test
+     And s2i build log should not contain Downloading:


### PR DESCRIPTION
This is broken for all flavours of image and needs investigation.

In the meantime the failure is just noise.