### PR TITLE
Merge down OpenJ9 commits from develop branch to release

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -50,6 +50,30 @@ cekit --descriptor openjdk-11-rhel8.yaml build
 
 This will produce an image named `openjdk/openjdk-11-rhel8`
 
+### RHEL 7 OpenJ9 8
+
+    cekit --redhat --descriptor openj9-8-rhel7.yaml build podman
+
+This will produce an image named `openj9/openj9-8-rhel7`.
+
+### RHEL 7 OpenJ9 11
+
+    cekit --redhat --descriptor openj9-11-rhel7.yaml build podman
+
+This will produce an image named `openj9/openj9-11-rhel7`.
+
+### RHEL 8 OpenJ9 8
+
+    cekit --redhat --descriptor openj9-8-rhel8.yaml build podman
+
+This will produce an image named `openj9/openj9-8-rhel8`.
+
+### RHEL 8 OpenJ9 11
+
+    cekit --redhat --descriptor openj9-11-rhel8.yaml build podman
+
+This will produce an image named `openj9/openj9-11-rhel8`.
+
 ## License
 
 See link:LICENSE[LICENSE] file.

--- a/openj9-11-rhel7.yaml
+++ b/openj9-11-rhel7.yaml
@@ -44,7 +44,7 @@ modules:
   - name: cct_module
     git:
       url: https://github.com/jboss-openshift/cct_module.git
-      ref: 1668f62d797e4eb75ad35544c8de9adf4325ec22
+      ref: 260c2a021dc3de9f83c3ae8d17b128403a62f0fc
   install:
   - name: jboss.container.openjdk.jdk
     version: "openj9-11"

--- a/openj9-11-rhel7.yaml
+++ b/openj9-11-rhel7.yaml
@@ -53,7 +53,7 @@ modules:
     version: '0!3.6'
   - name: jboss.container.maven.36.bash
     version: "3.6scl"
-  - name: jboss.container.java.rm-openjdk
+  - name: jboss.container.java.singleton-jdk
 
 help:
   add: true

--- a/openj9-11-rhel8.yaml
+++ b/openj9-11-rhel8.yaml
@@ -51,7 +51,7 @@ modules:
   - name: jboss.container.java.s2i.bash
   - name: jboss.container.maven.35.bash
     version: "3.5"
-  - name: jboss.container.java.rm-openjdk
+  - name: jboss.container.java.singleton-jdk
 
 help:
   add: true

--- a/openj9-8-rhel7.yaml
+++ b/openj9-8-rhel7.yaml
@@ -44,7 +44,7 @@ modules:
   - name: cct_module
     git:
       url: https://github.com/jboss-openshift/cct_module.git
-      ref: 1668f62d797e4eb75ad35544c8de9adf4325ec22
+      ref: 260c2a021dc3de9f83c3ae8d17b128403a62f0fc
   install:
   - name: jboss.container.openjdk.jdk
     version: "openj9-8"

--- a/openj9-8-rhel7.yaml
+++ b/openj9-8-rhel7.yaml
@@ -53,7 +53,7 @@ modules:
     version: '0!3.6'
   - name: jboss.container.maven.36.bash
     version: "3.6scl"
-  - name: jboss.container.java.rm-openjdk
+  - name: jboss.container.java.singleton-jdk
 
 help:
   add: true

--- a/openj9-8-rhel8.yaml
+++ b/openj9-8-rhel8.yaml
@@ -51,7 +51,7 @@ modules:
   - name: jboss.container.java.s2i.bash
   - name: jboss.container.maven.35.bash
     version: "3.5"
-  - name: jboss.container.java.rm-openjdk
+  - name: jboss.container.java.singleton-jdk
 
 help:
   add: true

--- a/templates/image-streams-ppc64le.json
+++ b/templates/image-streams-ppc64le.json
@@ -1,0 +1,402 @@
+{
+    "kind": "List",
+    "apiVersion": "v1",
+    "metadata": {
+        "name": "openjdk18-image-stream",
+        "annotations": {
+            "description": "ImageStream definition for Red Hat OpenJDK.",
+            "openshift.io/provider-display-name": "Red Hat, Inc."
+        }
+    },
+    "items": [
+        {
+            "kind": "ImageStream",
+            "apiVersion": "v1",
+            "metadata": {
+                "name": "redhat-openjdk18-openshift",
+                "annotations": {
+                    "openshift.io/display-name": "Red Hat OpenJDK 8",
+                    "openshift.io/provider-display-name": "Red Hat, Inc.",
+                    "version": "1.4.17"
+                },
+                "labels": {
+                    "xpaas": "1.4.17"
+                }
+            },
+            "spec": {
+                "tags": [
+                    {
+                        "name": "1.5",
+                        "annotations": {
+                            "openshift.io/display-name": "Red Hat OpenJDK 8",
+                            "description": "Build and run Java applications using Maven and OpenJDK 8.",
+                            "iconClass": "icon-rh-openjdk",
+                            "tags": "builder,java,openjdk,hidden",
+                            "supports": "java:8",
+                            "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts",
+                            "sampleContextDir": "undertow-servlet",
+                            "version": "1.5"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
+                        },
+                        "from": {
+                            "kind": "DockerImage",
+                            "name": "registry.redhat.io/redhat-openjdk-18/openjdk18-openshift:1.5"
+                        }
+                    },
+                    {
+                        "name": "1.6",
+                        "annotations": {
+                            "openshift.io/display-name": "Red Hat OpenJDK 8",
+                            "description": "Build and run Java applications using Maven and OpenJDK 8.",
+                            "iconClass": "icon-rh-openjdk",
+                            "tags": "builder,java,openjdk,hidden",
+                            "supports": "java:8",
+                            "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts",
+                            "sampleContextDir": "undertow-servlet",
+                            "version": "1.6"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
+                        },
+                        "from": {
+                            "kind": "DockerImage",
+                            "name": "registry.redhat.io/redhat-openjdk-18/openjdk18-openshift:1.6"
+                        }
+                    },
+                    {
+                        "name": "1.7",
+                        "annotations": {
+                            "openshift.io/display-name": "Red Hat OpenJDK 8",
+                            "description": "Build and run Java applications using Maven and OpenJDK 8.",
+                            "iconClass": "icon-rh-openjdk",
+                            "tags": "builder,java,openjdk,hidden",
+                            "supports": "java:8",
+                            "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts",
+                            "sampleContextDir": "undertow-servlet",
+                            "version": "1.7"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
+                        },
+                        "from": {
+                            "kind": "DockerImage",
+                            "name": "registry.redhat.io/redhat-openjdk-18/openjdk18-openshift:1.7"
+                        }
+                    },
+                    {
+                        "name": "1.8",
+                        "annotations": {
+                            "openshift.io/display-name": "Red Hat OpenJDK 8",
+                            "description": "Build and run Java applications using Maven and OpenJDK 8.",
+                            "iconClass": "icon-rh-openjdk",
+                            "tags": "builder,java,openjdk,hidden",
+                            "supports": "java:8",
+                            "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts",
+                            "sampleContextDir": "undertow-servlet",
+                            "version": "1.8"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
+                        },
+                        "from": {
+                            "kind": "DockerImage",
+                            "name": "registry.redhat.io/redhat-openjdk-18/openjdk18-openshift:1.8"
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "kind": "ImageStream",
+            "apiVersion": "v1",
+            "metadata": {
+                "name": "openjdk-11-rhel7",
+                "annotations": {
+                    "openshift.io/display-name": "Red Hat OpenJDK 11",
+                    "openshift.io/provider-display-name": "Red Hat, Inc.",
+                    "version": "1.4.17"
+                },
+                "labels": {
+                    "xpaas": "1.4.17"
+                }
+            },
+            "spec": {
+                "tags": [
+                    {
+                        "name": "1.0",
+                        "annotations": {
+                            "openshift.io/display-name": "Red Hat OpenJDK 11",
+                            "description": "Build and run Java applications using Maven and OpenJDK 11.",
+                            "iconClass": "icon-rh-openjdk",
+                            "tags": "builder,java,openjdk,hidden",
+                            "supports": "java:11",
+                            "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts",
+                            "sampleContextDir": "undertow-servlet",
+                            "version": "1.0"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
+                        },
+                        "from": {
+                            "kind": "DockerImage",
+                            "name": "registry.redhat.io/openjdk/openjdk-11-rhel7:1.0"
+                        }
+                    },
+                    {
+                        "name": "1.1",
+                        "annotations": {
+                            "openshift.io/display-name": "Red Hat OpenJDK 11",
+                            "description": "Build and run Java applications using Maven and OpenJDK 11.",
+                            "iconClass": "icon-rh-openjdk",
+                            "tags": "builder,java,openjdk,hidden",
+                            "supports": "java:11",
+                            "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts",
+                            "sampleContextDir": "undertow-servlet",
+                            "version": "1.1"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
+                        },
+                        "from": {
+                            "kind": "DockerImage",
+                            "name": "registry.redhat.io/openjdk/openjdk-11-rhel7:1.1"
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "kind": "ImageStream",
+            "apiVersion": "v1",
+            "metadata": {
+                "name": "openjdk-8-rhel8",
+                "annotations": {
+                    "openshift.io/display-name": "Red Hat OpenJDK 1.8 (RHEL8)",
+                    "openshift.io/provider-display-name": "Red Hat, Inc.",
+                    "version": "1.4.17"
+                },
+                "labels": {
+                    "xpaas": "1.4.17"
+                }
+            },
+            "spec": {
+                "tags": [
+                    {
+                        "name": "1.0",
+                        "annotations": {
+                            "openshift.io/display-name": "Red Hat OpenJDK 1.8 (RHEL8)",
+                            "description": "Build and run Java applications using Maven and OpenJDK 1.8 upon RHEL8.",
+                            "iconClass": "icon-rh-openjdk",
+                            "tags": "builder,java,openjdk,ubi8,hidden",
+                            "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts",
+                            "sampleContextDir": "undertow-servlet",
+                            "version": "1.0"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
+                        },
+                        "from": {
+                            "kind": "DockerImage",
+                            "name": "registry.redhat.io/openjdk/openjdk-8-rhel8:1.0"
+                        }
+                    },
+                    {
+                        "name": "1.1",
+                        "annotations": {
+                            "openshift.io/display-name": "Red Hat OpenJDK 1.8 (RHEL8)",
+                            "description": "Build and run Java applications using Maven and OpenJDK 1.8 upon RHEL8.",
+                            "iconClass": "icon-rh-openjdk",
+                            "tags": "builder,java,openjdk,ubi8,hidden",
+                            "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts",
+                            "sampleContextDir": "undertow-servlet",
+                            "version": "1.1"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
+                        },
+                        "from": {
+                            "kind": "DockerImage",
+                            "name": "registry.redhat.io/openjdk/openjdk-8-rhel8:1.1"
+                        }
+                    },
+                    {
+                        "name": "1.2",
+                        "annotations": {
+                            "openshift.io/display-name": "Red Hat OpenJDK 1.8 (RHEL8)",
+                            "description": "Build and run Java applications using Maven and OpenJDK 1.8 upon RHEL8.",
+                            "iconClass": "icon-rh-openjdk",
+                            "tags": "builder,java,openjdk,ubi8,hidden",
+                            "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts",
+                            "sampleContextDir": "undertow-servlet",
+                            "version": "1.2"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
+                        },
+                        "from": {
+                            "kind": "DockerImage",
+                            "name": "registry.redhat.io/openjdk/openjdk-8-rhel8:1.2"
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "kind": "ImageStream",
+            "apiVersion": "v1",
+            "metadata": {
+                "name": "openjdk-11-rhel8",
+                "annotations": {
+                    "openshift.io/display-name": "Red Hat OpenJDK 11 (RHEL8)",
+                    "openshift.io/provider-display-name": "Red Hat, Inc.",
+                    "version": "1.4.17"
+                },
+                "labels": {
+                    "xpaas": "1.4.17"
+                }
+            },
+            "spec": {
+                "tags": [
+                    {
+                        "name": "1.0",
+                        "annotations": {
+                            "openshift.io/display-name": "Red Hat OpenJDK 11 (RHEL8)",
+                            "description": "Build and run Java applications using Maven and OpenJDK 11 upon RHEL8.",
+                            "iconClass": "icon-rh-openjdk",
+                            "tags": "builder,java,openjdk,ubi8,hidden",
+                            "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts",
+                            "sampleContextDir": "undertow-servlet",
+                            "version": "1.0"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
+                        },
+                        "from": {
+                            "kind": "DockerImage",
+                            "name": "registry.redhat.io/openjdk/openjdk-11-rhel8:1.0"
+                        }
+                    },
+                    {
+                        "name": "1.1",
+                        "annotations": {
+                            "openshift.io/display-name": "Red Hat OpenJDK 11 (RHEL8)",
+                            "description": "Build and run Java applications using Maven and OpenJDK 11 upon RHEL8.",
+                            "iconClass": "icon-rh-openjdk",
+                            "tags": "builder,java,openjdk,ubi8,hidden",
+                            "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts",
+                            "sampleContextDir": "undertow-servlet",
+                            "version": "1.1"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
+                        },
+                        "from": {
+                            "kind": "DockerImage",
+                            "name": "registry.redhat.io/openjdk/openjdk-11-rhel8:1.1"
+                        }
+                    },
+                    {
+                        "name": "1.2",
+                        "annotations": {
+                            "openshift.io/display-name": "Red Hat OpenJDK 11 (RHEL8)",
+                            "description": "Build and run Java applications using Maven and OpenJDK 11 upon RHEL8.",
+                            "iconClass": "icon-rh-openjdk",
+                            "tags": "builder,java,openjdk,ubi8,hidden",
+                            "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts",
+                            "sampleContextDir": "undertow-servlet",
+                            "version": "1.2"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
+                        },
+                        "from": {
+                            "kind": "DockerImage",
+                            "name": "registry.redhat.io/openjdk/openjdk-11-rhel8:1.2"
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "kind": "ImageStream",
+            "apiVersion": "v1",
+            "metadata": {
+                "name": "java",
+                "annotations": {
+                    "openshift.io/display-name": "Red Hat OpenJDK",
+                    "openshift.io/provider-display-name": "Red Hat, Inc.",
+                    "version": "1.4.17"
+                },
+                "labels": {
+                    "xpaas": "1.4.17"
+                }
+            },
+            "spec": {
+                "tags": [
+                    {
+                        "name": "8",
+                        "annotations": {
+                            "openshift.io/display-name": "Red Hat OpenJDK 8",
+                            "description": "Build and run Java applications using Maven and OpenJDK 8.",
+                            "iconClass": "icon-rh-openjdk",
+                            "tags": "builder,java,openjdk",
+                            "supports": "java:8,java",
+                            "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts",
+                            "sampleContextDir": "undertow-servlet",
+                            "version": "8"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
+                        },
+                        "from": {
+                            "kind": "DockerImage",
+                            "name": "registry.redhat.io/redhat-openjdk-18/openjdk18-openshift:latest"
+                        }
+                    },
+                    {
+                        "name": "11",
+                        "annotations": {
+                            "openshift.io/display-name": "Red Hat OpenJDK 11",
+                            "description": "Build and run Java applications using Maven and OpenJDK 11.",
+                            "iconClass": "icon-rh-openjdk",
+                            "tags": "builder,java,openjdk",
+                            "supports": "java:11,java",
+                            "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts",
+                            "sampleContextDir": "undertow-servlet",
+                            "version": "11"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
+                        },
+                        "from": {
+                            "kind": "DockerImage",
+                            "name": "registry.redhat.io/openjdk/openjdk-11-rhel7:latest"
+                        }
+                    },
+                    {
+                        "name": "latest",
+                        "annotations": {
+                            "openshift.io/display-name": "Red Hat OpenJDK 11",
+                            "description": "Build and run Java applications using Maven and OpenJDK 11.",
+                            "iconClass": "icon-rh-openjdk",
+                            "tags": "builder,java,openjdk",
+                            "supports": "java:11,java",
+                            "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts",
+                            "sampleContextDir": "undertow-servlet",
+                            "version": "latest"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
+                        },
+                        "from": {
+                            "kind": "ImageStreamTag",
+                            "name": "11"
+                        }
+                    }
+                ]
+            }
+        }
+    ]
+}

--- a/templates/image-streams-s390x.json
+++ b/templates/image-streams-s390x.json
@@ -15,7 +15,7 @@
             "metadata": {
                 "name": "openj9-8-rhel7",
                 "annotations": {
-                    "openshift.io/display-name": "OpenJ9 8",
+                    "openshift.io/display-name": "OpenJ9 1.8.0",
                     "openshift.io/provider-display-name": "Red Hat, Inc.",
                     "version": "1.4.17"
                 },
@@ -28,8 +28,8 @@
                     {
                         "name": "1.1",
                         "annotations": {
-                            "openshift.io/display-name": "OpenJ9 8",
-                            "description": "Build and run Java applications using Maven and OpenJ9 8.",
+                            "openshift.io/display-name": "OpenJ9 1.8.0",
+                            "description": "Build and run Java applications using Maven and OpenJ9 1.8.0.",
                             "iconClass": "icon-rh-openj9",
                             "tags": "builder,java,openj9,hidden",
                             "supports": "java:8",
@@ -93,7 +93,7 @@
             "metadata": {
                 "name": "openj9-8-rhel8",
                 "annotations": {
-                    "openshift.io/display-name": "OpenJ9 1.8 (RHEL8)",
+                    "openshift.io/display-name": "OpenJ9 1.8.0 (RHEL8)",
                     "openshift.io/provider-display-name": "Red Hat, Inc.",
                     "version": "1.4.17"
                 },
@@ -106,8 +106,8 @@
                     {
                         "name": "1.1",
                         "annotations": {
-                            "openshift.io/display-name": "OpenJ9 1.8 (RHEL8)",
-                            "description": "Build and run Java applications using Maven and OpenJ9 1.8 upon RHEL8.",
+                            "openshift.io/display-name": "OpenJ9 1.8.0 (RHEL8)",
+                            "description": "Build and run Java applications using Maven and OpenJ9 1.8.0 upon RHEL8.",
                             "iconClass": "icon-rh-openj9",
                             "tags": "builder,java,openj9,ubi8,hidden",
                             "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts",
@@ -182,8 +182,8 @@
                     {
                         "name": "8",
                         "annotations": {
-                            "openshift.io/display-name": "OpenJ9 8",
-                            "description": "Build and run Java applications using Maven and OpenJ9 8.",
+                            "openshift.io/display-name": "OpenJ9 1.8.0",
+                            "description": "Build and run Java applications using Maven and OpenJ9 1.8.0.",
                             "iconClass": "icon-rh-openj9",
                             "tags": "builder,java,openj9",
                             "supports": "java:8,java",

--- a/templates/image-streams-s390x.json
+++ b/templates/image-streams-s390x.json
@@ -15,7 +15,7 @@
             "metadata": {
                 "name": "openj9-8-rhel7",
                 "annotations": {
-                    "openshift.io/display-name": "OpenJ9 1.8.0",
+                    "openshift.io/display-name": "OpenJ9 1.8.0 (RHEL7)",
                     "openshift.io/provider-display-name": "Red Hat, Inc.",
                     "version": "1.4.17"
                 },
@@ -28,7 +28,7 @@
                     {
                         "name": "1.1",
                         "annotations": {
-                            "openshift.io/display-name": "OpenJ9 1.8.0",
+                            "openshift.io/display-name": "OpenJ9 1.8.0 (RHEL7)",
                             "description": "Build and run Java applications using Maven and OpenJ9 1.8.0.",
                             "iconClass": "icon-rh-openj9",
                             "tags": "builder,java,openj9,hidden",
@@ -54,7 +54,7 @@
             "metadata": {
                 "name": "openj9-11-rhel7",
                 "annotations": {
-                    "openshift.io/display-name": "OpenJ9 11",
+                    "openshift.io/display-name": "OpenJ9 11 (RHEL7)",
                     "openshift.io/provider-display-name": "Red Hat, Inc.",
                     "version": "1.4.17"
                 },
@@ -67,7 +67,7 @@
                     {
                         "name": "1.1",
                         "annotations": {
-                            "openshift.io/display-name": "OpenJ9 11",
+                            "openshift.io/display-name": "OpenJ9 11 (RHEL7)",
                             "description": "Build and run Java applications using Maven and OpenJ9 11.",
                             "iconClass": "icon-rh-openj9",
                             "tags": "builder,java,openj9,hidden",
@@ -202,7 +202,7 @@
                     {
                         "name": "11",
                         "annotations": {
-                            "openshift.io/display-name": "Red Hat OpenJ9 11",
+                            "openshift.io/display-name": "Red Hat OpenJ9 11 (RHEL7)",
                             "description": "Build and run Java applications using Maven and OpenJ9 11.",
                             "iconClass": "icon-rh-openj9",
                             "tags": "builder,java,openj9",

--- a/templates/image-streams-s390x.json
+++ b/templates/image-streams-s390x.json
@@ -218,26 +218,6 @@
                             "kind": "DockerImage",
                             "name": "registry.redhat.io/openj9/openj9-11-rhel7:latest"
                         }
-                    },
-                    {
-                        "name": "latest",
-                        "annotations": {
-                            "openshift.io/display-name": "OpenJ9 11",
-                            "description": "Build and run Java applications using Maven and OpenJ9 11.",
-                            "iconClass": "icon-rh-openj9",
-                            "tags": "builder,java,openj9",
-                            "supports": "java:11,java",
-                            "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts",
-                            "sampleContextDir": "undertow-servlet",
-                            "version": "latest"
-                        },
-                        "referencePolicy": {
-                            "type": "Local"
-                        },
-                        "from": {
-                            "kind": "ImageStreamTag",
-                            "name": "11"
-                        }
                     }
                 ]
             }

--- a/templates/image-streams-s390x.json
+++ b/templates/image-streams-s390x.json
@@ -129,7 +129,7 @@
             "kind": "ImageStream",
             "apiVersion": "v1",
             "metadata": {
-                "name": "openjdk-11-rhel8",
+                "name": "openj9-11-rhel8",
                 "annotations": {
                     "openshift.io/display-name": "Red Hat OpenJDK 11 (RHEL8)",
                     "openshift.io/provider-display-name": "Red Hat, Inc.",
@@ -202,10 +202,10 @@
                     {
                         "name": "11",
                         "annotations": {
-                            "openshift.io/display-name": "Red Hat OpenJDK 11",
-                            "description": "Build and run Java applications using Maven and OpenJDK 11.",
-                            "iconClass": "icon-rh-openjdk",
-                            "tags": "builder,java,openjdk",
+                            "openshift.io/display-name": "Red Hat OpenJ9 11",
+                            "description": "Build and run Java applications using Maven and OpenJ9 11.",
+                            "iconClass": "icon-rh-openj9",
+                            "tags": "builder,java,openj9",
                             "supports": "java:11,java",
                             "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts",
                             "sampleContextDir": "undertow-servlet",

--- a/templates/image-streams-s390x.json
+++ b/templates/image-streams-s390x.json
@@ -218,6 +218,26 @@
                             "kind": "DockerImage",
                             "name": "registry.redhat.io/openj9/openj9-11-rhel7:latest"
                         }
+                    },
+                    {
+                        "name": "latest",
+                        "annotations": {
+                            "openshift.io/display-name": "Red Hat OpenJ9 11 (RHEL7)",
+                            "description": "Build and run Java applications using Maven and OpenJ9 11.",
+                            "iconClass": "icon-rh-openj9",
+                            "tags": "builder,java,openj9",
+                            "supports": "java:11,java",
+                            "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts",
+                            "sampleContextDir": "undertow-servlet",
+                            "version": "latest"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
+                        },
+                        "from": {
+                            "kind": "ImageStreamTag",
+                            "name": "11"
+                        }
                     }
                 ]
             }

--- a/templates/image-streams-s390x.json
+++ b/templates/image-streams-s390x.json
@@ -2,9 +2,9 @@
     "kind": "List",
     "apiVersion": "v1",
     "metadata": {
-        "name": "openjdk18-image-stream",
+        "name": "openj9-image-stream",
         "annotations": {
-            "description": "ImageStream definition for Red Hat OpenJDK.",
+            "description": "ImageStream definition for OpenJ9.",
             "openshift.io/provider-display-name": "Red Hat, Inc."
         }
     },
@@ -13,68 +13,9 @@
             "kind": "ImageStream",
             "apiVersion": "v1",
             "metadata": {
-                "name": "redhat-openjdk18-openshift",
+                "name": "openj9-8-rhel7",
                 "annotations": {
-                    "openshift.io/display-name": "Red Hat OpenJDK 8",
-                    "openshift.io/provider-display-name": "Red Hat, Inc.",
-                    "version": "1.4.17"
-                },
-                "labels": {
-                    "xpaas": "1.4.17"
-                }
-            },
-            "spec": {
-                "tags": [
-                    {
-                        "name": "1.7",
-                        "annotations": {
-                            "openshift.io/display-name": "Red Hat OpenJDK 8",
-                            "description": "Build and run Java applications using Maven and OpenJDK 8.",
-                            "iconClass": "icon-rh-openjdk",
-                            "tags": "builder,java,openjdk,hidden",
-                            "supports": "java:8",
-                            "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts",
-                            "sampleContextDir": "undertow-servlet",
-                            "version": "1.7"
-                        },
-                        "referencePolicy": {
-                            "type": "Local"
-                        },
-                        "from": {
-                            "kind": "DockerImage",
-                            "name": "registry.redhat.io/redhat-openjdk-18/openjdk18-openshift:1.7"
-                        }
-                    },
-                    {
-                        "name": "1.8",
-                        "annotations": {
-                            "openshift.io/display-name": "Red Hat OpenJDK 8",
-                            "description": "Build and run Java applications using Maven and OpenJDK 8.",
-                            "iconClass": "icon-rh-openjdk",
-                            "tags": "builder,java,openjdk,hidden",
-                            "supports": "java:8",
-                            "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts",
-                            "sampleContextDir": "undertow-servlet",
-                            "version": "1.8"
-                        },
-                        "referencePolicy": {
-                            "type": "Local"
-                        },
-                        "from": {
-                            "kind": "DockerImage",
-                            "name": "registry.redhat.io/redhat-openjdk-18/openjdk18-openshift:1.8"
-                        }
-                    }
-                ]
-            }
-        },
-        {
-            "kind": "ImageStream",
-            "apiVersion": "v1",
-            "metadata": {
-                "name": "openjdk-11-rhel7",
-                "annotations": {
-                    "openshift.io/display-name": "Red Hat OpenJDK 11",
+                    "openshift.io/display-name": "OpenJ9 8",
                     "openshift.io/provider-display-name": "Red Hat, Inc.",
                     "version": "1.4.17"
                 },
@@ -87,10 +28,49 @@
                     {
                         "name": "1.1",
                         "annotations": {
-                            "openshift.io/display-name": "Red Hat OpenJDK 11",
-                            "description": "Build and run Java applications using Maven and OpenJDK 11.",
-                            "iconClass": "icon-rh-openjdk",
-                            "tags": "builder,java,openjdk,hidden",
+                            "openshift.io/display-name": "OpenJ9 8",
+                            "description": "Build and run Java applications using Maven and OpenJ9 8.",
+                            "iconClass": "icon-rh-openj9",
+                            "tags": "builder,java,openj9,hidden",
+                            "supports": "java:8",
+                            "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts",
+                            "sampleContextDir": "undertow-servlet",
+                            "version": "1.1"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
+                        },
+                        "from": {
+                            "kind": "DockerImage",
+                            "name": "registry.redhat.io/openj9/openj9-8-rhel7:1.1"
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "kind": "ImageStream",
+            "apiVersion": "v1",
+            "metadata": {
+                "name": "openj9-11-rhel7",
+                "annotations": {
+                    "openshift.io/display-name": "OpenJ9 11",
+                    "openshift.io/provider-display-name": "Red Hat, Inc.",
+                    "version": "1.4.17"
+                },
+                "labels": {
+                    "xpaas": "1.4.17"
+                }
+            },
+            "spec": {
+                "tags": [
+                    {
+                        "name": "1.1",
+                        "annotations": {
+                            "openshift.io/display-name": "OpenJ9 11",
+                            "description": "Build and run Java applications using Maven and OpenJ9 11.",
+                            "iconClass": "icon-rh-openj9",
+                            "tags": "builder,java,openj9,hidden",
                             "supports": "java:11",
                             "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts",
                             "sampleContextDir": "undertow-servlet",
@@ -101,7 +81,7 @@
                         },
                         "from": {
                             "kind": "DockerImage",
-                            "name": "registry.redhat.io/openjdk/openjdk-11-rhel7:1.1"
+                            "name": "registry.redhat.io/openj9/openj9-11-rhel7:1.1"
                         }
                     }
                 ]
@@ -111,9 +91,9 @@
             "kind": "ImageStream",
             "apiVersion": "v1",
             "metadata": {
-                "name": "openjdk-8-rhel8",
+                "name": "openj9-8-rhel8",
                 "annotations": {
-                    "openshift.io/display-name": "Red Hat OpenJDK 1.8 (RHEL8)",
+                    "openshift.io/display-name": "OpenJ9 1.8 (RHEL8)",
                     "openshift.io/provider-display-name": "Red Hat, Inc.",
                     "version": "1.4.17"
                 },
@@ -124,31 +104,12 @@
             "spec": {
                 "tags": [
                     {
-                        "name": "1.0",
-                        "annotations": {
-                            "openshift.io/display-name": "Red Hat OpenJDK 1.8 (RHEL8)",
-                            "description": "Build and run Java applications using Maven and OpenJDK 1.8 upon RHEL8.",
-                            "iconClass": "icon-rh-openjdk",
-                            "tags": "builder,java,openjdk,ubi8,hidden",
-                            "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts",
-                            "sampleContextDir": "undertow-servlet",
-                            "version": "1.0"
-                        },
-                        "referencePolicy": {
-                            "type": "Local"
-                        },
-                        "from": {
-                            "kind": "DockerImage",
-                            "name": "registry.redhat.io/openjdk/openjdk-8-rhel8:1.0"
-                        }
-                    },
-                    {
                         "name": "1.1",
                         "annotations": {
-                            "openshift.io/display-name": "Red Hat OpenJDK 1.8 (RHEL8)",
-                            "description": "Build and run Java applications using Maven and OpenJDK 1.8 upon RHEL8.",
-                            "iconClass": "icon-rh-openjdk",
-                            "tags": "builder,java,openjdk,ubi8,hidden",
+                            "openshift.io/display-name": "OpenJ9 1.8 (RHEL8)",
+                            "description": "Build and run Java applications using Maven and OpenJ9 1.8 upon RHEL8.",
+                            "iconClass": "icon-rh-openj9",
+                            "tags": "builder,java,openj9,ubi8,hidden",
                             "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts",
                             "sampleContextDir": "undertow-servlet",
                             "version": "1.1"
@@ -158,26 +119,7 @@
                         },
                         "from": {
                             "kind": "DockerImage",
-                            "name": "registry.redhat.io/openjdk/openjdk-8-rhel8:1.1"
-                        }
-                    },
-                    {
-                        "name": "1.2",
-                        "annotations": {
-                            "openshift.io/display-name": "Red Hat OpenJDK 1.8 (RHEL8)",
-                            "description": "Build and run Java applications using Maven and OpenJDK 1.8 upon RHEL8.",
-                            "iconClass": "icon-rh-openjdk",
-                            "tags": "builder,java,openjdk,ubi8,hidden",
-                            "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts",
-                            "sampleContextDir": "undertow-servlet",
-                            "version": "1.2"
-                        },
-                        "referencePolicy": {
-                            "type": "Local"
-                        },
-                        "from": {
-                            "kind": "DockerImage",
-                            "name": "registry.redhat.io/openjdk/openjdk-8-rhel8:1.2"
+                            "name": "registry.redhat.io/openj9/openj9-8-rhel8:1.1"
                         }
                     }
                 ]
@@ -200,31 +142,12 @@
             "spec": {
                 "tags": [
                     {
-                        "name": "1.0",
-                        "annotations": {
-                            "openshift.io/display-name": "Red Hat OpenJDK 11 (RHEL8)",
-                            "description": "Build and run Java applications using Maven and OpenJDK 11 upon RHEL8.",
-                            "iconClass": "icon-rh-openjdk",
-                            "tags": "builder,java,openjdk,ubi8,hidden",
-                            "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts",
-                            "sampleContextDir": "undertow-servlet",
-                            "version": "1.0"
-                        },
-                        "referencePolicy": {
-                            "type": "Local"
-                        },
-                        "from": {
-                            "kind": "DockerImage",
-                            "name": "registry.redhat.io/openjdk/openjdk-11-rhel8:1.0"
-                        }
-                    },
-                    {
                         "name": "1.1",
                         "annotations": {
-                            "openshift.io/display-name": "Red Hat OpenJDK 11 (RHEL8)",
-                            "description": "Build and run Java applications using Maven and OpenJDK 11 upon RHEL8.",
-                            "iconClass": "icon-rh-openjdk",
-                            "tags": "builder,java,openjdk,ubi8,hidden",
+                            "openshift.io/display-name": "OpenJ9 11 (RHEL8)",
+                            "description": "Build and run Java applications using Maven and OpenJ9 11 upon RHEL8.",
+                            "iconClass": "icon-rh-openj9",
+                            "tags": "builder,java,openj9,ubi8,hidden",
                             "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts",
                             "sampleContextDir": "undertow-servlet",
                             "version": "1.1"
@@ -234,26 +157,7 @@
                         },
                         "from": {
                             "kind": "DockerImage",
-                            "name": "registry.redhat.io/openjdk/openjdk-11-rhel8:1.1"
-                        }
-                    },
-                    {
-                        "name": "1.2",
-                        "annotations": {
-                            "openshift.io/display-name": "Red Hat OpenJDK 11 (RHEL8)",
-                            "description": "Build and run Java applications using Maven and OpenJDK 11 upon RHEL8.",
-                            "iconClass": "icon-rh-openjdk",
-                            "tags": "builder,java,openjdk,ubi8,hidden",
-                            "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts",
-                            "sampleContextDir": "undertow-servlet",
-                            "version": "1.2"
-                        },
-                        "referencePolicy": {
-                            "type": "Local"
-                        },
-                        "from": {
-                            "kind": "DockerImage",
-                            "name": "registry.redhat.io/openjdk/openjdk-11-rhel8:1.2"
+                            "name": "registry.redhat.io/openj9/openj9-11-rhel8:1.1"
                         }
                     }
                 ]
@@ -265,7 +169,7 @@
             "metadata": {
                 "name": "java",
                 "annotations": {
-                    "openshift.io/display-name": "Red Hat OpenJDK",
+                    "openshift.io/display-name": "OpenJ9",
                     "openshift.io/provider-display-name": "Red Hat, Inc.",
                     "version": "1.4.17"
                 },
@@ -278,10 +182,10 @@
                     {
                         "name": "8",
                         "annotations": {
-                            "openshift.io/display-name": "Red Hat OpenJDK 8",
-                            "description": "Build and run Java applications using Maven and OpenJDK 8.",
-                            "iconClass": "icon-rh-openjdk",
-                            "tags": "builder,java,openjdk",
+                            "openshift.io/display-name": "OpenJ9 8",
+                            "description": "Build and run Java applications using Maven and OpenJ9 8.",
+                            "iconClass": "icon-rh-openj9",
+                            "tags": "builder,java,openj9",
                             "supports": "java:8,java",
                             "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts",
                             "sampleContextDir": "undertow-servlet",
@@ -292,7 +196,7 @@
                         },
                         "from": {
                             "kind": "DockerImage",
-                            "name": "registry.redhat.io/redhat-openjdk-18/openjdk18-openshift:latest"
+                            "name": "registry.redhat.io/openj9/openj9-8-rhel7:latest"
                         }
                     },
                     {
@@ -312,16 +216,16 @@
                         },
                         "from": {
                             "kind": "DockerImage",
-                            "name": "registry.redhat.io/openjdk/openjdk-11-rhel7:latest"
+                            "name": "registry.redhat.io/openj9/openj9-11-rhel7:latest"
                         }
                     },
                     {
                         "name": "latest",
                         "annotations": {
-                            "openshift.io/display-name": "Red Hat OpenJDK 11",
-                            "description": "Build and run Java applications using Maven and OpenJDK 11.",
-                            "iconClass": "icon-rh-openjdk",
-                            "tags": "builder,java,openjdk",
+                            "openshift.io/display-name": "OpenJ9 11",
+                            "description": "Build and run Java applications using Maven and OpenJ9 11.",
+                            "iconClass": "icon-rh-openj9",
+                            "tags": "builder,java,openj9",
                             "supports": "java:11,java",
                             "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts",
                             "sampleContextDir": "undertow-servlet",

--- a/templates/image-streams-s390x.json
+++ b/templates/image-streams-s390x.json
@@ -1,0 +1,342 @@
+{
+    "kind": "List",
+    "apiVersion": "v1",
+    "metadata": {
+        "name": "openjdk18-image-stream",
+        "annotations": {
+            "description": "ImageStream definition for Red Hat OpenJDK.",
+            "openshift.io/provider-display-name": "Red Hat, Inc."
+        }
+    },
+    "items": [
+        {
+            "kind": "ImageStream",
+            "apiVersion": "v1",
+            "metadata": {
+                "name": "redhat-openjdk18-openshift",
+                "annotations": {
+                    "openshift.io/display-name": "Red Hat OpenJDK 8",
+                    "openshift.io/provider-display-name": "Red Hat, Inc.",
+                    "version": "1.4.17"
+                },
+                "labels": {
+                    "xpaas": "1.4.17"
+                }
+            },
+            "spec": {
+                "tags": [
+                    {
+                        "name": "1.7",
+                        "annotations": {
+                            "openshift.io/display-name": "Red Hat OpenJDK 8",
+                            "description": "Build and run Java applications using Maven and OpenJDK 8.",
+                            "iconClass": "icon-rh-openjdk",
+                            "tags": "builder,java,openjdk,hidden",
+                            "supports": "java:8",
+                            "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts",
+                            "sampleContextDir": "undertow-servlet",
+                            "version": "1.7"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
+                        },
+                        "from": {
+                            "kind": "DockerImage",
+                            "name": "registry.redhat.io/redhat-openjdk-18/openjdk18-openshift:1.7"
+                        }
+                    },
+                    {
+                        "name": "1.8",
+                        "annotations": {
+                            "openshift.io/display-name": "Red Hat OpenJDK 8",
+                            "description": "Build and run Java applications using Maven and OpenJDK 8.",
+                            "iconClass": "icon-rh-openjdk",
+                            "tags": "builder,java,openjdk,hidden",
+                            "supports": "java:8",
+                            "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts",
+                            "sampleContextDir": "undertow-servlet",
+                            "version": "1.8"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
+                        },
+                        "from": {
+                            "kind": "DockerImage",
+                            "name": "registry.redhat.io/redhat-openjdk-18/openjdk18-openshift:1.8"
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "kind": "ImageStream",
+            "apiVersion": "v1",
+            "metadata": {
+                "name": "openjdk-11-rhel7",
+                "annotations": {
+                    "openshift.io/display-name": "Red Hat OpenJDK 11",
+                    "openshift.io/provider-display-name": "Red Hat, Inc.",
+                    "version": "1.4.17"
+                },
+                "labels": {
+                    "xpaas": "1.4.17"
+                }
+            },
+            "spec": {
+                "tags": [
+                    {
+                        "name": "1.1",
+                        "annotations": {
+                            "openshift.io/display-name": "Red Hat OpenJDK 11",
+                            "description": "Build and run Java applications using Maven and OpenJDK 11.",
+                            "iconClass": "icon-rh-openjdk",
+                            "tags": "builder,java,openjdk,hidden",
+                            "supports": "java:11",
+                            "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts",
+                            "sampleContextDir": "undertow-servlet",
+                            "version": "1.1"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
+                        },
+                        "from": {
+                            "kind": "DockerImage",
+                            "name": "registry.redhat.io/openjdk/openjdk-11-rhel7:1.1"
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "kind": "ImageStream",
+            "apiVersion": "v1",
+            "metadata": {
+                "name": "openjdk-8-rhel8",
+                "annotations": {
+                    "openshift.io/display-name": "Red Hat OpenJDK 1.8 (RHEL8)",
+                    "openshift.io/provider-display-name": "Red Hat, Inc.",
+                    "version": "1.4.17"
+                },
+                "labels": {
+                    "xpaas": "1.4.17"
+                }
+            },
+            "spec": {
+                "tags": [
+                    {
+                        "name": "1.0",
+                        "annotations": {
+                            "openshift.io/display-name": "Red Hat OpenJDK 1.8 (RHEL8)",
+                            "description": "Build and run Java applications using Maven and OpenJDK 1.8 upon RHEL8.",
+                            "iconClass": "icon-rh-openjdk",
+                            "tags": "builder,java,openjdk,ubi8,hidden",
+                            "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts",
+                            "sampleContextDir": "undertow-servlet",
+                            "version": "1.0"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
+                        },
+                        "from": {
+                            "kind": "DockerImage",
+                            "name": "registry.redhat.io/openjdk/openjdk-8-rhel8:1.0"
+                        }
+                    },
+                    {
+                        "name": "1.1",
+                        "annotations": {
+                            "openshift.io/display-name": "Red Hat OpenJDK 1.8 (RHEL8)",
+                            "description": "Build and run Java applications using Maven and OpenJDK 1.8 upon RHEL8.",
+                            "iconClass": "icon-rh-openjdk",
+                            "tags": "builder,java,openjdk,ubi8,hidden",
+                            "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts",
+                            "sampleContextDir": "undertow-servlet",
+                            "version": "1.1"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
+                        },
+                        "from": {
+                            "kind": "DockerImage",
+                            "name": "registry.redhat.io/openjdk/openjdk-8-rhel8:1.1"
+                        }
+                    },
+                    {
+                        "name": "1.2",
+                        "annotations": {
+                            "openshift.io/display-name": "Red Hat OpenJDK 1.8 (RHEL8)",
+                            "description": "Build and run Java applications using Maven and OpenJDK 1.8 upon RHEL8.",
+                            "iconClass": "icon-rh-openjdk",
+                            "tags": "builder,java,openjdk,ubi8,hidden",
+                            "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts",
+                            "sampleContextDir": "undertow-servlet",
+                            "version": "1.2"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
+                        },
+                        "from": {
+                            "kind": "DockerImage",
+                            "name": "registry.redhat.io/openjdk/openjdk-8-rhel8:1.2"
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "kind": "ImageStream",
+            "apiVersion": "v1",
+            "metadata": {
+                "name": "openjdk-11-rhel8",
+                "annotations": {
+                    "openshift.io/display-name": "Red Hat OpenJDK 11 (RHEL8)",
+                    "openshift.io/provider-display-name": "Red Hat, Inc.",
+                    "version": "1.4.17"
+                },
+                "labels": {
+                    "xpaas": "1.4.17"
+                }
+            },
+            "spec": {
+                "tags": [
+                    {
+                        "name": "1.0",
+                        "annotations": {
+                            "openshift.io/display-name": "Red Hat OpenJDK 11 (RHEL8)",
+                            "description": "Build and run Java applications using Maven and OpenJDK 11 upon RHEL8.",
+                            "iconClass": "icon-rh-openjdk",
+                            "tags": "builder,java,openjdk,ubi8,hidden",
+                            "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts",
+                            "sampleContextDir": "undertow-servlet",
+                            "version": "1.0"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
+                        },
+                        "from": {
+                            "kind": "DockerImage",
+                            "name": "registry.redhat.io/openjdk/openjdk-11-rhel8:1.0"
+                        }
+                    },
+                    {
+                        "name": "1.1",
+                        "annotations": {
+                            "openshift.io/display-name": "Red Hat OpenJDK 11 (RHEL8)",
+                            "description": "Build and run Java applications using Maven and OpenJDK 11 upon RHEL8.",
+                            "iconClass": "icon-rh-openjdk",
+                            "tags": "builder,java,openjdk,ubi8,hidden",
+                            "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts",
+                            "sampleContextDir": "undertow-servlet",
+                            "version": "1.1"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
+                        },
+                        "from": {
+                            "kind": "DockerImage",
+                            "name": "registry.redhat.io/openjdk/openjdk-11-rhel8:1.1"
+                        }
+                    },
+                    {
+                        "name": "1.2",
+                        "annotations": {
+                            "openshift.io/display-name": "Red Hat OpenJDK 11 (RHEL8)",
+                            "description": "Build and run Java applications using Maven and OpenJDK 11 upon RHEL8.",
+                            "iconClass": "icon-rh-openjdk",
+                            "tags": "builder,java,openjdk,ubi8,hidden",
+                            "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts",
+                            "sampleContextDir": "undertow-servlet",
+                            "version": "1.2"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
+                        },
+                        "from": {
+                            "kind": "DockerImage",
+                            "name": "registry.redhat.io/openjdk/openjdk-11-rhel8:1.2"
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "kind": "ImageStream",
+            "apiVersion": "v1",
+            "metadata": {
+                "name": "java",
+                "annotations": {
+                    "openshift.io/display-name": "Red Hat OpenJDK",
+                    "openshift.io/provider-display-name": "Red Hat, Inc.",
+                    "version": "1.4.17"
+                },
+                "labels": {
+                    "xpaas": "1.4.17"
+                }
+            },
+            "spec": {
+                "tags": [
+                    {
+                        "name": "8",
+                        "annotations": {
+                            "openshift.io/display-name": "Red Hat OpenJDK 8",
+                            "description": "Build and run Java applications using Maven and OpenJDK 8.",
+                            "iconClass": "icon-rh-openjdk",
+                            "tags": "builder,java,openjdk",
+                            "supports": "java:8,java",
+                            "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts",
+                            "sampleContextDir": "undertow-servlet",
+                            "version": "8"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
+                        },
+                        "from": {
+                            "kind": "DockerImage",
+                            "name": "registry.redhat.io/redhat-openjdk-18/openjdk18-openshift:latest"
+                        }
+                    },
+                    {
+                        "name": "11",
+                        "annotations": {
+                            "openshift.io/display-name": "Red Hat OpenJDK 11",
+                            "description": "Build and run Java applications using Maven and OpenJDK 11.",
+                            "iconClass": "icon-rh-openjdk",
+                            "tags": "builder,java,openjdk",
+                            "supports": "java:11,java",
+                            "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts",
+                            "sampleContextDir": "undertow-servlet",
+                            "version": "11"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
+                        },
+                        "from": {
+                            "kind": "DockerImage",
+                            "name": "registry.redhat.io/openjdk/openjdk-11-rhel7:latest"
+                        }
+                    },
+                    {
+                        "name": "latest",
+                        "annotations": {
+                            "openshift.io/display-name": "Red Hat OpenJDK 11",
+                            "description": "Build and run Java applications using Maven and OpenJDK 11.",
+                            "iconClass": "icon-rh-openjdk",
+                            "tags": "builder,java,openjdk",
+                            "supports": "java:11,java",
+                            "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts",
+                            "sampleContextDir": "undertow-servlet",
+                            "version": "latest"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
+                        },
+                        "from": {
+                            "kind": "ImageStreamTag",
+                            "name": "11"
+                        }
+                    }
+                ]
+            }
+        }
+    ]
+}


### PR DESCRIPTION
This is a rebase of all openj9-related commits on the develop branch, with minor edits to two so as to not modify the OpenJDK image descriptors, so that this PR brings release up to speed with the OpenJ9 work.