### PR TITLE
Updating cct_module tag to include snakeYAML CVE fix

### DIFF
--- a/openj9-11-rhel7.yaml
+++ b/openj9-11-rhel7.yaml
@@ -53,7 +53,7 @@ modules:
   - name: cct_module
     git:
       url: https://github.com/jboss-openshift/cct_module.git
-      ref: 0.42.0
+      ref: 0.42.1
   install:
   - name: jboss.container.openjdk.jdk
     version: "openj9-11"

--- a/openj9-11-rhel8.yaml
+++ b/openj9-11-rhel8.yaml
@@ -58,7 +58,7 @@ modules:
   - name: cct_module
     git:
       url: https://github.com/jboss-openshift/cct_module.git
-      ref: 0.42.0
+      ref: 0.42.1
   install:
   - name: jboss.container.openjdk.jdk
     version: "openj9-11"

--- a/openj9-8-rhel7.yaml
+++ b/openj9-8-rhel7.yaml
@@ -53,7 +53,7 @@ modules:
   - name: cct_module
     git:
       url: https://github.com/jboss-openshift/cct_module.git
-      ref: 0.42.0
+      ref: 0.42.1
   install:
   - name: jboss.container.openjdk.jdk
     version: "openj9-8"

--- a/openj9-8-rhel8.yaml
+++ b/openj9-8-rhel8.yaml
@@ -58,7 +58,7 @@ modules:
   - name: cct_module
     git:
       url: https://github.com/jboss-openshift/cct_module.git
-      ref: 0.42.0
+      ref: 0.42.1
   install:
   - name: jboss.container.openjdk.jdk
     version: "openj9-8"


### PR DESCRIPTION
There was a bump of Prometheus agent version to pick up SnakeYAML fix. The change has been tagged in 0.42.1 and hence the ref update will pick up the fix.

- [ ] Pull Request title is properly formatted: `[CLOUD-XYA] Subject`
- [ ] Pull Request contains link to the JIRA issue
- [X] Pull Request contains description of the issue
- [X] Pull Request does not include fixes for issues other than the main ticket
- [X] Attached commits represent units of work and are properly formatted
- [X] You have read and agreed to the Developer Certificate of Origin (DCO) (see `CONTRIBUTING.md`)
- [X] Every commit contains `Signed-off-by: Rafiur Rashid rrashid@redhat.com
