### PR TITLE
Fix 1.8 refs in image stream metadata

### DIFF
--- a/templates/image-streams.json
+++ b/templates/image-streams.json
@@ -423,44 +423,6 @@
             "kind": "ImageStream",
             "apiVersion": "v1",
             "metadata": {
-                "name": "openjdk-1.8-rhel8",
-                "annotations": {
-                    "openshift.io/display-name": "Red Hat OpenJDK 1.8 (RHEL8)",
-                    "openshift.io/provider-display-name": "Red Hat, Inc.",
-                    "version": "1.4.17"
-                }
-            },
-            "labels": {
-                "xpaas": "1.4.17"
-            },
-            "spec": {
-                "tags": [
-                    {
-                        "name": "1.0",
-                        "annotations": {
-                            "openshift.io/display-name": "Red Hat OpenJDK 1.8 (RHEL8)",
-                            "description": "Build and run Java applications using Maven and OpenJDK 1.8 upon RHEL8.",
-                            "iconClass": "icon-rh-openjdk",
-                            "tags": "builder,java,openjdk,ubi8,hidden",
-                            "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts",
-                            "sampleContextDir": "undertow-servlet",
-                            "version": "1.0"
-                        },
-                        "referencePolicy": {
-                            "type": "Local"
-                        },
-                        "from": {
-                            "kind": "DockerImage",
-                            "name": "registry.redhat.io/openjdk/openjdk-1.8-rhel8:1.0"
-                        }
-                    }
-                ]
-            }
-        },
-        {
-            "kind": "ImageStream",
-            "apiVersion": "v1",
-            "metadata": {
                 "name": "openjdk-11-rhel8",
                 "annotations": {
                     "openshift.io/display-name": "Red Hat OpenJDK 11 (RHEL8)",


### PR DESCRIPTION
This image name  was never valid. The :1.0 image exists in the
(correct) image stream, openjdk-8-rhel8.