### PR TITLE
[OPENJDK-159] fix FROM lines for OpenJ9 images

### DIFF
--- a/image.yaml
+++ b/image.yaml
@@ -2,7 +2,7 @@
 
 schema_version: 1
 
-from: "rhel7:7-released"
+from: "registry.redhat.io/rhel7/rhel"
 name: &name "redhat-openjdk-18/openjdk18-openshift"
 version: &version "1.8"
 description: "Source To Image (S2I) image for Red Hat OpenShift providing OpenJDK 8"

--- a/openj9-11-rhel7.yaml
+++ b/openj9-11-rhel7.yaml
@@ -4,7 +4,7 @@
 
 schema_version: 1
 
-from: "rhel7:7-released"
+from: "registry.redhat.io/rhel7/rhel"
 name: &name "openj9/openj9-11-rhel7"
 version: &version "1.1"
 description: "Source To Image (S2I) image for Red Hat OpenShift providing OpenJ9 11"

--- a/openj9-11-rhel8.yaml
+++ b/openj9-11-rhel8.yaml
@@ -4,7 +4,7 @@
 
 schema_version: 1
 
-from: "registry.access.redhat.com/ubi8/ubi-minimal"
+from: "registry.redhat.io/ubi8/ubi-minimal"
 name: &name "openj9/openj9-11-rhel8"
 version: &version "1.2"
 description: "Source To Image (S2I) image for Red Hat OpenShift providing OpenJ9 11"

--- a/openj9-8-rhel7.yaml
+++ b/openj9-8-rhel7.yaml
@@ -4,7 +4,7 @@
 
 schema_version: 1
 
-from: "rhel7:7-released"
+from: "registry.redhat.io/rhel7/rhel"
 name: &name "openj9/openj9-8-rhel7"
 version: &version "1.1"
 description: "Source To Image (S2I) image for Red Hat OpenShift providing OpenJ9 1.8"

--- a/openj9-8-rhel8.yaml
+++ b/openj9-8-rhel8.yaml
@@ -4,7 +4,7 @@
 
 schema_version: 1
 
-from: "registry.access.redhat.com/ubi8/ubi-minimal"
+from: "registry.redhat.io/ubi8/ubi-minimal"
 name: &name "openj9/openj9-8-rhel8"
 version: &version "1.2"
 description: "Source To Image (S2I) image for Red Hat OpenShift providing OpenJ9 1.8"

--- a/openjdk-11-rhel7.yaml
+++ b/openjdk-11-rhel7.yaml
@@ -2,7 +2,7 @@
 
 schema_version: 1
 
-from: "rhel7:7-released"
+from: "registry.redhat.io/rhel7/rhel"
 name: &name "openjdk/openjdk-11-rhel7"
 version: &version "1.1"
 description: "Source To Image (S2I) image for Red Hat OpenShift providing OpenJDK 11"

--- a/ubi8-openjdk-11.yaml
+++ b/ubi8-openjdk-11.yaml
@@ -2,7 +2,7 @@
 
 schema_version: 1
 
-from: "registry.access.redhat.com/ubi8/ubi-minimal"
+from: "registry.redhat.io/ubi8/ubi-minimal"
 name: &name "ubi8/openjdk-11"
 version: &version "1.3"
 description: "Source To Image (S2I) image for Red Hat OpenShift providing OpenJDK 11"

--- a/ubi8-openjdk-8.yaml
+++ b/ubi8-openjdk-8.yaml
@@ -2,7 +2,7 @@
 
 schema_version: 1
 
-from: "registry.access.redhat.com/ubi8/ubi-minimal"
+from: "registry.redhat.io/ubi8/ubi-minimal"
 name: &name "ubi8/openjdk-8"
 version: &version "1.3"
 description: "Source To Image (S2I) image for Red Hat OpenShift providing OpenJDK 1.8"


### PR DESCRIPTION
registry.access.redhat.com is not a permitted FROM source in OSBS.
Use registry.redhat.io instead, which is (but requires authentication)