### PR TITLE
fix imagestreamtag openjdk-8-rhel8:1.1 image reference

### DIFF
--- a/templates/image-streams.json
+++ b/templates/image-streams.json
@@ -298,7 +298,7 @@
                         },
                         "from": {
                             "kind": "DockerImage",
-                            "name": "registry.redhat.io/openjdk/openjdk-1.8-rhel8:1.1"
+                            "name": "registry.redhat.io/openjdk/openjdk-8-rhel8:1.1"
                         }
                     }
                 ]


### PR DESCRIPTION
Thanks for submitting your Pull Request!

Please make sure your PR meets the following requirements:

- [ ] Pull Request title is properly formatted: `[CLOUD-XYA] Subject`
- [ ] Pull Request contains link to the JIRA issue
- [ ] Pull Request contains description of the issue
- [ ] Pull Request does not include fixes for issues other than the main ticket
- [ ] Attached commits represent units of work and are properly formatted
- [ ] You have read and agreed to the Developer Certificate of Origin (DCO) (see `CONTRIBUTING.md`)
- [ ] Every commit contains `Signed-off-by: Your Name <yourname@example.com>` - use `git commit -s`


@jmtd - the import of imagestreamtag openjdk-8-rhel8:1.1 was failing in openshift 4.4 because of the typo here.

Can you handle creating the Jiras and linking to this PR (or creating our own Jira/PR) ?

thanks