### PR TITLE
reset openj9*rhel8 images on release branch to be equivalent to built images

### DIFF
--- a/openj9-11-rhel8.yaml
+++ b/openj9-11-rhel8.yaml
@@ -51,7 +51,7 @@ modules:
   - name: jboss.container.java.s2i.bash
   - name: jboss.container.maven.35.bash
     version: "3.5"
-  - name: jboss.container.java.singleton-jdk
+  - name: jboss.container.java.rm-openjdk
 
 help:
   add: true

--- a/openj9-8-rhel8.yaml
+++ b/openj9-8-rhel8.yaml
@@ -51,7 +51,7 @@ modules:
   - name: jboss.container.java.s2i.bash
   - name: jboss.container.maven.35.bash
     version: "3.5"
-  - name: jboss.container.java.singleton-jdk
+  - name: jboss.container.java.rm-openjdk
 
 help:
   add: true


### PR DESCRIPTION
This reverts the sources for the openj9/rhel8 images to reflect the source state that built the current images. This targets the release branch.

Commit 9f844fb4 was over-eager. The referenced version of cct_module
does not contain the singleton-jdk module. The presently-built OpenJ9 RHEL8
images were built against the current cct_module ref, with the older
"rm-openjdk" module name.