### PR TITLE
Fix for 'maven' and 'find' command issue in smoke test suite

### DIFF
--- a/openj9-11-rhel8.yaml
+++ b/openj9-11-rhel8.yaml
@@ -30,6 +30,8 @@ envs:
   value: *name
 - name: "JBOSS_IMAGE_VERSION"
   value: *version
+- name: "MAVEN_SKIP_RC"
+  value: true
 
 ports:
 - value: 8080
@@ -37,6 +39,8 @@ ports:
 
 packages:
   manager: microdnf
+  install:
+    - findutils
   content_sets:
     x86_64:
     - rhel-8-for-x86_64-baseos-rpms
@@ -58,7 +62,7 @@ modules:
   - name: cct_module
     git:
       url: https://github.com/jboss-openshift/cct_module.git
-      ref: 0.42.0
+      ref: 0.41.1
   install:
   - name: jboss.container.openjdk.jdk
     version: "openj9-11"

--- a/openj9-8-rhel8.yaml
+++ b/openj9-8-rhel8.yaml
@@ -30,6 +30,8 @@ envs:
   value: *name
 - name: "JBOSS_IMAGE_VERSION"
   value: *version
+- name: "MAVEN_SKIP_RC"
+  value: true
 
 ports:
 - value: 8080
@@ -37,6 +39,8 @@ ports:
 
 packages:
   manager: microdnf
+  install:
+    - findutils
   content_sets:
     x86_64:
     - rhel-8-for-x86_64-baseos-rpms
@@ -58,7 +62,7 @@ modules:
   - name: cct_module
     git:
       url: https://github.com/jboss-openshift/cct_module.git
-      ref: 0.42.0
+      ref: 0.41.1
   install:
   - name: jboss.container.openjdk.jdk
     version: "openj9-8"


### PR DESCRIPTION
The smoke test failed for recent builds of openj9 s2i rhel8 container images. 2 Issues were found related to a change in the `maven` startup script and unable to use the `find` command as the package was not available in the base image used `ubi8-minimal`.  The proposed fixes resolve the issue and passed all the smoke tests.

- [ ] Pull Request title is properly formatted: `[CLOUD-XYA] Subject`
- [ ] Pull Request contains link to the JIRA issue
- [X] Pull Request contains description of the issue
- [X] Pull Request does not include fixes for issues other than the main ticket
- [X] Attached commits represent units of work and are properly formatted
- [X] You have read and agreed to the Developer Certificate of Origin (DCO) (see `CONTRIBUTING.md`)
- [X] Every commit contains `Signed-off-by: Rafiur Rashid rrashid@redhat.com
