### PR TITLE
[CLOUD-3478] Remove obsolete tags from imagestreams

### DIFF
--- a/templates/image-streams.json
+++ b/templates/image-streams.json
@@ -26,146 +26,6 @@
             "spec": {
                 "tags": [
                     {
-                        "name": "1.0",
-                        "annotations": {
-                            "openshift.io/display-name": "Red Hat OpenJDK 8",
-                            "description": "Build and run Java applications using Maven and OpenJDK 8.",
-                            "iconClass": "icon-rh-openjdk",
-                            "tags": "builder,java,openjdk,hidden",
-                            "supports": "java:8",
-                            "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts",
-                            "sampleContextDir": "undertow-servlet",
-                            "version": "1.0"
-                        },
-                        "referencePolicy": {
-                            "type": "Local"
-                        },
-                        "from": {
-                            "kind": "DockerImage",
-                            "name": "registry.redhat.io/redhat-openjdk-18/openjdk18-openshift:1.0"
-                        }
-                    },
-                    {
-                        "name": "1.1",
-                        "annotations": {
-                            "openshift.io/display-name": "Red Hat OpenJDK 8",
-                            "description": "Build and run Java applications using Maven and OpenJDK 8.",
-                            "iconClass": "icon-rh-openjdk",
-                            "tags": "builder,java,openjdk,hidden",
-                            "supports": "java:8",
-                            "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts",
-                            "sampleContextDir": "undertow-servlet",
-                            "version": "1.1"
-                        },
-                        "referencePolicy": {
-                            "type": "Local"
-                        },
-                        "from": {
-                            "kind": "DockerImage",
-                            "name": "registry.redhat.io/redhat-openjdk-18/openjdk18-openshift:1.1"
-                        }
-                    },
-                    {
-                        "name": "1.2",
-                        "annotations": {
-                            "openshift.io/display-name": "Red Hat OpenJDK 8",
-                            "description": "Build and run Java applications using Maven and OpenJDK 8.",
-                            "iconClass": "icon-rh-openjdk",
-                            "tags": "builder,java,openjdk,hidden",
-                            "supports": "java:8",
-                            "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts",
-                            "sampleContextDir": "undertow-servlet",
-                            "version": "1.2"
-                        },
-                        "referencePolicy": {
-                            "type": "Local"
-                        },
-                        "from": {
-                            "kind": "DockerImage",
-                            "name": "registry.redhat.io/redhat-openjdk-18/openjdk18-openshift:1.2"
-                        }
-                    },
-                    {
-                        "name": "1.3",
-                        "annotations": {
-                            "openshift.io/display-name": "Red Hat OpenJDK 8",
-                            "description": "Build and run Java applications using Maven and OpenJDK 8.",
-                            "iconClass": "icon-rh-openjdk",
-                            "tags": "builder,java,openjdk,hidden",
-                            "supports": "java:8",
-                            "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts",
-                            "sampleContextDir": "undertow-servlet",
-                            "version": "1.3"
-                        },
-                        "referencePolicy": {
-                            "type": "Local"
-                        },
-                        "from": {
-                            "kind": "DockerImage",
-                            "name": "registry.redhat.io/redhat-openjdk-18/openjdk18-openshift:1.3"
-                        }
-                    },
-                    {
-                        "name": "1.4",
-                        "annotations": {
-                            "openshift.io/display-name": "Red Hat OpenJDK 8",
-                            "description": "Build and run Java applications using Maven and OpenJDK 8.",
-                            "iconClass": "icon-rh-openjdk",
-                            "tags": "builder,java,openjdk,hidden",
-                            "supports": "java:8",
-                            "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts",
-                            "sampleContextDir": "undertow-servlet",
-                            "version": "1.4"
-                        },
-                        "referencePolicy": {
-                            "type": "Local"
-                        },
-                        "from": {
-                            "kind": "DockerImage",
-                            "name": "registry.redhat.io/redhat-openjdk-18/openjdk18-openshift:1.4"
-                        }
-                    },
-                    {
-                        "name": "1.5",
-                        "annotations": {
-                            "openshift.io/display-name": "Red Hat OpenJDK 8",
-                            "description": "Build and run Java applications using Maven and OpenJDK 8.",
-                            "iconClass": "icon-rh-openjdk",
-                            "tags": "builder,java,openjdk,hidden",
-                            "supports": "java:8",
-                            "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts",
-                            "sampleContextDir": "undertow-servlet",
-                            "version": "1.5"
-                        },
-                        "referencePolicy": {
-                            "type": "Local"
-                        },
-                        "from": {
-                            "kind": "DockerImage",
-                            "name": "registry.redhat.io/redhat-openjdk-18/openjdk18-openshift:1.5"
-                        }
-                    },
-                    {
-                        "name": "1.6",
-                        "annotations": {
-                            "openshift.io/display-name": "Red Hat OpenJDK 8",
-                            "description": "Build and run Java applications using Maven and OpenJDK 8.",
-                            "iconClass": "icon-rh-openjdk",
-                            "tags": "builder,java,openjdk,hidden",
-                            "supports": "java:8",
-                            "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts",
-                            "sampleContextDir": "undertow-servlet",
-                            "version": "1.6"
-                        },
-                        "referencePolicy": {
-                            "type": "Local"
-                        },
-                        "from": {
-                            "kind": "DockerImage",
-                            "name": "registry.redhat.io/redhat-openjdk-18/openjdk18-openshift:1.6"
-                        }
-                    },
-                    {
                         "name": "1.7",
                         "annotations": {
                             "openshift.io/display-name": "Red Hat OpenJDK 8",
@@ -225,26 +85,6 @@
             "spec": {
                 "tags": [
                     {
-                        "name": "1.0",
-                        "annotations": {
-                            "openshift.io/display-name": "Red Hat OpenJDK 11",
-                            "description": "Build and run Java applications using Maven and OpenJDK 11.",
-                            "iconClass": "icon-rh-openjdk",
-                            "tags": "builder,java,openjdk,hidden",
-                            "supports": "java:11",
-                            "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts",
-                            "sampleContextDir": "undertow-servlet",
-                            "version": "1.0"
-                        },
-                        "referencePolicy": {
-                            "type": "Local"
-                        },
-                        "from": {
-                            "kind": "DockerImage",
-                            "name": "registry.redhat.io/openjdk/openjdk-11-rhel7:1.0"
-                        }
-                    },
-                    {
                         "name": "1.1",
                         "annotations": {
                             "openshift.io/display-name": "Red Hat OpenJDK 11",
@@ -283,25 +123,6 @@
             },
             "spec": {
                 "tags": [
-                    {
-                        "name": "1.0",
-                        "annotations": {
-                            "openshift.io/display-name": "Red Hat OpenJDK 1.8 (RHEL8)",
-                            "description": "Build and run Java applications using Maven and OpenJDK 1.8 upon RHEL8.",
-                            "iconClass": "icon-rh-openjdk",
-                            "tags": "builder,java,openjdk,ubi8,hidden",
-                            "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts",
-                            "sampleContextDir": "undertow-servlet",
-                            "version": "1.0"
-                        },
-                        "referencePolicy": {
-                            "type": "Local"
-                        },
-                        "from": {
-                            "kind": "DockerImage",
-                            "name": "registry.redhat.io/openjdk/openjdk-8-rhel8:1.0"
-                        }
-                    },
                     {
                         "name": "1.1",
                         "annotations": {
@@ -359,25 +180,6 @@
             },
             "spec": {
                 "tags": [
-                    {
-                        "name": "1.0",
-                        "annotations": {
-                            "openshift.io/display-name": "Red Hat OpenJDK 11 (RHEL8)",
-                            "description": "Build and run Java applications using Maven and OpenJDK 11 upon RHEL8.",
-                            "iconClass": "icon-rh-openjdk",
-                            "tags": "builder,java,openjdk,ubi8,hidden",
-                            "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts",
-                            "sampleContextDir": "undertow-servlet",
-                            "version": "1.0"
-                        },
-                        "referencePolicy": {
-                            "type": "Local"
-                        },
-                        "from": {
-                            "kind": "DockerImage",
-                            "name": "registry.redhat.io/openjdk/openjdk-11-rhel8:1.0"
-                        }
-                    },
                     {
                         "name": "1.1",
                         "annotations": {


### PR DESCRIPTION
This is an alternative to #110.  EITHER this OR that needs to be committed for multi-arch support.