### PR TITLE
openj9 - Import module 'jolokia' from cct_module and update image descriptors

### DIFF
--- a/modules/jolokia/7/artifacts/opt/jboss/container/jolokia/jolokia-opts
+++ b/modules/jolokia/7/artifacts/opt/jboss/container/jolokia/jolokia-opts
@@ -1,0 +1,92 @@
+#!/bin/sh
+
+# Check whether a given config is contained in AB_JOLOKIA_OPTS
+is_in_jolokia_opts() {
+  local prop=$1
+  if [ -n "${AB_JOLOKIA_OPTS}" ] && [ x"${AB_JOLOKIA_OPTS}" != x"${AB_JOLOKIA_OPTS/${prop}/}" ]; then
+     echo "yes"
+  else
+     echo "no"
+  fi
+}
+
+get_jolokia_properties() {
+
+  echo "host=${AB_JOLOKIA_HOST:-*}"
+  echo "port=${AB_JOLOKIA_PORT:-8778}"
+  echo "discoveryEnabled=${AB_JOLOKIA_DISCOVERY_ENABLED:=false}"
+
+  if [ -n "$AB_JOLOKIA_PASSWORD" ]; then
+     echo "user=${AB_JOLOKIA_USER:-jolokia}"
+     echo "password=${AB_JOLOKIA_PASSWORD}"
+  fi
+  if [ -n "$AB_JOLOKIA_HTTPS" ]; then
+     echo "protocol=https"
+     use_https=1
+  fi
+
+  # Integration with OpenShift client cert auth is enabled
+  # by default if not explicitly turned off by setting to 'false'
+  if [ "x${AB_JOLOKIA_AUTH_OPENSHIFT}" != "xfalse" ] && [ -f "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt" ]; then
+     echo "useSslClientAuthentication=true"
+     echo "extraClientCheck=true"
+
+     if [ -z ${use_https+x} ]; then
+       echo "protocol=https"
+     fi
+     if [ $(is_in_jolokia_opts "caCert") != "yes" ]; then
+        echo "caCert=/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
+     fi
+
+     if [ $(is_in_jolokia_opts "clientPrincipal") != "yes" ]; then
+        if [ x"${AB_JOLOKIA_AUTH_OPENSHIFT}" != x"${AB_JOLOKIA_AUTH_OPENSHIFT/=/}" ]; then
+           # Supposed to contain a principal name to check
+           echo "clientPrincipal=`echo ${AB_JOLOKIA_AUTH_OPENSHIFT} | sed -e 's/ /\\\\ /g'`"
+        else
+           echo "clientPrincipal=cn=system:master-proxy"
+        fi
+     fi
+  fi
+
+  # Add extra opts
+  if [ -n "${AB_JOLOKIA_OPTS}" ]; then
+     echo "${AB_JOLOKIA_OPTS}" | tr "," "\n"
+  fi
+
+}
+
+write_jolokia_properties() {
+  local jolokia_property_file="$1"
+
+  # Setup Jolokia to accept basic auth, using a randomly generated password that is stored
+  # in the container in the ${DEPLOYMENTS_DIR}/jolokia.pw file.
+  if [ "$AB_JOLOKIA_PASSWORD_RANDOM" == "true" ]; then
+    pw_file="${JBOSS_CONTAINER_JOLOKIA_MODULE}/etc/jolokia.pw"
+    if [ -f "${pw_file}" ] ; then
+      AB_JOLOKIA_PASSWORD=`cat "${pw_file}"`
+    else
+      AB_JOLOKIA_PASSWORD=`tr -cd '[:alnum:]' < /dev/urandom | fold -w30 | head -n1`
+      touch "${pw_file}"
+      chmod 660 "${pw_file}"
+      cat > "${pw_file}" <<EOF
+$AB_JOLOKIA_PASSWORD
+EOF
+    fi
+    export AB_JOLOKIA_PASSWORD
+  fi
+
+  touch "${jolokia_property_file}"
+  chmod 660 "${jolokia_property_file}"
+  cat > "${jolokia_property_file}" <<EOF
+$(get_jolokia_properties)
+EOF
+
+}
+
+if [ -z "${AB_JOLOKIA_OFF+x}" ]; then
+  if [ -z "${AB_JOLOKIA_CONFIG}" ]; then
+    AB_JOLOKIA_CONFIG="${JBOSS_CONTAINER_JOLOKIA_MODULE}/etc/jolokia.properties"
+    write_jolokia_properties "$AB_JOLOKIA_CONFIG"
+  fi
+  echo "-javaagent:/usr/share/java/jolokia-jvm-agent/jolokia-jvm.jar=config=${AB_JOLOKIA_CONFIG}"
+fi

--- a/modules/jolokia/7/backward_compatibility.sh
+++ b/modules/jolokia/7/backward_compatibility.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+# Set up jolokia for java s2i builder image
+set -euo pipefail
+
+# Legacy locations
+
+ln -s /opt/jboss/container/jolokia /opt/jolokia
+chown -h jboss:root /opt/jolokia
+
+ln -s /usr/share/java/jolokia-jvm-agent/jolokia-jvm.jar \
+	$JBOSS_CONTAINER_JOLOKIA_MODULE/jolokia.jar

--- a/modules/jolokia/7/configure.sh
+++ b/modules/jolokia/7/configure.sh
@@ -1,0 +1,24 @@
+#!/bin/sh
+# Configure module
+set -e
+
+SCRIPT_DIR=$(dirname $0)
+ARTIFACTS_DIR=${SCRIPT_DIR}/artifacts
+
+mkdir -p /usr/share/java/jolokia-jvm-agent
+mv /tmp/artifacts/jolokia-jvm-*-agent.jar \
+	/usr/share/java/jolokia-jvm-agent/jolokia-jvm.jar
+chown -h jboss:root \
+	/usr/share/java/jolokia-jvm-agent/jolokia-jvm.jar
+
+chown -R jboss:root $SCRIPT_DIR
+chmod -R ug+rwX $SCRIPT_DIR
+chmod ug+x ${ARTIFACTS_DIR}/opt/jboss/container/jolokia/*
+
+pushd ${ARTIFACTS_DIR}
+cp -pr * /
+popd
+
+mkdir -p /opt/jboss/container/jolokia/etc
+chmod 775 /opt/jboss/container/jolokia/etc
+chown -R jboss:root /opt/jboss/container/jolokia/etc

--- a/modules/jolokia/7/module.yaml
+++ b/modules/jolokia/7/module.yaml
@@ -1,0 +1,66 @@
+schema_version: 1
+
+name: jboss.container.jolokia
+version: '7'
+description: ^
+  Provides support for configuring Jolokia.  Basic usage is
+  opts="$JBOSS_CONTAINER_JOLOKIA_MODULE/jolokia-opts"
+
+labels:
+- name: io.fabric8.s2i.version.jolokia
+  value: "1.6.2-redhat-00002"
+
+envs:
+- name: JOLOKIA_VERSION
+  description: Version of Jolokia being used.
+  value: "1.6.2"
+- name: AB_JOLOKIA_PASSWORD_RANDOM
+  description: Determines if a random AB_JOLOKIA_PASSWORD be generated. Set to **true** to generate random password. Generated value will be written to `/opt/jolokia/etc/jolokia.pw`.
+  value: "true"
+- name: AB_JOLOKIA_AUTH_OPENSHIFT
+  description: Switch on client authentication for OpenShift TLS communication. The value of this parameter can be a relative distinguished name which must be contained in a presented client's certificate. Enabling this parameter will automatically switch Jolokia into https communication mode. The default CA cert is set to `/var/run/secrets/kubernetes.io/serviceaccount/ca.crt`.
+  value: "true"
+- name: AB_JOLOKIA_HTTPS
+  description: Switch on secure communication with https. By default self signed server certificates are generated if no `serverCert` configuration is given in **AB_JOLOKIA_OPTS**.
+  value: "true"
+- name: AB_JOLOKIA_OFF
+  description: If set disables activation of Joloka (i.e. echos an empty value). By default, Jolokia is enabled.
+  example: "true"
+- name: AB_JOLOKIA_CONFIG
+  description: If set uses this file (including path) as Jolokia JVM agent properties (as described in Jolokia's link:https://www.jolokia.org/reference/html/agents.html#agents-jvm[reference manual]). If not set, the `/opt/jolokia/etc/jolokia.properties` will be created using the settings as defined in the manual. Otherwise the rest of the settings in this document are ignored.
+  example: "/opt/jolokia/custom.properties"
+- name: AB_JOLOKIA_HOST
+  description: Host address to bind to. Defaults to **0.0.0.0**.
+  example: "127.0.0.1"
+- name: AB_JOLOKIA_PORT
+  description: Port to listen to. Defaults to **8778**.
+  example: "5432"
+- name: AB_JOLOKIA_USER
+  description: User for basic authentication. Defaults to **jolokia**.
+  example: "myusername"
+- name: AB_JOLOKIA_PASSWORD
+  description: Password for basic authentication. By default authentication is switched off.
+  example: "mypassword"
+- name: AB_JOLOKIA_ID
+  description: Agent ID to use (`$HOSTNAME` by default, which is the container id).
+  example: "openjdk-app-1-xqlsj"
+- name: AB_JOLOKIA_DISCOVERY_ENABLED
+  description: Enable Jolokia discovery. Defaults to **false**.
+  example: "true"
+- name: AB_JOLOKIA_OPTS
+  description: Additional options to be appended to the agent configuration. They should be given in the format `key=value,key=value,...`.
+  example: "backlog=20"
+- name: JBOSS_CONTAINER_JOLOKIA_MODULE
+  value: /opt/jboss/container/jolokia
+
+ports:
+- value: 8778
+
+execute:
+- script: configure.sh
+- script: backward_compatibility.sh
+
+artifacts:
+- name: jolokia-jvm
+  target: jolokia-jvm-1.6.2.redhat-00002-agent.jar
+  md5: 760f2fbaf6b142192f3cee2c99bfcbf8

--- a/modules/jolokia/8.2/artifacts/opt/jboss/container/jolokia/jolokia-opts
+++ b/modules/jolokia/8.2/artifacts/opt/jboss/container/jolokia/jolokia-opts
@@ -1,0 +1,92 @@
+#!/bin/sh
+
+# Check whether a given config is contained in AB_JOLOKIA_OPTS
+is_in_jolokia_opts() {
+  local prop=$1
+  if [ -n "${AB_JOLOKIA_OPTS}" ] && [ x"${AB_JOLOKIA_OPTS}" != x"${AB_JOLOKIA_OPTS/${prop}/}" ]; then
+     echo "yes"
+  else
+     echo "no"
+  fi
+}
+
+get_jolokia_properties() {
+
+  echo "host=${AB_JOLOKIA_HOST:-*}"
+  echo "port=${AB_JOLOKIA_PORT:-8778}"
+  echo "discoveryEnabled=${AB_JOLOKIA_DISCOVERY_ENABLED:=false}"
+
+  if [ -n "$AB_JOLOKIA_PASSWORD" ]; then
+     echo "user=${AB_JOLOKIA_USER:-jolokia}"
+     echo "password=${AB_JOLOKIA_PASSWORD}"
+  fi
+  if [ -n "$AB_JOLOKIA_HTTPS" ]; then
+     echo "protocol=https"
+     use_https=1
+  fi
+
+  # Integration with OpenShift client cert auth is enabled
+  # by default if not explicitly turned off by setting to 'false'
+  if [ "x${AB_JOLOKIA_AUTH_OPENSHIFT}" != "xfalse" ] && [ -f "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt" ]; then
+     echo "useSslClientAuthentication=true"
+     echo "extraClientCheck=true"
+
+     if [ -z ${use_https+x} ]; then
+       echo "protocol=https"
+     fi
+     if [ $(is_in_jolokia_opts "caCert") != "yes" ]; then
+        echo "caCert=/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
+     fi
+
+     if [ $(is_in_jolokia_opts "clientPrincipal") != "yes" ]; then
+        if [ x"${AB_JOLOKIA_AUTH_OPENSHIFT}" != x"${AB_JOLOKIA_AUTH_OPENSHIFT/=/}" ]; then
+           # Supposed to contain a principal name to check
+           echo "clientPrincipal=`echo ${AB_JOLOKIA_AUTH_OPENSHIFT} | sed -e 's/ /\\\\ /g'`"
+        else
+           echo "clientPrincipal=cn=system:master-proxy"
+        fi
+     fi
+  fi
+
+  # Add extra opts
+  if [ -n "${AB_JOLOKIA_OPTS}" ]; then
+     echo "${AB_JOLOKIA_OPTS}" | tr "," "\n"
+  fi
+
+}
+
+write_jolokia_properties() {
+  local jolokia_property_file="$1"
+
+  # Setup Jolokia to accept basic auth, using a randomly generated password that is stored
+  # in the container in the ${DEPLOYMENTS_DIR}/jolokia.pw file.
+  if [ "$AB_JOLOKIA_PASSWORD_RANDOM" == "true" ]; then
+    pw_file="${JBOSS_CONTAINER_JOLOKIA_MODULE}/etc/jolokia.pw"
+    if [ -f "${pw_file}" ] ; then
+      AB_JOLOKIA_PASSWORD=`cat "${pw_file}"`
+    else
+      AB_JOLOKIA_PASSWORD=`tr -cd '[:alnum:]' < /dev/urandom | fold -w30 | head -n1`
+      touch "${pw_file}"
+      chmod 660 "${pw_file}"
+      cat > "${pw_file}" <<EOF
+$AB_JOLOKIA_PASSWORD
+EOF
+    fi
+    export AB_JOLOKIA_PASSWORD
+  fi
+
+  touch "${jolokia_property_file}"
+  chmod 660 "${jolokia_property_file}"
+  cat > "${jolokia_property_file}" <<EOF
+$(get_jolokia_properties)
+EOF
+
+}
+
+if [ -z "${AB_JOLOKIA_OFF+x}" ]; then
+  if [ -z "${AB_JOLOKIA_CONFIG}" ]; then
+    AB_JOLOKIA_CONFIG="${JBOSS_CONTAINER_JOLOKIA_MODULE}/etc/jolokia.properties"
+    write_jolokia_properties "$AB_JOLOKIA_CONFIG"
+  fi
+  echo "-javaagent:/usr/share/java/jolokia-jvm-agent/jolokia-jvm.jar=config=${AB_JOLOKIA_CONFIG}"
+fi

--- a/modules/jolokia/8.2/backward_compatibility.sh
+++ b/modules/jolokia/8.2/backward_compatibility.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -euo pipefail
+
+# Legacy (pre-RPM) location
+ln -s /usr/share/java/jolokia-jvm-agent/jolokia-jvm.jar \
+	$JBOSS_CONTAINER_JOLOKIA_MODULE/jolokia.jar

--- a/modules/jolokia/8.2/configure.sh
+++ b/modules/jolokia/8.2/configure.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+# Configure module
+set -e
+
+SCRIPT_DIR=$(dirname $0)
+ARTIFACTS_DIR=${SCRIPT_DIR}/artifacts
+
+chown -R jboss:root $SCRIPT_DIR
+chmod -R ug+rwX $SCRIPT_DIR
+chmod ug+x ${ARTIFACTS_DIR}/opt/jboss/container/jolokia/*
+
+pushd ${ARTIFACTS_DIR}
+cp -pr * /
+popd
+
+mkdir -p /opt/jboss/container/jolokia/etc
+chmod 775 /opt/jboss/container/jolokia/etc
+chown -R jboss:root /opt/jboss/container/jolokia/etc

--- a/modules/jolokia/8.2/module.yaml
+++ b/modules/jolokia/8.2/module.yaml
@@ -1,0 +1,65 @@
+schema_version: 1
+
+name: jboss.container.jolokia
+version: '8.2'
+description: ^
+  Provides support for configuring Jolokia.  Basic usage is
+  opts="$JBOSS_CONTAINER_JOLOKIA_MODULE/jolokia-opts"
+
+labels:
+- name: io.fabric8.s2i.version.jolokia
+  value: "1.6.2-redhat-00002"
+
+envs:
+- name: JOLOKIA_VERSION
+  description: Version of Jolokia being used.
+  value: "1.6.2"
+- name: AB_JOLOKIA_PASSWORD_RANDOM
+  description: Determines if a random AB_JOLOKIA_PASSWORD be generated. Set to **true** to generate random password. Generated value will be written to `/opt/jolokia/etc/jolokia.pw`.
+  value: "true"
+- name: AB_JOLOKIA_AUTH_OPENSHIFT
+  description: Switch on client authentication for OpenShift TLS communication. The value of this parameter can be a relative distinguished name which must be contained in a presented client's certificate. Enabling this parameter will automatically switch Jolokia into https communication mode. The default CA cert is set to `/var/run/secrets/kubernetes.io/serviceaccount/ca.crt`.
+  value: "true"
+- name: AB_JOLOKIA_HTTPS
+  description: Switch on secure communication with https. By default self signed server certificates are generated if no `serverCert` configuration is given in **AB_JOLOKIA_OPTS**.
+  value: "true"
+- name: AB_JOLOKIA_OFF
+  description: If set disables activation of Joloka (i.e. echos an empty value). By default, Jolokia is enabled.
+  example: "true"
+- name: AB_JOLOKIA_CONFIG
+  description: If set uses this file (including path) as Jolokia JVM agent properties (as described in Jolokia's link:https://www.jolokia.org/reference/html/agents.html#agents-jvm[reference manual]). If not set, the `/opt/jolokia/etc/jolokia.properties` will be created using the settings as defined in the manual. Otherwise the rest of the settings in this document are ignored.
+  example: "/opt/jolokia/custom.properties"
+- name: AB_JOLOKIA_HOST
+  description: Host address to bind to. Defaults to **0.0.0.0**.
+  example: "127.0.0.1"
+- name: AB_JOLOKIA_PORT
+  description: Port to listen to. Defaults to **8778**.
+  example: "5432"
+- name: AB_JOLOKIA_USER
+  description: User for basic authentication. Defaults to **jolokia**.
+  example: "myusername"
+- name: AB_JOLOKIA_PASSWORD
+  description: Password for basic authentication. By default authentication is switched off.
+  example: "mypassword"
+- name: AB_JOLOKIA_ID
+  description: Agent ID to use (`$HOSTNAME` by default, which is the container id).
+  example: "openjdk-app-1-xqlsj"
+- name: AB_JOLOKIA_DISCOVERY_ENABLED
+  description: Enable Jolokia discovery. Defaults to **false**.
+  example: "true"
+- name: AB_JOLOKIA_OPTS
+  description: Additional options to be appended to the agent configuration. They should be given in the format `key=value,key=value,...`.
+  example: "backlog=20"
+- name: JBOSS_CONTAINER_JOLOKIA_MODULE
+  value: /opt/jboss/container/jolokia
+
+ports:
+- value: 8778
+
+execute:
+- script: configure.sh
+- script: backward_compatibility.sh
+
+packages:
+  install:
+    - jolokia-jvm-agent

--- a/openj9-11-rhel7.yaml
+++ b/openj9-11-rhel7.yaml
@@ -50,10 +50,7 @@ packages:
 
 modules:
   repositories:
-  - name: cct_module
-    git:
-      url: https://github.com/jboss-openshift/cct_module.git
-      ref: 0.44.0
+  - path: modules
   install:
   - name: jboss.container.openjdk.jdk
     version: "openj9-11"

--- a/openj9-11-rhel8.yaml
+++ b/openj9-11-rhel8.yaml
@@ -55,10 +55,7 @@ packages:
 
 modules:
   repositories:
-  - name: cct_module
-    git:
-      url: https://github.com/jboss-openshift/cct_module.git
-      ref: 0.44.0
+  - path: modules
   install:
   - name: jboss.container.openjdk.jdk
     version: "openj9-11"

--- a/openj9-8-rhel7.yaml
+++ b/openj9-8-rhel7.yaml
@@ -50,10 +50,7 @@ packages:
 
 modules:
   repositories:
-  - name: cct_module
-    git:
-      url: https://github.com/jboss-openshift/cct_module.git
-      ref: 0.44.0
+  - path: modules
   install:
   - name: jboss.container.openjdk.jdk
     version: "openj9-8"

--- a/openj9-8-rhel8.yaml
+++ b/openj9-8-rhel8.yaml
@@ -55,10 +55,7 @@ packages:
 
 modules:
   repositories:
-  - name: cct_module
-    git:
-      url: https://github.com/jboss-openshift/cct_module.git
-      ref: 0.44.0
+  - path: modules
   install:
   - name: jboss.container.openjdk.jdk
     version: "openj9-8"


### PR DESCRIPTION
Imports the 'jolokia' module used in the openj9 images from cct_modules to a local path under "modules/".
Updates reference to the cct_modules repository in the image descriptors to the local path.

- [ ] Pull Request title is properly formatted: `[CLOUD-XYA] Subject`
- [ ] Pull Request contains link to the JIRA issue
- [X] Pull Request contains description of the issue
- [X] Pull Request does not include fixes for issues other than the main ticket
- [X] Attached commits represent units of work and are properly formatted
- [X] You have read and agreed to the Developer Certificate of Origin (DCO) (see `CONTRIBUTING.md`)
- [X] Every commit contains `Signed-off-by: Rafiur Rashid rrashid@redhat.com
