### PR TITLE
[OPENJDK-112] Import behave tests from cct_modules

### DIFF
--- a/tests/features/java.security.feature
+++ b/tests/features/java.security.feature
@@ -1,0 +1,7 @@
+@openjdk
+@ubi8
+@redhat-openjdk-18
+Feature: Openshift S2I tests
+  Scenario: Check networkaddress.cache.negative.ttl has been set correctly
+    Given s2i build https://github.com/jboss-openshift/openshift-examples/ from binary-cli-security-property
+    Then s2i build log should contain networkaddress.cache.negative.ttl=0

--- a/tests/features/jolokia.feature
+++ b/tests/features/jolokia.feature
@@ -1,0 +1,21 @@
+# Tests for jboss/container/jolokia
+Feature: Openshift OpenJDK Jolokia tests
+
+  @openj9
+  Scenario: Check Environment variable is correct
+    Given s2i build https://github.com/jboss-openshift/openshift-quickstarts from undertow-servlet
+    Then run sh -c 'unzip -q -p /usr/share/java/jolokia-jvm-agent/jolokia-jvm.jar META-INF/maven/org.jolokia/jolokia-jvm/pom.properties | grep -F ${JOLOKIA_VERSION}' in container and check its output for version=
+
+  @jboss-decisionserver-6
+  @jboss-processserver-6
+  @jboss-webserver-3/webserver30-tomcat7-openshift
+  @jboss-webserver-3/webserver31-tomcat7-openshift
+  @jboss-webserver-3/webserver30-tomcat8-openshift
+  @jboss-webserver-3/webserver31-tomcat8-openshift
+  @jboss-amq-6
+  Scenario: Check jolokia port is available
+    When container is ready
+    Then check that port 8778 is open
+    Then inspect container
+       | path                    | value       |
+       | /Config/ExposedPorts    | 8778/tcp    |

--- a/tests/features/prometheus.feature
+++ b/tests/features/prometheus.feature
@@ -1,0 +1,29 @@
+@openjdk
+@redhat/openjdk-8-rhel7
+@openj9
+@ubi8/openjdk-8
+@ubi8/openjdk-11
+Feature: Prometheus agent tests
+
+  Scenario: Verify API and defaults
+    When container is started with args and env
+      | arg_env                  | value |
+      | env_AB_PROMETHEUS_ENABLE | false |
+      | arg_command              | bash -c 'source $JBOSS_CONTAINER_PROMETHEUS_MODULE/prometheus-opts; get_prometheus_opts' |
+    Then container log should not contain -javaagent:/usr/share/java/prometheus-jmx-exporter/jmx_prometheus_javaagent.jar=9799:/opt/jboss/container/prometheus/etc/jmx-exporter-config.yaml
+
+  Scenario: Check Prometheus configuration
+    When container is started with args and env
+      | arg_env                  | value |
+      | env_AB_PROMETHEUS_ENABLE | true  |
+      | arg_command              | bash -c 'source $JBOSS_CONTAINER_PROMETHEUS_MODULE/prometheus-opts; get_prometheus_opts' |
+    Then container log should contain -javaagent:/usr/share/java/prometheus-jmx-exporter/jmx_prometheus_javaagent.jar=9799:/opt/jboss/container/prometheus/etc/jmx-exporter-config.yaml
+
+  Scenario: Check Prometheus custom configuration
+    When container is started with args and env
+      | arg_env                               | value                                  |
+      | env_AB_PROMETHEUS_ENABLE              | true                                   |
+      | env_AB_PROMETHEUS_JMX_EXPORTER_PORT   | 8080                                   |
+      | env_AB_PROMETHEUS_JMX_EXPORTER_CONFIG | /path/to/some/jmx-exporter-config.yaml |
+      | arg_command                           | bash -c 'source $JBOSS_CONTAINER_PROMETHEUS_MODULE/prometheus-opts; get_prometheus_opts' |
+    Then container log should contain -javaagent:/usr/share/java/prometheus-jmx-exporter/jmx_prometheus_javaagent.jar=8080:/path/to/some/jmx-exporter-config.yaml

--- a/tests/features/s2i-core.feature
+++ b/tests/features/s2i-core.feature
@@ -1,0 +1,9 @@
+@openjdk
+@ubi8
+@redhat-openjdk-18
+@openj9
+Feature: Openshift S2I tests
+  # OPENJDK-84 - /tmp/src should not be present after build
+  Scenario: run an s2i build and check that /tmp/src has been removed afterwards
+    Given s2i build https://github.com/jboss-openshift/openshift-examples from spring-boot-sample-simple
+    Then run stat /tmp/src in container and immediately check its output does not contain File:


### PR DESCRIPTION
I forgot to copy the behave tests from the cct_module repository
as part of the previous commit. Before that, the ubi8/openjdk-11
image ran 134 steps. Currently it runs 124. This commit should
push the number back up to 134.

Once the CI finishes I can check the number of steps run in the
CI logs.