### PR TITLE
Updated content sets to include openj9 rpms - s390x & ppc64le

### DIFF
--- a/openj9-11-rhel7.yaml
+++ b/openj9-11-rhel7.yaml
@@ -40,9 +40,11 @@ packages:
     s390x:
     - rhel-7-for-system-z-rpms
     - rhel-7-server-for-system-z-rhscl-rpms
+    - openj9-1-for-rhel-7-server-for-system-z-rpms
     ppc64le:
     - rhel-7-server-for-power-le-rhscl-rpms
     - rhel-7-for-power-le-rpms
+    - openj9-1-for-rhel-7-server-for-power-le-rpms
 
 modules:
   repositories:

--- a/openj9-11-rhel7.yaml
+++ b/openj9-11-rhel7.yaml
@@ -75,11 +75,6 @@ osbs:
           - s390x
           - ppc64le
       compose:
-        # used for requesting ODCS compose of type "tag"
-        packages:
-          - java-11-openj9
-          - java-11-openj9-headless
-          - java-11-openj9-devel
         signing_intent: release
         # used for inheritance of yum repos and ODCS composes from baseimage build
         inherit: true

--- a/openj9-11-rhel7.yaml
+++ b/openj9-11-rhel7.yaml
@@ -75,6 +75,11 @@ osbs:
           - s390x
           - ppc64le
       compose:
+        # used for requesting ODCS compose of type "tag"
+        packages:
+          - java-11-openj9
+          - java-11-openj9-headless
+          - java-11-openj9-devel
         signing_intent: release
         # used for inheritance of yum repos and ODCS composes from baseimage build
         inherit: true

--- a/openj9-11-rhel7.yaml
+++ b/openj9-11-rhel7.yaml
@@ -40,10 +40,12 @@ packages:
     s390x:
     - rhel-7-for-system-z-rpms
     - rhel-7-server-for-system-z-rhscl-rpms
+    - rhel-7-for-system-z-optional-rpms
     - openj9-1-for-rhel-7-server-for-system-z-rpms
     ppc64le:
     - rhel-7-server-for-power-le-rhscl-rpms
     - rhel-7-for-power-le-rpms
+    - rhel-7-for-power-le-optional-rpms
     - openj9-1-for-rhel-7-server-for-power-le-rpms
 
 modules:

--- a/openj9-11-rhel8.yaml
+++ b/openj9-11-rhel8.yaml
@@ -83,6 +83,11 @@ osbs:
           - s390x
           - ppc64le
       compose:
+        # used for requesting ODCS compose of type "tag"
+        packages:
+          - java-11-openj9
+          - java-11-openj9-headless
+          - java-11-openj9-devel
         signing_intent: release
         # used for inheritance of yum repos and ODCS composes from baseimage build
         inherit: true

--- a/openj9-11-rhel8.yaml
+++ b/openj9-11-rhel8.yaml
@@ -83,14 +83,10 @@ osbs:
           - s390x
           - ppc64le
       compose:
-        # used for requesting ODCS compose of type "tag"
-        packages:
-          - java-11-openj9
-          - java-11-openj9-headless
-          - java-11-openj9-devel
         signing_intent: release
         # used for inheritance of yum repos and ODCS composes from baseimage build
         inherit: true
+        pulp_repos: true
   repository:
     name: containers/openj9
     branch: openj9-11-rhel8

--- a/openj9-11-rhel8.yaml
+++ b/openj9-11-rhel8.yaml
@@ -44,12 +44,14 @@ packages:
     ppc64le:
     - rhel-8-for-ppc64le-baseos-rpms
     - rhel-8-for-ppc64le-appstream-rpms
+    - openj9-1-for-rhel-8-ppc64le-rpms
     aarch64:
     - rhel-8-for-aarch64-baseos-rpms
     - rhel-8-for-aarch64-appstream-rpms
     s390x:
     - rhel-8-for-s390x-baseos-rpms
     - rhel-8-for-s390x-appstream-rpms
+    - openj9-1-for-rhel-8-s390x-rpms
 
 modules:
   repositories:

--- a/openj9-8-rhel7.yaml
+++ b/openj9-8-rhel7.yaml
@@ -41,10 +41,12 @@ packages:
     - rhel-7-for-system-z-rpms
     - rhel-7-for-system-z-optional-rpms
     - rhel-7-server-for-system-z-rhscl-rpms
+    - openj9-1-for-rhel-7-server-for-system-z-rpms
     ppc64le:
     - rhel-7-server-for-power-le-rhscl-rpms
     - rhel-7-for-power-le-rpms
     - rhel-7-for-power-le-optional-rpms
+    - openj9-1-for-rhel-7-server-for-power-le-rpms
 
 modules:
   repositories:

--- a/openj9-8-rhel7.yaml
+++ b/openj9-8-rhel7.yaml
@@ -77,11 +77,6 @@ osbs:
           - s390x
           - ppc64le
       compose:
-        # used for requesting ODCS compose of type "tag"
-        packages:
-          - java-1.8.0-openj9
-          - java-1.8.0-openj9-headless
-          - java-1.8.0-openj9-devel
         signing_intent: release
         # used for inheritance of yum repos and ODCS composes from baseimage build
         inherit: true

--- a/openj9-8-rhel7.yaml
+++ b/openj9-8-rhel7.yaml
@@ -77,6 +77,11 @@ osbs:
           - s390x
           - ppc64le
       compose:
+        # used for requesting ODCS compose of type "tag"
+        packages:
+          - java-1.8.0-openj9
+          - java-1.8.0-openj9-headless
+          - java-1.8.0-openj9-devel
         signing_intent: release
         # used for inheritance of yum repos and ODCS composes from baseimage build
         inherit: true

--- a/openj9-8-rhel8.yaml
+++ b/openj9-8-rhel8.yaml
@@ -83,14 +83,10 @@ osbs:
           - s390x
           - ppc64le
       compose:
-        # used for requesting ODCS compose of type "tag"
-        packages:
-          - java-1.8.0-openj9
-          - java-1.8.0-openj9-headless
-          - java-1.8.0-openj9-devel
         signing_intent: release
         # used for inheritance of yum repos and ODCS composes from baseimage build
         inherit: true
+        pulp_repos: true
   repository:
     name: containers/openj9
     branch: openj9-8-rhel8

--- a/openj9-8-rhel8.yaml
+++ b/openj9-8-rhel8.yaml
@@ -83,6 +83,11 @@ osbs:
           - s390x
           - ppc64le
       compose:
+        # used for requesting ODCS compose of type "tag"
+        packages:
+          - java-1.8.0-openj9
+          - java-1.8.0-openj9-headless
+          - java-1.8.0-openj9-devel
         signing_intent: release
         # used for inheritance of yum repos and ODCS composes from baseimage build
         inherit: true

--- a/openj9-8-rhel8.yaml
+++ b/openj9-8-rhel8.yaml
@@ -44,12 +44,14 @@ packages:
     ppc64le:
     - rhel-8-for-ppc64le-baseos-rpms
     - rhel-8-for-ppc64le-appstream-rpms
+    - openj9-1-for-rhel-8-ppc64le-rpms
     aarch64:
     - rhel-8-for-aarch64-baseos-rpms
     - rhel-8-for-aarch64-appstream-rpms
     s390x:
     - rhel-8-for-s390x-baseos-rpms
     - rhel-8-for-s390x-appstream-rpms
+    - openj9-1-for-rhel-8-s390x-rpms
 
 modules:
   repositories:


### PR DESCRIPTION
Currently, in CVP the openj9 (jdk11 & 8 + rhel8 & rhel7) content_sets test fails for both s390x & ppc64le. There is a new content set entity that contains the openj9 rpms. Updating the content sets passes the test in CVP

https://errata.devel.redhat.com/tps/errata_results/48250

- [ ] Pull Request title is properly formatted: `[CLOUD-XYA] Subject`
- [ ] Pull Request contains link to the JIRA issue
- [X] Pull Request contains description of the issue
- [X] Pull Request does not include fixes for issues other than the main ticket
- [X] Attached commits represent units of work and are properly formatted
- [X] You have read and agreed to the Developer Certificate of Origin (DCO) (see `CONTRIBUTING.md`)
- [X] Every commit contains `Signed-off-by: Rafiur Rashid rrashid@redhat.com