### PR TITLE
[OPENJDK-158] Update from: for RHEL8/UBI8-based images

### DIFF
--- a/openj9-11-rhel8.yaml
+++ b/openj9-11-rhel8.yaml
@@ -4,7 +4,7 @@
 
 schema_version: 1
 
-from: "ubi8-minimal:8-released"
+from: "registry.access.redhat.com/ubi8/ubi-minimal"
 name: &name "openj9/openj9-11-rhel8"
 version: &version "1.2"
 description: "Source To Image (S2I) image for Red Hat OpenShift providing OpenJ9 11"

--- a/openj9-8-rhel8.yaml
+++ b/openj9-8-rhel8.yaml
@@ -4,7 +4,7 @@
 
 schema_version: 1
 
-from: "ubi8-minimal:8-released"
+from: "registry.access.redhat.com/ubi8/ubi-minimal"
 name: &name "openj9/openj9-8-rhel8"
 version: &version "1.2"
 description: "Source To Image (S2I) image for Red Hat OpenShift providing OpenJ9 1.8"

--- a/ubi8-openjdk-11.yaml
+++ b/ubi8-openjdk-11.yaml
@@ -2,7 +2,7 @@
 
 schema_version: 1
 
-from: "ubi8-minimal:8-released"
+from: "registry.access.redhat.com/ubi8/ubi-minimal"
 name: &name "ubi8/openjdk-11"
 version: &version "1.3"
 description: "Source To Image (S2I) image for Red Hat OpenShift providing OpenJDK 11"

--- a/ubi8-openjdk-8.yaml
+++ b/ubi8-openjdk-8.yaml
@@ -2,7 +2,7 @@
 
 schema_version: 1
 
-from: "ubi8-minimal:8-released"
+from: "registry.access.redhat.com/ubi8/ubi-minimal"
 name: &name "ubi8/openjdk-8"
 version: &version "1.3"
 description: "Source To Image (S2I) image for Red Hat OpenShift providing OpenJDK 1.8"


### PR DESCRIPTION
Internal support for ":*-released" tags is going away by the end
of September. Meanwhile, internal support for a fully-qualified
external base image URI is now available.

Update the from: for RHEL8-based images to a fully qualified,
globally available container registry URI.

This also makes simple local building of those images easier.