### PR TITLE
[CLOUD-3762] Restructure java imagestreams

### DIFF
--- a/templates/community-image-streams.json
+++ b/templates/community-image-streams.json
@@ -90,9 +90,9 @@
             "spec": {
                 "tags": [
                     {
-                        "name": "8",
+                        "name": "openjdk-8-ubi8",
                         "annotations": {
-                            "openshift.io/display-name": "Red Hat OpenJDK 8",
+                            "openshift.io/display-name": "Red Hat OpenJDK 8 (UBI 8)",
                             "description": "Build and run Java applications using Maven and OpenJDK 1.8 upon UBI8.",
                             "iconClass": "icon-rh-openjdk",
                             "tags": "builder,java,openjdk",
@@ -110,9 +110,29 @@
                         }
                     },
                     {
-                        "name": "11",
+                        "name": "8",
                         "annotations": {
-                            "openshift.io/display-name": "Red Hat OpenJDK 11",
+                            "openshift.io/display-name": "Red Hat OpenJDK 8",
+                            "description": "Build and run Java applications using Maven and OpenJDK 1.8 upon UBI8.",
+                            "iconClass": "icon-rh-openjdk",
+                            "tags": "builder,java,openjdk,hidden",
+                            "supports": "java:8,java",
+                            "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts",
+                            "sampleContextDir": "undertow-servlet",
+                            "version": "8"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
+                        },
+                        "from": {
+                            "kind": "DockerImage",
+                            "name": "registry.access.redhat.com/ubi8/openjdk-8:latest"
+                        }
+                    },
+                    {
+                        "name": "openjdk-11-ubi8",
+                        "annotations": {
+                            "openshift.io/display-name": "Red Hat OpenJDK 11 (UBI 8)",
                             "description": "Build and run Java applications using Maven and OpenJDK 11 upon UBI8.",
                             "iconClass": "icon-rh-openjdk",
                             "tags": "builder,java,openjdk",
@@ -130,13 +150,33 @@
                         }
                     },
                     {
-                        "name": "latest",
+                        "name": "11",
                         "annotations": {
                             "openshift.io/display-name": "Red Hat OpenJDK 11",
                             "description": "Build and run Java applications using Maven and OpenJDK 11 upon UBI8.",
                             "iconClass": "icon-rh-openjdk",
-                            "tags": "builder,java,openjdk",
+                            "tags": "builder,java,openjdk,hidden",
                             "supports": "java:11,java",
+                            "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts",
+                            "sampleContextDir": "undertow-servlet",
+                            "version": "11"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
+                        },
+                        "from": {
+                            "kind": "DockerImage",
+                            "name": "registry.access.redhat.com/ubi8/openjdk-11:latest"
+                        }
+                    },
+                    {
+                        "name": "latest",
+                        "annotations": {
+                            "openshift.io/display-name": "Java (Latest)",
+                            "description": "Build and run Java applications using Maven.",
+                            "iconClass": "icon-rh-openjdk",
+                            "tags": "builder,java,openjdk",
+                            "supports": "java",
                             "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts",
                             "sampleContextDir": "undertow-servlet",
                             "version": "latest"
@@ -146,7 +186,7 @@
                         },
                         "from": {
                             "kind": "ImageStreamTag",
-                            "name": "11"
+                            "name": "openjdk-11-ubi8"
                         }
                     }
                 ]

--- a/templates/image-streams-ppc64le.json
+++ b/templates/image-streams-ppc64le.json
@@ -260,9 +260,29 @@
             "spec": {
                 "tags": [
                     {
-                        "name": "8",
+                        "name": "openjdk-8-ubi8",
                         "annotations": {
-                            "openshift.io/display-name": "Red Hat OpenJDK 8",
+                            "openshift.io/display-name": "Red Hat OpenJDK 8 (UBI 8)",
+                            "description": "Build and run Java applications using Maven and OpenJDK 8.",
+                            "iconClass": "icon-rh-openjdk",
+                            "tags": "builder,java,openjdk",
+                            "supports": "java:8,java",
+                            "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts",
+                            "sampleContextDir": "undertow-servlet",
+                            "version": "8"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
+                        },
+                        "from": {
+                            "kind": "DockerImage",
+                            "name": "registry.redhat.io/ubi8/openjdk-8:latest"
+                        }
+                    },
+                    {
+                        "name": "openjdk-8-el7",
+                        "annotations": {
+                            "openshift.io/display-name": "Red Hat OpenJDK 8 (RHEL 7)",
                             "description": "Build and run Java applications using Maven and OpenJDK 8.",
                             "iconClass": "icon-rh-openjdk",
                             "tags": "builder,java,openjdk",
@@ -280,9 +300,49 @@
                         }
                     },
                     {
-                        "name": "11",
+                        "name": "8",
                         "annotations": {
-                            "openshift.io/display-name": "Red Hat OpenJDK 11",
+                            "openshift.io/display-name": "Red Hat OpenJDK 8",
+                            "description": "Build and run Java applications using Maven and OpenJDK 8.",
+                            "iconClass": "icon-rh-openjdk",
+                            "tags": "builder,java,openjdk,hidden",
+                            "supports": "java:8,java",
+                            "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts",
+                            "sampleContextDir": "undertow-servlet",
+                            "version": "8"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
+                        },
+                        "from": {
+                            "kind": "DockerImage",
+                            "name": "registry.redhat.io/redhat-openjdk-18/openjdk18-openshift:latest"
+                        }
+                    },
+                    {
+                        "name": "openjdk-11-ubi8",
+                        "annotations": {
+                            "openshift.io/display-name": "Red Hat OpenJDK 11 (UBI 8)",
+                            "description": "Build and run Java applications using Maven and OpenJDK 11.",
+                            "iconClass": "icon-rh-openjdk",
+                            "tags": "builder,java,openjdk",
+                            "supports": "java:11,java",
+                            "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts",
+                            "sampleContextDir": "undertow-servlet",
+                            "version": "11"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
+                        },
+                        "from": {
+                            "kind": "DockerImage",
+                            "name": "registry.redhat.io/ubi8/openjdk-11:latest"
+                        }
+                    },
+                    {
+                        "name": "openjdk-11-el7",
+                        "annotations": {
+                            "openshift.io/display-name": "Red Hat OpenJDK 11 (RHEL 7)",
                             "description": "Build and run Java applications using Maven and OpenJDK 11.",
                             "iconClass": "icon-rh-openjdk",
                             "tags": "builder,java,openjdk",
@@ -300,13 +360,33 @@
                         }
                     },
                     {
-                        "name": "latest",
+                        "name": "11",
                         "annotations": {
                             "openshift.io/display-name": "Red Hat OpenJDK 11",
                             "description": "Build and run Java applications using Maven and OpenJDK 11.",
                             "iconClass": "icon-rh-openjdk",
-                            "tags": "builder,java,openjdk",
+                            "tags": "builder,java,openjdk,hidden",
                             "supports": "java:11,java",
+                            "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts",
+                            "sampleContextDir": "undertow-servlet",
+                            "version": "11"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
+                        },
+                        "from": {
+                            "kind": "DockerImage",
+                            "name": "registry.redhat.io/openjdk/openjdk-11-rhel7:latest"
+                        }
+                    },
+                    {
+                        "name": "latest",
+                        "annotations": {
+                            "openshift.io/display-name": "Java (Latest)",
+                            "description": "Build and run Java applications using Maven.",
+                            "iconClass": "icon-rh-openjdk",
+                            "tags": "builder,java,openjdk",
+                            "supports": "java",
                             "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts",
                             "sampleContextDir": "undertow-servlet",
                             "version": "latest"
@@ -316,7 +396,7 @@
                         },
                         "from": {
                             "kind": "ImageStreamTag",
-                            "name": "11"
+                            "name": "openjdk-11-ubi8"
                         }
                     }
                 ]

--- a/templates/image-streams-s390x.json
+++ b/templates/image-streams-s390x.json
@@ -414,9 +414,69 @@
             "spec": {
                 "tags": [
                     {
-                        "name": "8",
+                        "name": "openjdk-8-ubi8",
                         "annotations": {
-                            "openshift.io/display-name": "OpenJ9 1.8.0",
+                            "openshift.io/display-name": "Red Hat OpenJDK 8 (UBI 8)",
+                            "description": "Build and run Java applications using Maven and OpenJDK 8.",
+                            "iconClass": "icon-rh-openjdk",
+                            "tags": "builder,java,openjdk",
+                            "supports": "java:8,java",
+                            "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts",
+                            "sampleContextDir": "undertow-servlet",
+                            "version": "8"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
+                        },
+                        "from": {
+                            "kind": "DockerImage",
+                            "name": "registry.redhat.io/ubi8/openjdk-8:latest"
+                        }
+                    },
+                    {
+                        "name": "openjdk-8-el7",
+                        "annotations": {
+                            "openshift.io/display-name": "Red Hat OpenJDK 8 (RHEL 7)",
+                            "description": "Build and run Java applications using Maven and OpenJDK 8.",
+                            "iconClass": "icon-rh-openjdk",
+                            "tags": "builder,java,openjdk",
+                            "supports": "java:8,java",
+                            "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts",
+                            "sampleContextDir": "undertow-servlet",
+                            "version": "8"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
+                        },
+                        "from": {
+                            "kind": "DockerImage",
+                            "name": "registry.redhat.io/redhat-openjdk-18/openjdk18-openshift:latest"
+                        }
+                    },
+                    {
+                        "name": "openj9-8-el8",
+                        "annotations": {
+                            "openshift.io/display-name": "OpenJ9 1.8.0 (RHEL 8)",
+                            "description": "Build and run Java applications using Maven and OpenJ9 1.8.0.",
+                            "iconClass": "icon-rh-openj9",
+                            "tags": "builder,java,openj9",
+                            "supports": "java:8,java",
+                            "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts",
+                            "sampleContextDir": "undertow-servlet",
+                            "version": "8"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
+                        },
+                        "from": {
+                            "kind": "DockerImage",
+                            "name": "registry.redhat.io/openj9/openj9-8-rhel8:latest"
+                        }
+                    },
+                    {
+                        "name": "openj9-8-el7",
+                        "annotations": {
+                            "openshift.io/display-name": "OpenJ9 1.8.0 (RHEL 7)",
                             "description": "Build and run Java applications using Maven and OpenJ9 1.8.0.",
                             "iconClass": "icon-rh-openj9",
                             "tags": "builder,java,openj9",
@@ -434,9 +494,89 @@
                         }
                     },
                     {
-                        "name": "11",
+                        "name": "8",
                         "annotations": {
-                            "openshift.io/display-name": "Red Hat OpenJ9 11 (RHEL7)",
+                            "openshift.io/display-name": "OpenJ9 1.8.0",
+                            "description": "Build and run Java applications using Maven and OpenJ9 1.8.0.",
+                            "iconClass": "icon-rh-openj9",
+                            "tags": "builder,java,openj9,hidden",
+                            "supports": "java:8,java",
+                            "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts",
+                            "sampleContextDir": "undertow-servlet",
+                            "version": "8"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
+                        },
+                        "from": {
+                            "kind": "DockerImage",
+                            "name": "registry.redhat.io/openj9/openj9-8-rhel7:latest"
+                        }
+                    },
+                    {
+                        "name": "openjdk-11-ubi8",
+                        "annotations": {
+                            "openshift.io/display-name": "Red Hat OpenJDK 11 (UBI 8)",
+                            "description": "Build and run Java applications using Maven and OpenJDK 11.",
+                            "iconClass": "icon-rh-openjdk",
+                            "tags": "builder,java,openjdk",
+                            "supports": "java:11,java",
+                            "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts",
+                            "sampleContextDir": "undertow-servlet",
+                            "version": "11"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
+                        },
+                        "from": {
+                            "kind": "DockerImage",
+                            "name": "registry.redhat.io/ubi8/openjdk-11:latest"
+                        }
+                    },
+                    {
+                        "name": "openjdk-11-el7",
+                        "annotations": {
+                            "openshift.io/display-name": "Red Hat OpenJDK 11 (RHEL 7)",
+                            "description": "Build and run Java applications using Maven and OpenJDK 11.",
+                            "iconClass": "icon-rh-openjdk",
+                            "tags": "builder,java,openjdk",
+                            "supports": "java:11,java",
+                            "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts",
+                            "sampleContextDir": "undertow-servlet",
+                            "version": "11"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
+                        },
+                        "from": {
+                            "kind": "DockerImage",
+                            "name": "registry.redhat.io/openjdk/openjdk-11-rhel7:latest"
+                        }
+                    },
+                    {
+                        "name": "openj9-11-el8",
+                        "annotations": {
+                            "openshift.io/display-name": "Red Hat OpenJ9 11 (RHEL 8)",
+                            "description": "Build and run Java applications using Maven and OpenJ9 11.",
+                            "iconClass": "icon-rh-openj9",
+                            "tags": "builder,java,openj9",
+                            "supports": "java:11,java",
+                            "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts",
+                            "sampleContextDir": "undertow-servlet",
+                            "version": "11"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
+                        },
+                        "from": {
+                            "kind": "DockerImage",
+                            "name": "registry.redhat.io/openj9/openj9-11-rhel8:latest"
+                        }
+                    },
+                    {
+                        "name": "openj9-11-el7",
+                        "annotations": {
+                            "openshift.io/display-name": "Red Hat OpenJ9 11 (RHEL 7)",
                             "description": "Build and run Java applications using Maven and OpenJ9 11.",
                             "iconClass": "icon-rh-openj9",
                             "tags": "builder,java,openj9",
@@ -454,13 +594,33 @@
                         }
                     },
                     {
-                        "name": "latest",
+                        "name": "11",
                         "annotations": {
                             "openshift.io/display-name": "Red Hat OpenJ9 11 (RHEL7)",
                             "description": "Build and run Java applications using Maven and OpenJ9 11.",
                             "iconClass": "icon-rh-openj9",
-                            "tags": "builder,java,openj9",
+                            "tags": "builder,java,openj9,hidden",
                             "supports": "java:11,java",
+                            "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts",
+                            "sampleContextDir": "undertow-servlet",
+                            "version": "11"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
+                        },
+                        "from": {
+                            "kind": "DockerImage",
+                            "name": "registry.redhat.io/openj9/openj9-11-rhel7:latest"
+                        }
+                    },
+                    {
+                        "name": "latest",
+                        "annotations": {
+                            "openshift.io/display-name": "Java (Latest)",
+                            "description": "Build and run Java applications using Maven.",
+                            "iconClass": "icon-rh-openj9",
+                            "tags": "builder,java,openj9",
+                            "supports": "java",
                             "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts",
                             "sampleContextDir": "undertow-servlet",
                             "version": "latest"
@@ -470,7 +630,7 @@
                         },
                         "from": {
                             "kind": "ImageStreamTag",
-                            "name": "11"
+                            "name": "openjdk-11-ubi8"
                         }
                     }
                 ]

--- a/templates/image-streams.json
+++ b/templates/image-streams.json
@@ -360,9 +360,29 @@
             "spec": {
                 "tags": [
                     {
-                        "name": "8",
+                        "name": "openjdk-8-ubi8",
                         "annotations": {
-                            "openshift.io/display-name": "Red Hat OpenJDK 8",
+                            "openshift.io/display-name": "Red Hat OpenJDK 8 (UBI 8)",
+                            "description": "Build and run Java applications using Maven and OpenJDK 8.",
+                            "iconClass": "icon-rh-openjdk",
+                            "tags": "builder,java,openjdk",
+                            "supports": "java:8,java",
+                            "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts",
+                            "sampleContextDir": "undertow-servlet",
+                            "version": "8"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
+                        },
+                        "from": {
+                            "kind": "DockerImage",
+                            "name": "registry.redhat.io/ubi8/openjdk-8:latest"
+                        }
+                    },
+                    {
+                        "name": "openjdk-8-el7",
+                        "annotations": {
+                            "openshift.io/display-name": "Red Hat OpenJDK 8 (RHEL 7)",
                             "description": "Build and run Java applications using Maven and OpenJDK 8.",
                             "iconClass": "icon-rh-openjdk",
                             "tags": "builder,java,openjdk",
@@ -380,9 +400,49 @@
                         }
                     },
                     {
-                        "name": "11",
+                        "name": "8",
                         "annotations": {
-                            "openshift.io/display-name": "Red Hat OpenJDK 11",
+                            "openshift.io/display-name": "Red Hat OpenJDK 8",
+                            "description": "Build and run Java applications using Maven and OpenJDK 8.",
+                            "iconClass": "icon-rh-openjdk",
+                            "tags": "builder,java,openjdk,hidden",
+                            "supports": "java:8,java",
+                            "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts",
+                            "sampleContextDir": "undertow-servlet",
+                            "version": "8"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
+                        },
+                        "from": {
+                            "kind": "DockerImage",
+                            "name": "registry.redhat.io/redhat-openjdk-18/openjdk18-openshift:latest"
+                        }
+                    },
+                    {
+                        "name": "openjdk-11-ubi8",
+                        "annotations": {
+                            "openshift.io/display-name": "Red Hat OpenJDK 11 (UBI 8)",
+                            "description": "Build and run Java applications using Maven and OpenJDK 11.",
+                            "iconClass": "icon-rh-openjdk",
+                            "tags": "builder,java,openjdk",
+                            "supports": "java:11,java",
+                            "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts",
+                            "sampleContextDir": "undertow-servlet",
+                            "version": "11"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
+                        },
+                        "from": {
+                            "kind": "DockerImage",
+                            "name": "registry.redhat.io/ubi8/openjdk-11:latest"
+                        }
+                    },
+                    {
+                        "name": "openjdk-11-el7",
+                        "annotations": {
+                            "openshift.io/display-name": "Red Hat OpenJDK 11 (RHEL 7)",
                             "description": "Build and run Java applications using Maven and OpenJDK 11.",
                             "iconClass": "icon-rh-openjdk",
                             "tags": "builder,java,openjdk",
@@ -400,13 +460,33 @@
                         }
                     },
                     {
-                        "name": "latest",
+                        "name": "11",
                         "annotations": {
                             "openshift.io/display-name": "Red Hat OpenJDK 11",
                             "description": "Build and run Java applications using Maven and OpenJDK 11.",
                             "iconClass": "icon-rh-openjdk",
-                            "tags": "builder,java,openjdk",
+                            "tags": "builder,java,openjdk,hidden",
                             "supports": "java:11,java",
+                            "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts",
+                            "sampleContextDir": "undertow-servlet",
+                            "version": "11"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
+                        },
+                        "from": {
+                            "kind": "DockerImage",
+                            "name": "registry.redhat.io/openjdk/openjdk-11-rhel7:latest"
+                        }
+                    },
+                    {
+                        "name": "latest",
+                        "annotations": {
+                            "openshift.io/display-name": "Java (Latest)",
+                            "description": "Build and run Java applications using Maven.",
+                            "iconClass": "icon-rh-openjdk",
+                            "tags": "builder,java,openjdk",
+                            "supports": "java",
                             "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts",
                             "sampleContextDir": "undertow-servlet",
                             "version": "latest"
@@ -416,7 +496,7 @@
                         },
                         "from": {
                             "kind": "ImageStreamTag",
-                            "name": "11"
+                            "name": "openjdk-11-ubi8"
                         }
                     }
                 ]


### PR DESCRIPTION
Following the model being implemented by the SCLs, imagestreams are now
defined by both runtime and underlying OS version, with an emphasis on
making UBI 8 available and default.

In the case of Java, we also have both OpenJ9 alongside OpenJDK on some
architectures as an additional option.  The naming scheme used here
should cover any expected permutations going forward.