### PR TITLE
Re-enable singleton-jdk for ubi8/openjdk-11

### DIFF
--- a/ubi8-openjdk-11.yaml
+++ b/ubi8-openjdk-11.yaml
@@ -51,6 +51,7 @@ modules:
   - name: jboss.container.maven
     version: "8.2.3.6"
   - name: jboss.container.java.s2i.bash
+  - name: jboss.container.java.singleton-jdk
 
 help:
   add: true


### PR DESCRIPTION
Jiri A noticed that java-1.8.0-openjdk-headless had snuck back into the ubi8/openjdk-11 RC build, and so this module is sadly still necessary for now.