### PR TITLE
Update/add dependency on "singleton-jdk" module

### DIFF
--- a/image.yaml
+++ b/image.yaml
@@ -52,6 +52,7 @@ modules:
     version: '0!3.6'
   - name: jboss.container.maven.36.bash
     version: "3.6scl"
+  - name: jboss.container.java.singleton-jdk
 
 help:
   add: true

--- a/image.yaml
+++ b/image.yaml
@@ -42,7 +42,7 @@ modules:
   - name: cct_module
     git:
       url: https://github.com/jboss-openshift/cct_module.git
-      ref: 1668f62d797e4eb75ad35544c8de9adf4325ec22
+      ref: 260c2a021dc3de9f83c3ae8d17b128403a62f0fc
 
   install:
   - name: jboss.container.openjdk.jdk

--- a/openj9-11-rhel7.yaml
+++ b/openj9-11-rhel7.yaml
@@ -44,7 +44,7 @@ modules:
   - name: cct_module
     git:
       url: https://github.com/jboss-openshift/cct_module.git
-      ref: 1668f62d797e4eb75ad35544c8de9adf4325ec22
+      ref: 260c2a021dc3de9f83c3ae8d17b128403a62f0fc
   install:
   - name: jboss.container.openjdk.jdk
     version: "openj9-11"

--- a/openj9-11-rhel7.yaml
+++ b/openj9-11-rhel7.yaml
@@ -53,7 +53,7 @@ modules:
     version: '0!3.6'
   - name: jboss.container.maven.36.bash
     version: "3.6scl"
-  - name: jboss.container.java.rm-openjdk
+  - name: jboss.container.java.singleton-jdk
 
 help:
   add: true

--- a/openj9-11-rhel8.yaml
+++ b/openj9-11-rhel8.yaml
@@ -51,7 +51,7 @@ modules:
   - name: jboss.container.java.s2i.bash
   - name: jboss.container.maven.35.bash
     version: "3.5"
-  - name: jboss.container.java.rm-openjdk
+  - name: jboss.container.java.singleton-jdk
 
 help:
   add: true

--- a/openj9-8-rhel7.yaml
+++ b/openj9-8-rhel7.yaml
@@ -44,7 +44,7 @@ modules:
   - name: cct_module
     git:
       url: https://github.com/jboss-openshift/cct_module.git
-      ref: 1668f62d797e4eb75ad35544c8de9adf4325ec22
+      ref: 260c2a021dc3de9f83c3ae8d17b128403a62f0fc
   install:
   - name: jboss.container.openjdk.jdk
     version: "openj9-8"

--- a/openj9-8-rhel7.yaml
+++ b/openj9-8-rhel7.yaml
@@ -53,7 +53,7 @@ modules:
     version: '0!3.6'
   - name: jboss.container.maven.36.bash
     version: "3.6scl"
-  - name: jboss.container.java.rm-openjdk
+  - name: jboss.container.java.singleton-jdk
 
 help:
   add: true

--- a/openj9-8-rhel8.yaml
+++ b/openj9-8-rhel8.yaml
@@ -51,7 +51,7 @@ modules:
   - name: jboss.container.java.s2i.bash
   - name: jboss.container.maven.35.bash
     version: "3.5"
-  - name: jboss.container.java.rm-openjdk
+  - name: jboss.container.java.singleton-jdk
 
 help:
   add: true

--- a/openjdk-11-rhel7.yaml
+++ b/openjdk-11-rhel7.yaml
@@ -48,6 +48,7 @@ modules:
     version: '0!3.6'
   - name: jboss.container.maven.36.bash
     version: "3.6scl"
+  - name: jboss.container.java.singleton-jdk
 
 help:
   add: true

--- a/openjdk-11-rhel7.yaml
+++ b/openjdk-11-rhel7.yaml
@@ -39,7 +39,7 @@ modules:
   - name: cct_module
     git:
       url: https://github.com/jboss-openshift/cct_module.git
-      ref: 1668f62d797e4eb75ad35544c8de9adf4325ec22
+      ref: 260c2a021dc3de9f83c3ae8d17b128403a62f0fc
   install:
   - name: jboss.container.openjdk.jdk
     version: "11"

--- a/openjdk-11-rhel8.yaml
+++ b/openjdk-11-rhel8.yaml
@@ -46,6 +46,7 @@ modules:
   - name: jboss.container.java.s2i.bash
   - name: jboss.container.maven.35.bash
     version: "3.5"
+  - name: jboss.container.java.singleton-jdk
 
 help:
   add: true

--- a/openjdk-8-rhel8.yaml
+++ b/openjdk-8-rhel8.yaml
@@ -46,6 +46,7 @@ modules:
   - name: jboss.container.java.s2i.bash
   - name: jboss.container.maven.35.bash
     version: "3.5"
+  - name: jboss.container.java.singleton-jdk
 
 help:
   add: true


### PR DESCRIPTION
This is to be merged *after* https://github.com/jboss-openshift/cct_module/pull/366

The new singleton-jdk module handles ensuring that we only have one set of JDK packages installed at a time: one version, one vendor.