### PR TITLE
Adjust behave test tagging: don't run x86_64 label check on OpenJ9 (and more)

### DIFF
--- a/tests/features/java/openjdk_s2i.feature
+++ b/tests/features/java/openjdk_s2i.feature
@@ -1,6 +1,6 @@
 # OpenJDK/hotspot only
-@openjdk @redhat-openjdk-18
-@centos/openjdk-8-centos7 @centos/openjdk-11-centos7
+@openjdk
+@redhat-openjdk-18
 Feature: Openshift OpenJDK-only S2I tests
   Scenario: Check java perf dir owned by jboss (CLOUD-2070)
     Given s2i build https://github.com/jboss-openshift/openshift-quickstarts from undertow-servlet

--- a/tests/features/openshift.feature
+++ b/tests/features/openshift.feature
@@ -1,13 +1,8 @@
 @openjdk
 @ubi8
-@redhat/openjdk-8-rhel7
-@openj9
+@redhat-openjdk-18
 Feature: Tests for all openshift images
 
-  @openjdk
-  @ubi8
-  @redhat-openjdk-18
-  @openj9
   Scenario: Check that product labels are correctly set
     # We don't set 'release' or 'architecture' on CI builds, but it's set on OSBS builds
     # Since we base on an image which has it already set, it's kind of meaningless
@@ -17,9 +12,6 @@ Feature: Tests for all openshift images
     Then the image should contain label release
     And the image should contain label architecture with value x86_64
 
-  @openjdk
-  @ubi8
-  @redhat-openjdk-18
   @openj9
   Scenario: Check that common labels are correctly set
     Given image is built


### PR DESCRIPTION
The main effort here was to stop running a check for the x86_64 label on the OpenJ9 images, since they will run the tests on s390x. But I also tidied up the tagging in that file and fixed another problem I spotted elsewhere.