### PR TITLE
Initial Github Action/workflow for building

### DIFF
--- a/.github/workflows/ubi8-openjdk-11.yml
+++ b/.github/workflows/ubi8-openjdk-11.yml
@@ -1,0 +1,33 @@
+name: OpenJDK 11 S2I Image CI
+on: [push, pull_request]
+env:
+  LANG: en_US.UTF-8
+  CEKIT_VERSION: 3.6.0
+jobs:
+  openjdkci:
+    name: OpenJDK S2I Build and Test
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+    steps:
+      - uses: actions/checkout@v2
+      - name: Verify latest UBI image is present
+        run: |
+          docker pull registry.access.redhat.com/ubi8/ubi-minimal:latest
+          docker tag  registry.access.redhat.com/ubi8/ubi-minimal:latest registry.redhat.io/ubi8/ubi-minimal:latest
+          docker image ls | grep ubi8
+      - name: Setup required system packages
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y krb5-multidev virtualenv
+      - name: Setup virtualenv and install cekit and required packages
+        run: |
+          mkdir ~/cekit${{ env.CEKIT_VERSION }}
+          virtualenv ~/cekit${{ env.CEKIT_VERSION }}
+          . ~/cekit${{ env.CEKIT_VERSION }}/bin/activate
+          pip install cekit==${{ env.CEKIT_VERSION }} docker docker-squash odcs behave lxml
+      - name: Build
+        run: |
+          . ~/cekit${{ env.CEKIT_VERSION }}/bin/activate
+          cekit -v --descriptor ubi8-openjdk-11.yaml build --overrides '{"packages": {"content_sets_file": null }}' docker
+          docker image ls

--- a/.github/workflows/ubi8-openjdk-8.yml
+++ b/.github/workflows/ubi8-openjdk-8.yml
@@ -1,0 +1,33 @@
+name: OpenJDK 8 S2I Image CI
+on: [push, pull_request]
+env:
+  LANG: en_US.UTF-8
+  CEKIT_VERSION: 3.6.0
+jobs:
+  openjdkci:
+    name: OpenJDK S2I Build and Test
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+    steps:
+      - uses: actions/checkout@v2
+      - name: Verify latest UBI image is present
+        run: |
+          docker pull registry.access.redhat.com/ubi8/ubi-minimal:latest
+          docker tag  registry.access.redhat.com/ubi8/ubi-minimal:latest registry.redhat.io/ubi8/ubi-minimal:latest
+          docker image ls | grep ubi8
+      - name: Setup required system packages
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y krb5-multidev virtualenv
+      - name: Setup virtualenv and install cekit and required packages
+        run: |
+          mkdir ~/cekit${{ env.CEKIT_VERSION }}
+          virtualenv ~/cekit${{ env.CEKIT_VERSION }}
+          . ~/cekit${{ env.CEKIT_VERSION }}/bin/activate
+          pip install cekit==${{ env.CEKIT_VERSION }} docker docker-squash odcs behave lxml
+      - name: Build
+        run: |
+          . ~/cekit${{ env.CEKIT_VERSION }}/bin/activate
+          cekit -v --descriptor ubi8-openjdk-8.yaml build --overrides '{"packages": {"content_sets_file": null }}' docker
+          docker image ls


### PR DESCRIPTION
This adds two GitHub workflows (one for JDK 8, one for JDK 11) that will trigger on every pull request or commit. The two workflows attempt to build the UBI8 images (via cekit 3.6.0 and the docker back-end) and will report if that fails.

Future improvements

 * parallel build the different JDK flavours
 * speed up the build process by pre-preparing a cekit builder?
 * auto publish the build containers somewhere in some cases