### PR TITLE
Update cct_module to pick up Prometheus CVE fix

### DIFF
--- a/image.yaml
+++ b/image.yaml
@@ -41,7 +41,7 @@ modules:
   - name: cct_module
     git:
       url: https://github.com/jboss-openshift/cct_module.git
-      ref: 0.41.0
+      ref: 0.41.1
 
   install:
   - name: jboss.container.openjdk.jdk

--- a/openjdk-11-rhel7.yaml
+++ b/openjdk-11-rhel7.yaml
@@ -38,7 +38,7 @@ modules:
   - name: cct_module
     git:
       url: https://github.com/jboss-openshift/cct_module.git
-      ref: 0.41.0
+      ref: 0.41.1
   install:
   - name: jboss.container.openjdk.jdk
     version: "11"


### PR DESCRIPTION
The cct_module tag 0.41.1 is here: https://github.com/jboss-openshift/cct_module/commit/9ea7e5c8ced8bea53dfd88067862b788aace0dc6