### PR TITLE
Adjust test-tagging to account for runtime images

### DIFF
--- a/tests/features/java.security.feature
+++ b/tests/features/java.security.feature
@@ -1,5 +1,6 @@
 @openjdk
-@ubi8
+@ubi8/openjdk-8
+@ubi8/openjdk-11
 @redhat-openjdk-18
 Feature: Openshift S2I tests
   Scenario: Check networkaddress.cache.negative.ttl has been set correctly

--- a/tests/features/java/gc.feature
+++ b/tests/features/java/gc.feature
@@ -1,5 +1,6 @@
 @openjdk
-@ubi8
+@ubi8/openjdk-8
+@ubi8/openjdk-11
 @redhat-openjdk-18
 @openj9
 Feature: Openshift OpenJDK GC tests

--- a/tests/features/java/java_s2i.feature
+++ b/tests/features/java/java_s2i.feature
@@ -1,5 +1,6 @@
 @openjdk
-@ubi8
+@ubi8/openjdk-8
+@ubi8/openjdk-11
 @redhat-openjdk-18
 @openj9
 Feature: Openshift OpenJDK S2I tests

--- a/tests/features/java/java_s2i_inc.feature
+++ b/tests/features/java/java_s2i_inc.feature
@@ -1,5 +1,6 @@
 @openjdk
-@ubi8
+@ubi8/openjdk-8
+@ubi8/openjdk-11
 @redhat-openjdk-18
 @openj9
 Feature: Openshift OpenJDK S2I tests

--- a/tests/features/java/ports.feature
+++ b/tests/features/java/ports.feature
@@ -1,5 +1,6 @@
 @openjdk
-@ubi8
+@ubi8/openjdk-8
+@ubi8/openjdk-11
 @redhat-openjdk-18
 @openj9
 Feature: Openshift OpenJDK port tests

--- a/tests/features/java/runtime.feature
+++ b/tests/features/java/runtime.feature
@@ -1,7 +1,8 @@
 Feature: Openshift OpenJDK Runtime tests
 
   @openjdk
-  @ubi8
+  @ubi8/openjdk-8
+  @ubi8/openjdk-11
   @redhat-openjdk-18
   @openj9
   Scenario: Ensure JVM_ARGS is no longer present in the run script
@@ -9,7 +10,8 @@ Feature: Openshift OpenJDK Runtime tests
     Then file /usr/local/s2i/run should not contain JVM_ARGS
 
   @openjdk
-  @ubi8
+  @ubi8/openjdk-8
+  @ubi8/openjdk-11
   @redhat-openjdk-18
   @openj9
   Scenario: Ensure JAVA_ARGS are passed through to the running java application
@@ -19,7 +21,8 @@ Feature: Openshift OpenJDK Runtime tests
     Then container log should contain /deployments/undertow-servlet.jar Hello from CTF test
 
   @openjdk
-  @ubi8
+  @ubi8/openjdk-8
+  @ubi8/openjdk-11
   @redhat-openjdk-18
   # Not @openj9 yet, we do not set any specific options for it yet
   Scenario: Ensure diagnostic options work correctly

--- a/tests/features/openshift.feature
+++ b/tests/features/openshift.feature
@@ -1,8 +1,10 @@
 @openjdk
-@ubi8
+@ubi8/openjdk-8
+@ubi8/openjdk-11
 @redhat-openjdk-18
 Feature: Tests for all openshift images
 
+  @ubi8
   Scenario: Check that product labels are correctly set
     # We don't set 'release' or 'architecture' on CI builds, but it's set on OSBS builds
     # Since we base on an image which has it already set, it's kind of meaningless

--- a/tests/features/s2i-core.feature
+++ b/tests/features/s2i-core.feature
@@ -1,5 +1,6 @@
 @openjdk
-@ubi8
+@ubi8/openjdk-8
+@ubi8/openjdk-11
 @redhat-openjdk-18
 @openj9
 Feature: Openshift S2I tests


### PR DESCRIPTION
Any test tagged '@ubi8' will run on the new runtime image descriptors,
but they are all currently dependent upon performing S2I builds which
is not supported.

Adjust the tagging to be specific to the ubi8/openjdk-8 and
ubi8/openjdk-11 images.