### PR TITLE
[OPENJDK-256] Move ubi8-* images to cct_module tag 0.41.2

### DIFF
--- a/ubi8-openjdk-11.yaml
+++ b/ubi8-openjdk-11.yaml
@@ -40,7 +40,7 @@ modules:
   - name: cct_module
     git:
       url: https://github.com/jboss-openshift/cct_module.git
-      ref: 0.41.0
+      ref: 0.41.2
   install:
   - name: jboss.container.microdnf-bz-workaround
   - name: jboss.container.openjdk.jdk

--- a/ubi8-openjdk-8.yaml
+++ b/ubi8-openjdk-8.yaml
@@ -40,7 +40,7 @@ modules:
   - name: cct_module
     git:
       url: https://github.com/jboss-openshift/cct_module.git
-      ref: 0.41.0
+      ref: 0.41.2
   install:
   - name: jboss.container.microdnf-bz-workaround
   - name: jboss.container.openjdk.jdk


### PR DESCRIPTION
<https://issues.redhat.com/browse/OPENJDK-256>

Significant change: two modules now require package "findutils"
Insignificant: Prometheus module version 7 change (not in use)

- [x] Pull Request title is properly formatted: `[CLOUD-XYA] Subject`
- [x] Pull Request contains link to the JIRA issue
- [x] Pull Request contains description of the issue
- [x] Pull Request does not include fixes for issues other than the main ticket
- [x] Attached commits represent units of work and are properly formatted
- [x] You have read and agreed to the Developer Certificate of Origin (DCO) (see `CONTRIBUTING.md`)
- [x] Every commit contains `Signed-off-by: Your Name <yourname@example.com>` - use `git commit -s`
