### PR TITLE
Java's tag name should contain only version

### DIFF
--- a/templates/image-streams.json
+++ b/templates/image-streams.json
@@ -434,7 +434,7 @@
                         },
                         "from": {
                             "kind": "ImageStreamTag",
-                            "name": "java:11"
+                            "name": "11"
                         }
                     }
                 ]


### PR DESCRIPTION
Other tags for all the ImageStreams are containing only version, without the name.

We need to fix this as part of https://bugzilla.redhat.com/show_bug.cgi?id=1778613

Not sure if any other changes are needed in this PR (bumping version number in ImageStream label or annotation)

Based on https://github.com/openshift/cluster-samples-operator/pull/201#issuecomment-560424788