### PR TITLE
redhat metadata fixup: don't inherit content sets, ubi8/jdk8 microdnf

### DIFF
--- a/redhat/openjdk18-openshift.yaml
+++ b/redhat/openjdk18-openshift.yaml
@@ -1,15 +1,3 @@
-packages:
-  content_sets:
-    ppc64le:
-    - rhel-7-server-for-power-le-rhscl-rpms
-    - rhel-7-for-power-le-rpms
-    x86_64:
-    - rhel-server-rhscl-7-rpms
-    - rhel-7-server-rpms
-    s390x:
-    - rhel-7-for-system-z-rpms
-    - rhel-7-server-for-system-z-rhscl-rpms
-
 osbs:
   configuration:
     container:
@@ -23,3 +11,15 @@ osbs:
   repository:
     name: containers/redhat-openjdk-18
     branch: jb-openjdk-1.8-openshift-rhel-7
+
+packages:
+  content_sets:
+    ppc64le:
+    - rhel-7-server-for-power-le-rhscl-rpms
+    - rhel-7-for-power-le-rpms
+    x86_64:
+    - rhel-server-rhscl-7-rpms
+    - rhel-7-server-rpms
+    s390x:
+    - rhel-7-for-system-z-rpms
+    - rhel-7-server-for-system-z-rhscl-rpms

--- a/redhat/ubi8-openjdk-11.yaml
+++ b/redhat/ubi8-openjdk-11.yaml
@@ -3,7 +3,6 @@ osbs:
     container:
       compose:
         pulp_repos: true
-        inherit: true
         packages:
         - java-11-openjdk
         - java-11-openjdk-devel

--- a/redhat/ubi8-openjdk-8.yaml
+++ b/redhat/ubi8-openjdk-8.yaml
@@ -13,6 +13,7 @@ osbs:
     branch: openjdk-8-ubi8
 
 packages:
+  manager: microdnf
   content_sets:
     x86_64:
     - rhel-8-for-x86_64-baseos-rpms

--- a/redhat/ubi8-openjdk-8.yaml
+++ b/redhat/ubi8-openjdk-8.yaml
@@ -3,7 +3,6 @@ osbs:
     container:
       compose:
         pulp_repos: true
-        inherit: true
         packages:
         - java-1.8.0-openjdk
         - java-1.8.0-openjdk-devel


### PR DESCRIPTION
 * re-order packages/osbs stanza in RHEL7/JDK8 file to match the others
 *  remove inherit: true from ubi8 images to prevent leaking pre-GA content
 * re-add manager: microdnf to ubi8/jdk8 that was accidentaly dropped in an earlier refactoring