### PR TITLE
Bump cct_module tag to 0.43.0

### DIFF
--- a/openjdk-11-rhel7.yaml
+++ b/openjdk-11-rhel7.yaml
@@ -38,7 +38,7 @@ modules:
   - name: cct_module
     git:
       url: https://github.com/jboss-openshift/cct_module.git
-      ref: 0.41.0
+      ref: 0.43.0
   install:
   - name: jboss.container.openjdk.jdk
     version: "11"

--- a/openjdk18-openshift.yaml
+++ b/openjdk18-openshift.yaml
@@ -38,7 +38,7 @@ modules:
   - name: cct_module
     git:
       url: https://github.com/jboss-openshift/cct_module.git
-      ref: 0.41.0
+      ref: 0.43.0
 
   install:
   - name: jboss.container.openjdk.jdk

--- a/ubi8-openjdk-11.yaml
+++ b/ubi8-openjdk-11.yaml
@@ -40,7 +40,7 @@ modules:
   - name: cct_module
     git:
       url: https://github.com/jboss-openshift/cct_module.git
-      ref: 0.41.0
+      ref: 0.43.0
   install:
   - name: jboss.container.openjdk.jdk
     version: "11"

--- a/ubi8-openjdk-8.yaml
+++ b/ubi8-openjdk-8.yaml
@@ -40,7 +40,7 @@ modules:
   - name: cct_module
     git:
       url: https://github.com/jboss-openshift/cct_module.git
-      ref: 0.41.0
+      ref: 0.43.0
   install:
   - name: jboss.container.openjdk.jdk
     version: "8"


### PR DESCRIPTION
This fixes building RHEL7-based images, which are broken at the moment
because half of the "remove jolokia" change was committed to the image
descriptor, but the other half was committed to cct_module between
0.42.0 and 0.43.0. It also catches up the RHEL8 images to the latest
developments queued up for the next release.