### PR TITLE
[OPENJDK-146] Updated openj9 rhel7 content sets list - s390x & ppc64le

### DIFF
--- a/content_sets_rhel7.yml
+++ b/content_sets_rhel7.yml
@@ -1,6 +1,8 @@
 s390x:
 - rhel-7-for-system-z-rpms
+- rhel-7-for-system-z-optional-rpms
 - rhel-7-server-for-system-z-rhscl-rpms
 ppc64le:
 - rhel-7-server-for-power-le-rhscl-rpms
 - rhel-7-for-power-le-rpms
+- rhel-7-for-power-le-optional-rpms


### PR DESCRIPTION
Fixes for the openj9 RHEL7 s2i image error in CVP tests regarding content_sets.

Jira Issue:
https://issues.redhat.com/browse/OPENJDK-146

 Signed-off-by: Rafiur Rashid rrashid@redhat.com

- [X] Pull Request title is properly formatted: `[CLOUD-XYA] Subject`
- [X] Pull Request contains link to the JIRA issue
- [X] Pull Request contains description of the issue
- [X] Pull Request does not include fixes for issues other than the main ticket
- [X] Attached commits represent units of work and are properly formatted
- [X] You have read and agreed to the Developer Certificate of Origin (DCO) (see `CONTRIBUTING.md`)
- [X] Every commit contains `Signed-off-by: Your Name <yourname@example.com>` - use `git commit -s`
