### PR TITLE
Fix incremental S2I tests

### DIFF
--- a/tests/features/java/java_s2i_inc.feature
+++ b/tests/features/java/java_s2i_inc.feature
@@ -1,8 +1,8 @@
-# NOT tagged for any images - test broken
+@openjdk
+@ubi8
+@redhat-openjdk-18
+@openj9
 Feature: Openshift OpenJDK S2I tests
-# NOTE: these tests should be usable with the other images once we have refactored the JDK scripts.
-# These builds do not actually run maven. This is important, because the proxy
-# options supplied do not specify a valid HTTP proxy.
 
   # test incremental builds
   Scenario: Check incremental builds cache .m2
@@ -10,9 +10,9 @@ Feature: Openshift OpenJDK S2I tests
         | variable    | value               |
         | JAVA_ARGS   | Hello from CTF test |
     Then container log should contain /deployments/undertow-servlet.jar Hello from CTF test
-     And s2i build log should contain Downloading:
+     And s2i build log should contain Downloading from central:
     Given s2i build https://github.com/jboss-openshift/openshift-quickstarts from undertow-servlet with env and incremental
         | variable    | value               |
         | JAVA_ARGS   | Hello from CTF test |
     Then container log should contain /deployments/undertow-servlet.jar Hello from CTF test
-     And s2i build log should not contain Downloading:
+     And s2i build log should not contain Downloading from central:


### PR DESCRIPTION
The exact string output by Maven had changed since the test was
originally written. Retag the test to run for all the OpenJDK
images.