### PR TITLE
Revert OpenJ9 RHEL7 images to state of last build

### DIFF
--- a/openj9-11-rhel7.yaml
+++ b/openj9-11-rhel7.yaml
@@ -44,7 +44,7 @@ modules:
   - name: cct_module
     git:
       url: https://github.com/jboss-openshift/cct_module.git
-      ref: 260c2a021dc3de9f83c3ae8d17b128403a62f0fc
+      ref: 1668f62d797e4eb75ad35544c8de9adf4325ec22
   install:
   - name: jboss.container.openjdk.jdk
     version: "openj9-11"
@@ -53,7 +53,7 @@ modules:
     version: '0!3.6'
   - name: jboss.container.maven.36.bash
     version: "3.6scl"
-  - name: jboss.container.java.singleton-jdk
+  - name: jboss.container.java.rm-openjdk
 
 help:
   add: true

--- a/openj9-8-rhel7.yaml
+++ b/openj9-8-rhel7.yaml
@@ -44,7 +44,7 @@ modules:
   - name: cct_module
     git:
       url: https://github.com/jboss-openshift/cct_module.git
-      ref: 260c2a021dc3de9f83c3ae8d17b128403a62f0fc
+      ref: 1668f62d797e4eb75ad35544c8de9adf4325ec22
   install:
   - name: jboss.container.openjdk.jdk
     version: "openj9-8"
@@ -53,7 +53,7 @@ modules:
     version: '0!3.6'
   - name: jboss.container.maven.36.bash
     version: "3.6scl"
-  - name: jboss.container.java.singleton-jdk
+  - name: jboss.container.java.rm-openjdk
 
 help:
   add: true


### PR DESCRIPTION
Sorry for not addressing this in #120 . I think this should finally resolve the matter.

For OpenJ9/RHEL7 images this time.

This reverts commit 9f844fb4e1008cdf5973d7f0f13739012526be11 and also
rolls back the cekit reference. The sources now reflect exactly the
state they were in when the last builds were produced: confirmed by
cekit osbs build and comparing the dist-git commits.