### PR TITLE
Bump cct_module to 0.44.0

### DIFF
--- a/openjdk-11-rhel7.yaml
+++ b/openjdk-11-rhel7.yaml
@@ -38,7 +38,7 @@ modules:
   - name: cct_module
     git:
       url: https://github.com/jboss-openshift/cct_module.git
-      ref: 0.43.0
+      ref: 0.44.0
   install:
   - name: jboss.container.openjdk.jdk
     version: "11"

--- a/openjdk18-openshift.yaml
+++ b/openjdk18-openshift.yaml
@@ -38,7 +38,7 @@ modules:
   - name: cct_module
     git:
       url: https://github.com/jboss-openshift/cct_module.git
-      ref: 0.43.0
+      ref: 0.44.0
 
   install:
   - name: jboss.container.openjdk.jdk

--- a/ubi8-openjdk-11.yaml
+++ b/ubi8-openjdk-11.yaml
@@ -40,7 +40,7 @@ modules:
   - name: cct_module
     git:
       url: https://github.com/jboss-openshift/cct_module.git
-      ref: 0.43.0
+      ref: 0.44.0
   install:
   - name: jboss.container.openjdk.jdk
     version: "11"

--- a/ubi8-openjdk-8.yaml
+++ b/ubi8-openjdk-8.yaml
@@ -40,7 +40,7 @@ modules:
   - name: cct_module
     git:
       url: https://github.com/jboss-openshift/cct_module.git
-      ref: 0.43.0
+      ref: 0.44.0
   install:
   - name: jboss.container.openjdk.jdk
     version: "8"


### PR DESCRIPTION
This pulls in
"blank maven.conf instead of removing it"
<https://github.com/jboss-openshift/cct_module/pull/391>
which should fix the Behave tests in GitHub Actions CI, and

"Enable maven AppStream module via conf file"
https://github.com/jboss-openshift/cct_module/pull/390