### PR TITLE
Add OpenJDK packages explicitly to ODCS Composes

### DIFF
--- a/redhat/openjdk-11-rhel7.yaml
+++ b/redhat/openjdk-11-rhel7.yaml
@@ -3,6 +3,10 @@ osbs:
     container:
       compose:
         pulp_repos: true
+        packages:
+        - java-11-openjdk
+        - java-11-openjdk-devel
+        - java-11-openjdk-headless
   repository:
     name: containers/openjdk
     branch: openjdk-11-rhel7

--- a/redhat/openjdk18-openshift.yaml
+++ b/redhat/openjdk18-openshift.yaml
@@ -15,6 +15,10 @@ osbs:
     container:
       compose:
         pulp_repos: true
+        packages:
+        - java-1.8.0-openjdk
+        - java-1.8.0-openjdk-devel
+        - java-1.8.0-openjdk-headless
   repository:
     name: containers/redhat-openjdk-18
     branch: jb-openjdk-1.8-openshift-rhel-7

--- a/redhat/ubi8-openjdk-11.yaml
+++ b/redhat/ubi8-openjdk-11.yaml
@@ -4,6 +4,10 @@ osbs:
       compose:
         pulp_repos: true
         inherit: true
+        packages:
+        - java-11-openjdk
+        - java-11-openjdk-devel
+        - java-11-openjdk-headless
   repository:
     name: containers/openjdk
     branch: openjdk-11-ubi8

--- a/redhat/ubi8-openjdk-8.yaml
+++ b/redhat/ubi8-openjdk-8.yaml
@@ -4,6 +4,10 @@ osbs:
       compose:
         pulp_repos: true
         inherit: true
+        packages:
+        - java-1.8.0-openjdk
+        - java-1.8.0-openjdk-devel
+        - java-1.8.0-openjdk-headless
   repository:
     name: containers/openjdk
     branch: openjdk-8-ubi8


### PR DESCRIPTION
This allows us to build containers with OpenJDK packages that have not
yet shipped in RHEL but are about to; we can then ship the container and
the OpenJDK RPM update at the same time.

Thanks Severin for the suggestion.