### PR TITLE
[redhat] Use signing-intent release

### DIFF
--- a/redhat/openjdk-11-rhel7.yaml
+++ b/redhat/openjdk-11-rhel7.yaml
@@ -7,6 +7,7 @@ osbs:
         - java-11-openjdk
         - java-11-openjdk-devel
         - java-11-openjdk-headless
+        signing_intent: release
   repository:
     name: containers/openjdk
     branch: openjdk-11-rhel7

--- a/redhat/openjdk18-openshift.yaml
+++ b/redhat/openjdk18-openshift.yaml
@@ -19,6 +19,7 @@ osbs:
         - java-1.8.0-openjdk
         - java-1.8.0-openjdk-devel
         - java-1.8.0-openjdk-headless
+        signing_intent: release
   repository:
     name: containers/redhat-openjdk-18
     branch: jb-openjdk-1.8-openshift-rhel-7

--- a/redhat/ubi8-openjdk-11.yaml
+++ b/redhat/ubi8-openjdk-11.yaml
@@ -8,6 +8,7 @@ osbs:
         - java-11-openjdk
         - java-11-openjdk-devel
         - java-11-openjdk-headless
+        signing_intent: release
   repository:
     name: containers/openjdk
     branch: openjdk-11-ubi8

--- a/redhat/ubi8-openjdk-8.yaml
+++ b/redhat/ubi8-openjdk-8.yaml
@@ -8,6 +8,7 @@ osbs:
         - java-1.8.0-openjdk
         - java-1.8.0-openjdk-devel
         - java-1.8.0-openjdk-headless
+        signing_intent: release
   repository:
     name: containers/openjdk
     branch: openjdk-8-ubi8


### PR DESCRIPTION
We should use signing intent release for the ODCS packages. This has the advantage
that the build fails with unsigned packages.