### PR TITLE
Pin base images to RHEL minor version

### DIFF
--- a/.github/workflows/ubi8-openjdk-11.yml
+++ b/.github/workflows/ubi8-openjdk-11.yml
@@ -3,6 +3,7 @@ on: [push, pull_request]
 env:
   LANG: en_US.UTF-8
   CEKIT_VERSION: 3.6.0
+  BASE_IMG_VERSION: 8.2
 jobs:
   openjdkci:
     name: OpenJDK S2I Build and Test
@@ -13,8 +14,8 @@ jobs:
       - uses: actions/checkout@v2
       - name: Verify latest UBI image is present
         run: |
-          docker pull registry.access.redhat.com/ubi8/ubi-minimal:latest
-          docker tag  registry.access.redhat.com/ubi8/ubi-minimal:latest registry.redhat.io/ubi8/ubi-minimal:latest
+          docker pull registry.access.redhat.com/ubi8/ubi-minimal:${{ env.BASE_IMG_VERSION }}
+          docker tag  registry.access.redhat.com/ubi8/ubi-minimal:${{ env.BASE_IMG_VERSION }} registry.redhat.io/ubi8/ubi-minimal:${{ env.BASE_IMG_VERSION }}
           docker image ls | grep ubi8
       - name: Setup required system packages
         run: |

--- a/.github/workflows/ubi8-openjdk-8.yml
+++ b/.github/workflows/ubi8-openjdk-8.yml
@@ -3,6 +3,7 @@ on: [push, pull_request]
 env:
   LANG: en_US.UTF-8
   CEKIT_VERSION: 3.6.0
+  BASE_IMG_VERSION: 8.2
 jobs:
   openjdkci:
     name: OpenJDK S2I Build and Test
@@ -13,8 +14,8 @@ jobs:
       - uses: actions/checkout@v2
       - name: Verify latest UBI image is present
         run: |
-          docker pull registry.access.redhat.com/ubi8/ubi-minimal:latest
-          docker tag  registry.access.redhat.com/ubi8/ubi-minimal:latest registry.redhat.io/ubi8/ubi-minimal:latest
+          docker pull registry.access.redhat.com/ubi8/ubi-minimal:${{ env.BASE_IMG_VERSION }}
+          docker tag  registry.access.redhat.com/ubi8/ubi-minimal:${{ env.BASE_IMG_VERSION }} registry.redhat.io/ubi8/ubi-minimal:${{ env.BASE_IMG_VERSION }}
           docker image ls | grep ubi8
       - name: Setup required system packages
         run: |

--- a/image.yaml
+++ b/image.yaml
@@ -2,7 +2,7 @@
 
 schema_version: 1
 
-from: "registry.redhat.io/rhel7/rhel"
+from: "registry.redhat.io/rhel7/rhel:7.8"
 name: &name "redhat-openjdk-18/openjdk18-openshift"
 version: &version "1.8"
 description: "Source To Image (S2I) image for Red Hat OpenShift providing OpenJDK 8"

--- a/openjdk-11-rhel7.yaml
+++ b/openjdk-11-rhel7.yaml
@@ -2,7 +2,7 @@
 
 schema_version: 1
 
-from: "registry.redhat.io/rhel7/rhel"
+from: "registry.redhat.io/rhel7/rhel:7.8"
 name: &name "openjdk/openjdk-11-rhel7"
 version: &version "1.1"
 description: "Source To Image (S2I) image for Red Hat OpenShift providing OpenJDK 11"

--- a/ubi8-openjdk-11.yaml
+++ b/ubi8-openjdk-11.yaml
@@ -2,7 +2,7 @@
 
 schema_version: 1
 
-from: "registry.redhat.io/ubi8/ubi-minimal"
+from: "registry.redhat.io/ubi8/ubi-minimal:8.2"
 name: &name "ubi8/openjdk-11"
 version: &version "1.3"
 description: "Source To Image (S2I) image for Red Hat OpenShift providing OpenJDK 11"

--- a/ubi8-openjdk-8.yaml
+++ b/ubi8-openjdk-8.yaml
@@ -2,7 +2,7 @@
 
 schema_version: 1
 
-from: "registry.redhat.io/ubi8/ubi-minimal"
+from: "registry.redhat.io/ubi8/ubi-minimal:8.2"
 name: &name "ubi8/openjdk-8"
 version: &version "1.3"
 description: "Source To Image (S2I) image for Red Hat OpenShift providing OpenJDK 1.8"


### PR DESCRIPTION
After thinking about it for a while, I think we should explicitly stick
to a given RHEL minor release as our FROM image, and manage an upgrade
to the new minor release when available, bumping our own minor version
at the same time. Rationale: a given RPM might have a function or ABI
change in a RHEL minor release (I believe), which could cause behaviour
changes in our images, so we should gate those changes with a minor
version bump ourselves.

This is necessary for the RHEL7 bases too, as current minor is 7.8 and
there's a 7.9 in the pipeline.

Depending on scheduling we may want  to cherry-pick this to the release
branch too, but it might not be necessary.