### PR TITLE
updated openj9 cct_module ref. value to 0.42.0

### DIFF
--- a/openj9-11-rhel7.yaml
+++ b/openj9-11-rhel7.yaml
@@ -43,7 +43,7 @@ modules:
   - name: cct_module
     git:
       url: https://github.com/jboss-openshift/cct_module.git
-      ref: 0.41.0
+      ref: 0.42.0
   install:
   - name: jboss.container.openjdk.jdk
     version: "openj9-11"

--- a/openj9-11-rhel8.yaml
+++ b/openj9-11-rhel8.yaml
@@ -44,7 +44,7 @@ modules:
   - name: cct_module
     git:
       url: https://github.com/jboss-openshift/cct_module.git
-      ref: 0.41.0
+      ref: 0.42.0
   install:
   - name: jboss.container.openjdk.jdk
     version: "openj9-11"

--- a/openj9-8-rhel7.yaml
+++ b/openj9-8-rhel7.yaml
@@ -43,7 +43,7 @@ modules:
   - name: cct_module
     git:
       url: https://github.com/jboss-openshift/cct_module.git
-      ref: 0.41.0
+      ref: 0.42.0
   install:
   - name: jboss.container.openjdk.jdk
     version: "openj9-8"

--- a/openj9-8-rhel8.yaml
+++ b/openj9-8-rhel8.yaml
@@ -44,7 +44,7 @@ modules:
   - name: cct_module
     git:
       url: https://github.com/jboss-openshift/cct_module.git
-      ref: 0.41.0
+      ref: 0.42.0
   install:
   - name: jboss.container.openjdk.jdk
     version: "openj9-8"


### PR DESCRIPTION
Updated openj9 cct_module ref. value to 0.42.0 in the rhel7 and rhel8 override files.

- [ ] Pull Request title is properly formatted: `[CLOUD-XYA] Subject`
- [ ] Pull Request contains link to the JIRA issue
- [X] Pull Request contains description of the issue
- [X] Pull Request does not include fixes for issues other than the main ticket
- [X] Attached commits represent units of work and are properly formatted
- [X] You have read and agreed to the Developer Certificate of Origin (DCO) (see `CONTRIBUTING.md`)
- [X] Signed-off-by: Rafiur Rashid rrashid@redhat.com
