### PR TITLE
Don't install jboss.container.dnf module

### DIFF
--- a/ubi8-openjdk-11.yaml
+++ b/ubi8-openjdk-11.yaml
@@ -45,7 +45,6 @@ modules:
   - name: jboss.container.openjdk.jdk
     version: "11"
   - name: jboss.container.prometheus
-  - name: jboss.container.dnf
   - name: jboss.container.maven
     version: "8.2.3.6"
   - name: jboss.container.java.s2i.bash

--- a/ubi8-openjdk-8.yaml
+++ b/ubi8-openjdk-8.yaml
@@ -45,7 +45,6 @@ modules:
   - name: jboss.container.openjdk.jdk
     version: "8"
   - name: jboss.container.prometheus
-  - name: jboss.container.dnf
   - name: jboss.container.maven
     version: "8.2.3.6.8"
   - name: jboss.container.java.s2i.bash


### PR DESCRIPTION
Since <https://github.com/jboss-openshift/cct_module/pull/390> we
do not require DNF for the UBI images.