### PR TITLE
Bump cct_module ref for all images

### DIFF
--- a/image.yaml
+++ b/image.yaml
@@ -41,7 +41,7 @@ modules:
   - name: cct_module
     git:
       url: https://github.com/jboss-openshift/cct_module.git
-      ref: 260c2a021dc3de9f83c3ae8d17b128403a62f0fc
+      ref: b41f89355be15ee5fd687c850c21d95c925b540e
 
   install:
   - name: jboss.container.openjdk.jdk

--- a/openj9-11-rhel7.yaml
+++ b/openj9-11-rhel7.yaml
@@ -43,7 +43,7 @@ modules:
   - name: cct_module
     git:
       url: https://github.com/jboss-openshift/cct_module.git
-      ref: 260c2a021dc3de9f83c3ae8d17b128403a62f0fc
+      ref: b41f89355be15ee5fd687c850c21d95c925b540e
   install:
   - name: jboss.container.openjdk.jdk
     version: "openj9-11"

--- a/openj9-11-rhel8.yaml
+++ b/openj9-11-rhel8.yaml
@@ -43,7 +43,7 @@ modules:
   - name: cct_module
     git:
       url: https://github.com/jboss-openshift/cct_module.git
-      ref: 0.39.0
+      ref: b41f89355be15ee5fd687c850c21d95c925b540e
   install:
   - name: jboss.container.openjdk.jdk
     version: "openj9-11"

--- a/openj9-8-rhel7.yaml
+++ b/openj9-8-rhel7.yaml
@@ -43,7 +43,7 @@ modules:
   - name: cct_module
     git:
       url: https://github.com/jboss-openshift/cct_module.git
-      ref: 260c2a021dc3de9f83c3ae8d17b128403a62f0fc
+      ref: b41f89355be15ee5fd687c850c21d95c925b540e
   install:
   - name: jboss.container.openjdk.jdk
     version: "openj9-8"

--- a/openj9-8-rhel8.yaml
+++ b/openj9-8-rhel8.yaml
@@ -43,7 +43,7 @@ modules:
   - name: cct_module
     git:
       url: https://github.com/jboss-openshift/cct_module.git
-      ref: 0.39.0
+      ref: b41f89355be15ee5fd687c850c21d95c925b540e
   install:
   - name: jboss.container.openjdk.jdk
     version: "openj9-8"

--- a/openjdk-11-rhel7.yaml
+++ b/openjdk-11-rhel7.yaml
@@ -38,7 +38,7 @@ modules:
   - name: cct_module
     git:
       url: https://github.com/jboss-openshift/cct_module.git
-      ref: 260c2a021dc3de9f83c3ae8d17b128403a62f0fc
+      ref: b41f89355be15ee5fd687c850c21d95c925b540e
   install:
   - name: jboss.container.openjdk.jdk
     version: "11"

--- a/openjdk-11-rhel8.yaml
+++ b/openjdk-11-rhel8.yaml
@@ -38,7 +38,7 @@ modules:
   - name: cct_module
     git:
       url: https://github.com/jboss-openshift/cct_module.git
-      ref: 0.38.0
+      ref: b41f89355be15ee5fd687c850c21d95c925b540e
   install:
   - name: jboss.container.openjdk.jdk
     version: "11"

--- a/openjdk-8-rhel8.yaml
+++ b/openjdk-8-rhel8.yaml
@@ -38,7 +38,7 @@ modules:
   - name: cct_module
     git:
       url: https://github.com/jboss-openshift/cct_module.git
-      ref: 0.38.0
+      ref: b41f89355be15ee5fd687c850c21d95c925b540e
   install:
   - name: jboss.container.openjdk.jdk
     version: "8"


### PR DESCRIPTION
This fixes build failures for some images which require the singleton-jdk
module but reference a version of cct_module prior to its introduction.

See also GitHub PR #120.

Here I take the opportunity to harmonize the cct_module ref across all the
development images.