### PR TITLE
Remove private repo URI from redhat overrides and GitHub workflows

### DIFF
--- a/.github/workflows/ubi8-openjdk-11.yml
+++ b/.github/workflows/ubi8-openjdk-11.yml
@@ -15,7 +15,6 @@ jobs:
       - name: Verify latest UBI image is present
         run: |
           docker pull registry.access.redhat.com/ubi8/ubi-minimal:latest
-          docker tag  registry.access.redhat.com/ubi8/ubi-minimal:latest registry.redhat.io/ubi8/ubi-minimal:latest
           docker image ls | grep ubi8
       - name: Setup required system packages
         run: |

--- a/.github/workflows/ubi8-openjdk-8.yml
+++ b/.github/workflows/ubi8-openjdk-8.yml
@@ -15,7 +15,6 @@ jobs:
       - name: Verify latest UBI image is present
         run: |
           docker pull registry.access.redhat.com/ubi8/ubi-minimal:latest
-          docker tag  registry.access.redhat.com/ubi8/ubi-minimal:latest registry.redhat.io/ubi8/ubi-minimal:latest
           docker image ls | grep ubi8
       - name: Setup required system packages
         run: |

--- a/redhat/ubi8-openjdk-11.yaml
+++ b/redhat/ubi8-openjdk-11.yaml
@@ -1,5 +1,3 @@
-from: "registry.redhat.io/ubi8/ubi-minimal"
-
 osbs:
   configuration:
     container:

--- a/redhat/ubi8-openjdk-8.yaml
+++ b/redhat/ubi8-openjdk-8.yaml
@@ -1,5 +1,3 @@
-from: "registry.redhat.io/ubi8/ubi-minimal"
-
 osbs:
   configuration:
     container:


### PR DESCRIPTION
Our internal build infrastructure now supports
registry.access.redhat.com in the FROM line. We no longer need to
override that for internal builds.

We don't need to pull-and-tag the public URI in the GitHub workflows (in
fact we haven't needed to since the FROM line was changed to the public
URI in the main image descriptors)