### PR TITLE
Track UBI8 8.1; bump minor version

### DIFF
--- a/openj9-11-rhel8.yaml
+++ b/openj9-11-rhel8.yaml
@@ -5,7 +5,7 @@
 
 schema_version: 1
 
-from: "ubi8:8.0-released"
+from: "ubi8:8-released"
 name: &name "openj9/openj9-11-rhel8"
 version: &version "1.1"
 description: "Source To Image (S2I) image for Red Hat OpenShift providing OpenJ9 11"

--- a/openj9-8-rhel8.yaml
+++ b/openj9-8-rhel8.yaml
@@ -5,7 +5,7 @@
 
 schema_version: 1
 
-from: "ubi8:8.0-released"
+from: "ubi8:8-released"
 name: &name "openj9/openj9-8-rhel8"
 version: &version "1.1"
 description: "Source To Image (S2I) image for Red Hat OpenShift providing OpenJ9 1.8"

--- a/openjdk-11-rhel8.yaml
+++ b/openjdk-11-rhel8.yaml
@@ -3,7 +3,7 @@
 
 schema_version: 1
 
-from: "ubi8:8.1-released"
+from: "ubi8:8-released"
 name: &name "openjdk/openjdk-11-rhel8"
 version: &version "1.2"
 description: "Source To Image (S2I) image for Red Hat OpenShift providing OpenJDK 11"

--- a/openjdk-11-rhel8.yaml
+++ b/openjdk-11-rhel8.yaml
@@ -3,9 +3,9 @@
 
 schema_version: 1
 
-from: "ubi8:8.0-released"
+from: "ubi8:8.1-released"
 name: &name "openjdk/openjdk-11-rhel8"
-version: &version "1.1"
+version: &version "1.2"
 description: "Source To Image (S2I) image for Red Hat OpenShift providing OpenJDK 11"
 
 labels:

--- a/openjdk-8-rhel8.yaml
+++ b/openjdk-8-rhel8.yaml
@@ -3,9 +3,9 @@
 
 schema_version: 1
 
-from: "ubi8:8.0-released"
+from: "ubi8:8.1-released"
 name: &name "openjdk/openjdk-8-rhel8"
-version: &version "1.1"
+version: &version "1.2"
 description: "Source To Image (S2I) image for Red Hat OpenShift providing OpenJDK 1.8"
 
 labels:

--- a/openjdk-8-rhel8.yaml
+++ b/openjdk-8-rhel8.yaml
@@ -3,7 +3,7 @@
 
 schema_version: 1
 
-from: "ubi8:8.1-released"
+from: "ubi8:8-released"
 name: &name "openjdk/openjdk-8-rhel8"
 version: &version "1.2"
 description: "Source To Image (S2I) image for Red Hat OpenShift providing OpenJDK 1.8"


### PR DESCRIPTION
Track UBI8 8.1 instead of 8.0.

Bump minor version since this could be a significant change.