### PR TITLE
Runtime Images CMD

### DIFF
--- a/modules/maven-runtime/s2i/artifacts/opt/jboss/container/maven/s2i/maven-overrides
+++ b/modules/maven-runtime/s2i/artifacts/opt/jboss/container/maven/s2i/maven-overrides
@@ -1,0 +1,32 @@
+# Overrides basic functionality by using archived repo by default
+function maven_init_var_MAVEN_LOCAL_REPO() {
+  MAVEN_LOCAL_REPO="${MAVEN_LOCAL_REPO:-${MAVEN_REPO_LOCAL:-${_MAVEN_S2I_ARCHIVED_REPO}}}"
+}
+
+# Overrides basic functionality by looking fore settings.xml in <source>/configuration
+function maven_init_var_MAVEN_SETTINGS_XML() {
+  if [ -f "${MAVEN_SETTINGS_XML}" ]; then
+    :
+  elif [ -f "${S2I_SOURCE_DIR}/configuration/settings.xml" ]; then
+    MAVEN_SETTINGS_XML="${HOME}/.m2/settings.xml"
+    mkdir -p $(dirname "${MAVEN_SETTINGS_XML}")
+    cp "${S2I_SOURCE_DIR}/configuration/settings.xml" "${MAVEN_SETTINGS_XML}"
+  elif [ -f "${HOME}/.m2/settings.xml" ]; then
+    MAVEN_SETTINGS_XML="${HOME}/.m2/settings.xml"
+  else
+    MAVEN_SETTINGS_XML="${_MAVEN_S2I_SETTINGS_XML}"
+    cp "${JBOSS_CONTAINER_MAVEN_DEFAULT_MODULE}/jboss-settings.xml" "${MAVEN_SETTINGS_XML}"
+  fi
+}
+
+# Overrides basic functionality by copying over archived maven repository
+function maven_init_local_repo() {
+  # unpack artifacts from previous build
+  if [ -d "${_MAVEN_S2I_ARCHIVED_REPO}" -a "${MAVEN_LOCAL_REPO}" != "${_MAVEN_S2I_ARCHIVED_REPO}" ]; then
+    # copy to expected repo location
+    cp -rpn "${_MAVEN_S2I_ARCHIVED_REPO}" "${MAVEN_LOCAL_REPO}"
+    rm -rf "${_MAVEN_S2I_ARCHIVED_REPO}"
+    # allows save-artifacts to work without modification
+    ln -s "${MAVEN_LOCAL_REPO}" "${_MAVEN_S2I_ARCHIVED_REPO}"
+  fi
+}

--- a/modules/maven-runtime/s2i/artifacts/opt/jboss/container/maven/s2i/maven-s2i
+++ b/modules/maven-runtime/s2i/artifacts/opt/jboss/container/maven/s2i/maven-s2i
@@ -1,0 +1,148 @@
+
+# include dependencies
+source "${JBOSS_CONTAINER_UTIL_LOGGING_MODULE}/logging.sh"
+source "${JBOSS_CONTAINER_S2I_CORE_MODULE}/s2i-core"
+
+# initialization of maven s2i module
+function maven_s2i_init() {
+  # backward compatibility; s2i_core_init will initialize S2I_ENABLE_INCREMENTAL_BUILDS
+  if [ "x$S2I_ENABLE_INCREMENTAL_BUILDS" == "x" ]; then
+    if [ "${MAVEN_CLEAR_REPO,,}" == "true" ]; then
+      S2I_ENABLE_INCREMENTAL_BUILDS="false"
+    else
+      S2I_ENABLE_INCREMENTAL_BUILDS="true"
+    fi
+  fi
+  # core environment
+  s2i_core_init
+
+  # initialize maven s2i environment variables
+  # use - instead of :- to allow empty artifact dir setting for access to maven_s2i_custom_binary_build
+  MAVEN_S2I_ARTIFACT_DIRS="${MAVEN_S2I_ARTIFACT_DIRS-${ARTIFACT_DIR-target}}"
+  MAVEN_S2I_GOALS="${MAVEN_S2I_GOALS:-package}"
+
+  # make sure MAVEN_CLEAR_REPO and S2I_ENABLE_INCREMENTAL_BUILDS are in sync
+  if [ "${S2I_ENABLE_INCREMENTAL_BUILDS,,}" == "true" ]; then
+    MAVEN_CLEAR_REPO="false"
+  else
+    MAVEN_CLEAR_REPO="true"
+  fi
+  export MAVEN_CLEAR_REPO
+
+  # Internal variables:
+  # Location of Maven settings.xml file to use.
+  _MAVEN_S2I_SETTINGS_XML="${S2I_ARTIFACTS_DIR}/configuration/settings.xml"
+
+  # Location of archived local Maven repository.  Used with incremental builds.
+  _MAVEN_S2I_ARCHIVED_REPO="${S2I_ARTIFACTS_DIR}/m2"
+
+  # include maven scripts
+  if test -r "${JBOSS_CONTAINER_MAVEN_DEFAULT_MODULE}"/scl-enable-maven; then
+	  source "${JBOSS_CONTAINER_MAVEN_DEFAULT_MODULE}"/scl-enable-maven
+  fi
+  source "${JBOSS_CONTAINER_MAVEN_DEFAULT_MODULE}"/maven.sh
+
+  # Overrides for use with maven s2i
+  source "${JBOSS_CONTAINER_MAVEN_S2I_MODULE}"/maven-overrides
+
+  # initialize old variables
+  maven_s2i_backward_compatibility
+
+  # let users override anything if they need to
+  maven_s2i_source_maven_overrides
+
+  # initialize the maven environment
+  maven_init
+}
+
+# setup old variables in case anybody is still using them
+function maven_s2i_backward_compatibility() {
+  export ARTIFACT_DIR="$MAVEN_S2I_ARTIFACT_DIRS"
+}
+
+function maven_s2i_source_maven_overrides() {
+  # extensions can use this to override functions provided by this module
+  # For example:
+  # source custom-maven.sh
+  : #noop
+}
+
+# main entry point, perform the build
+function maven_s2i_build() {
+  maven_s2i_init
+  if [ -f "${S2I_SOURCE_DIR}/pom.xml" ]; then
+    # maven build
+    maven_s2i_maven_build
+  else
+    # binary build
+    maven_s2i_binary_build
+  fi
+  s2i_core_copy_artifacts "${S2I_SOURCE_DIR}"
+
+  s2i_core_process_image_mounts
+
+  s2i_core_cleanup
+
+  # Remove java tmp perf data dir owned by 185
+  rm -rf /tmp/hsperfdata_jboss
+}
+
+# perform a maven build, i.e.  mvn ...
+# internal method
+function maven_s2i_maven_build() { 
+  maven_build "${S2I_SOURCE_DIR}" "${MAVEN_S2I_GOALS}"
+  maven_s2i_deploy_artifacts
+  maven_cleanup
+}
+
+# copy build output to deployments folder
+# internal method
+function maven_s2i_deploy_artifacts() {
+  if [ -n "$(type -t maven_s2i_deploy_artifacts_override)" ]; then
+    eval maven_s2i_deploy_artifacts_override $*
+    return $?
+  fi
+
+  local artifact_dirs=${1:-${MAVEN_S2I_ARTIFACT_DIRS}}
+
+  if [[ ! "${S2I_SOURCE_DIR}" =~ ^\/ ]]; then
+    log_error "$FUNCNAME: Absolute path required for source directory \"$source_dir\"!"
+    exit 1
+  fi
+
+  IFS=',' read -a artifact_dirs <<< "${artifact_dirs:-target}"
+  (
+    for artifact_dir in "${artifact_dirs[@]}"
+    do
+        if [[ "${artifact_dir}" =~ ^\/ ]]; then
+          log_error "Absolute path found in MAVEN_S2I_ARTIFACT_DIRS: ${artifact_dir}"
+          exit 1
+        else
+          # temporarily override source dir so it copies from the dir we pass in
+          S2I_SOURCE_DEPLOYMENTS_DIR=${artifact_dir}
+          s2i_core_copy_deployments "${S2I_SOURCE_DIR}"
+        fi
+    done
+  )
+}
+
+# perform a binary build, basically copy what's here to deployments
+# internal method
+function maven_s2i_binary_build() {
+  log_info "S2I source build with plain binaries detected"
+  if [ -n "$(type -t maven_s2i_custom_binary_build)" ]; then
+    eval maven_s2i_custom_binary_build $*
+    return $?
+  fi
+  maven_s2i_deploy_artifacts "."
+}
+
+# persist artifacts for use with incremental builds
+function maven_s2i_save_artifacts() {
+  # only process artifacts dir if it exists and is not empty
+  if [ -n "${S2I_ARTIFACTS_DIR}" -a -n "$(find ${S2I_ARTIFACTS_DIR} -maxdepth 0 -type d ! -empty 2> /dev/null)" ]; then
+     pushd "${S2I_ARTIFACTS_DIR}" &> /dev/null
+     tar chf - *
+     popd &> /dev/null
+  fi
+}

--- a/modules/maven-runtime/s2i/artifacts/usr/local/s2i/assemble
+++ b/modules/maven-runtime/s2i/artifacts/usr/local/s2i/assemble
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+set -e
+
+source "${JBOSS_CONTAINER_UTIL_LOGGING_MODULE}/logging.sh"
+source "${JBOSS_CONTAINER_MAVEN_S2I_MODULE}/maven-s2i"
+
+# invoke the build
+maven_s2i_build

--- a/modules/maven-runtime/s2i/artifacts/usr/local/s2i/save-artifacts
+++ b/modules/maven-runtime/s2i/artifacts/usr/local/s2i/save-artifacts
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+source "${JBOSS_CONTAINER_MAVEN_S2I_MODULE}/maven-s2i"
+
+# initialize the module
+maven_s2i_init
+
+# persist the artifacts
+maven_s2i_save_artifacts

--- a/modules/maven-runtime/s2i/configure.sh
+++ b/modules/maven-runtime/s2i/configure.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+# Configure module
+set -e
+
+SCRIPT_DIR=$(dirname $0)
+ARTIFACTS_DIR=${SCRIPT_DIR}/artifacts
+
+chown -R jboss:root $SCRIPT_DIR
+chmod -R ug+rwX $SCRIPT_DIR
+chmod ug+x ${ARTIFACTS_DIR}/opt/jboss/container/maven/s2i/*
+chmod ug+x ${ARTIFACTS_DIR}/usr/local/s2i/*
+
+pushd ${ARTIFACTS_DIR}
+cp -pr * /
+popd

--- a/modules/maven-runtime/s2i/module.yaml
+++ b/modules/maven-runtime/s2i/module.yaml
@@ -1,0 +1,35 @@
+schema_version: 1
+name: jboss.container.maven-runtime.s2i
+version: '1.0'
+description: ^
+  Provides s2i capabilities built around Maven.
+  Defines environment variables and labels used by Maven s2i.
+
+envs:
+- name: MAVEN_S2I_ARTIFACT_DIRS
+  description: >
+    Relative paths of source directories to scan for build output, which will
+    be copied to $DEPLOY_DIR.  Defaults to **target**
+  example: target
+
+- name: MAVEN_S2I_GOALS
+  description: >
+    Space separated list of goals to be executed with maven build, e.g.
+    mvn $MAVEN_S2I_GOALS.  Defaults to **package**
+  example: package install
+
+- name: JBOSS_CONTAINER_MAVEN_S2I_MODULE
+  value: /opt/jboss/container/maven/s2i
+
+# Deprecated environment variables
+- name: ARTIFACT_DIR
+  description: Deprecated by **MAVEN_S2I_ARTIFACT_DIRS**.
+
+execute:
+- script: configure.sh
+
+modules:
+  install:
+  - name: jboss.container.s2i-runtime.core.api
+  - name: jboss.container.s2i-runtime.core.bash
+  - name: jboss.container.util.logging.bash

--- a/modules/run-runtime/bash/artifacts/opt/jboss/container/java/run/run-env.sh
+++ b/modules/run-runtime/bash/artifacts/opt/jboss/container/java/run/run-env.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+# Set the application dir to the S2I deployment dir
+JAVA_APP_DIR=/deployments

--- a/modules/run-runtime/bash/artifacts/opt/jboss/container/java/run/run-java.sh
+++ b/modules/run-runtime/bash/artifacts/opt/jboss/container/java/run/run-java.sh
@@ -1,0 +1,248 @@
+#!/bin/sh
+
+# Fail on a single failed command
+set -eo pipefail
+
+source "$JBOSS_CONTAINER_UTIL_LOGGING_MODULE/logging.sh"
+
+if [ "${SCRIPT_DEBUG}" = "true" ] ; then
+    set -x
+    log_info "Script debugging is enabled, allowing bash commands and their arguments to be printed as they are executed"
+fi
+
+# ==========================================================
+# Generic run script for running arbitrary Java applications
+#
+# Source and Documentation can be found
+# at https://github.com/fabric8io/run-java-sh
+#
+# ==========================================================
+
+# Error is indicated with a prefix in the return value
+check_error() {
+  local msg=$1
+  if echo ${msg} | grep -q "^ERROR:"; then
+    log_error ${msg}
+    exit 1
+  fi
+}
+
+# Try hard to find a sane default jar-file
+auto_detect_jar_file() {
+  local dir=$1
+
+  # Filter out temporary jars from the shade plugin which start with 'original-'
+  local old_dir=$(pwd)
+  cd ${dir}
+  if [ $? = 0 ]; then
+    local nr_jars=`ls *.jar 2>/dev/null | grep -v '^original-' | wc -l | tr -d '[[:space:]]'`
+    if [ ${nr_jars} = 1 ]; then
+      ls *.jar | grep -v '^original-'
+      exit 0
+    fi
+
+    log_error "Neither \$JAVA_MAIN_CLASS nor \$JAVA_APP_JAR is set and ${nr_jars} JARs found in ${dir} (1 expected)"
+    cd ${old_dir}
+  else
+    log_error "No directory ${dir} found for auto detection"
+  fi
+}
+
+# Check directories (arg 2...n) for a jar file (arg 1)
+get_jar_file() {
+  local jar=$1
+  shift;
+
+  if [ "${jar:0:1}" = "/" ]; then
+    if [ -f "${jar}" ]; then
+      echo "${jar}"
+    else
+      log_error "No such file ${jar}"
+    fi
+  else
+    for dir in $*; do
+      if [ -f "${dir}/$jar" ]; then
+        echo "${dir}/$jar"
+        return
+      fi
+    done
+    log_error "No ${jar} found in $*"
+  fi
+}
+
+load_env() {
+  # Configuration stuff is read from this file
+  local run_env_sh="run-env.sh"
+
+  # Load default default config
+  if [ -f "${JBOSS_CONTAINER_JAVA_RUN_MODULE}/${run_env_sh}" ]; then
+    source "${JBOSS_CONTAINER_JAVA_RUN_MODULE}/${run_env_sh}"
+  fi
+
+  # Check also $JAVA_APP_DIR. Overrides other defaults
+  # It's valid to set the app dir in the default script
+  if [ -z "${JAVA_APP_DIR}" ]; then
+    # XXX: is this correct?  This is defaulted above to /deployments.  Should we
+    # define a default to the old /opt/java-run?
+    JAVA_APP_DIR="${JBOSS_CONTAINER_JAVA_RUN_MODULE}"
+  else
+    if [ -f "${JAVA_APP_DIR}/${run_env_sh}" ]; then
+      source "${JAVA_APP_DIR}/${run_env_sh}"
+    fi
+  fi
+  export JAVA_APP_DIR
+
+  # Read in container limits and export the as environment variables
+  if [ -f "${JBOSS_CONTAINER_JAVA_JVM_MODULE}/container-limits" ]; then
+    source "${JBOSS_CONTAINER_JAVA_JVM_MODULE}/container-limits"
+  fi
+
+  # JAVA_LIB_DIR defaults to JAVA_APP_DIR
+  export JAVA_LIB_DIR="${JAVA_LIB_DIR:-${JAVA_APP_DIR}}"
+  if [ -z "${JAVA_MAIN_CLASS}" ] && [ -z "${JAVA_APP_JAR}" ]; then
+    JAVA_APP_JAR="$(auto_detect_jar_file ${JAVA_APP_DIR})"
+    check_error "${JAVA_APP_JAR}"
+  fi
+
+  if [ "x${JAVA_APP_JAR}" != x ]; then
+    local jar="$(get_jar_file ${JAVA_APP_JAR} ${JAVA_APP_DIR} ${JAVA_LIB_DIR})"
+    check_error "${jar}"
+    export JAVA_APP_JAR=${jar}
+  else
+    export JAVA_MAIN_CLASS
+  fi
+}
+
+# Check for standard /opt/run-java-options first, fallback to run-java-options in the path if not existing
+run_java_options() {
+  if [ -f "/opt/run-java-options" ]; then
+    echo `sh /opt/run-java-options`
+  else
+    which run-java-options >/dev/null 2>&1
+    if [ $? = 0 ]; then
+      echo `run-java-options`
+    fi
+  fi
+}
+
+# Combine all java options
+get_java_options() {
+  local java_opts
+  local debug_opts
+  if [ -f "${JBOSS_CONTAINER_JAVA_JVM_MODULE}/java-default-options" ]; then
+    java_opts=$(${JBOSS_CONTAINER_JAVA_JVM_MODULE}/java-default-options)
+  fi
+  if [ -f "${JBOSS_CONTAINER_JAVA_JVM_MODULE}/debug-options" ]; then
+    debug_opts=$(${JBOSS_CONTAINER_JAVA_JVM_MODULE}/debug-options)
+  fi
+  if [ -f "${JBOSS_CONTAINER_JAVA_PROXY_MODULE}/proxy-options" ]; then
+    source "${JBOSS_CONTAINER_JAVA_PROXY_MODULE}/proxy-options"
+    proxy_opts="$(proxy_options)"
+  fi
+  # Normalize spaces with awk (i.e. trim and elimate double spaces)
+  echo "${JAVA_OPTS} $(run_java_options) ${debug_opts} ${proxy_opts} ${java_opts} ${JAVA_OPTS_APPEND}" | awk '$1=$1'
+}
+
+# Read in a classpath either from a file with a single line, colon separated
+# or given line-by-line in separate lines
+# Arg 1: path to claspath (must exist), optional arg2: application jar, which is stripped from the classpath in
+# multi line arrangements
+format_classpath() {
+  local cp_file="$1"
+  local app_jar="$2"
+
+  local wc_out=`wc -l $1 2>&1`
+  if [ $? -ne 0 ]; then
+    log_error "Cannot read lines in ${cp_file}: $wc_out"
+    exit 1
+  fi
+
+  local nr_lines=`echo $wc_out | awk '{ print $1 }'`
+  if [ ${nr_lines} -gt 1 ]; then
+    local sep=""
+    local classpath=""
+    while read file; do
+      local full_path="${JAVA_LIB_DIR}/${file}"
+      # Don't include app jar if include in list
+      if [ x"${app_jar}" != x"${full_path}" ]; then
+        classpath="${classpath}${sep}${full_path}"
+      fi
+      sep=":"
+    done < "${cp_file}"
+    echo "${classpath}"
+  else
+    # Supposed to be a single line, colon separated classpath file
+    cat "${cp_file}"
+  fi
+}
+
+# Fetch classpath from env or from a local "run-classpath" file
+get_classpath() {
+  local cp_path="."
+  if [ "x${JAVA_LIB_DIR}" != "x${JAVA_APP_DIR}" ]; then
+    cp_path="${cp_path}:${JAVA_LIB_DIR}"
+  fi
+  if [ -z "${JAVA_CLASSPATH}" ] && [ "x${JAVA_MAIN_CLASS}" != x ]; then
+    if [ "x${JAVA_APP_JAR}" != x ]; then
+      cp_path="${cp_path}:${JAVA_APP_JAR}"
+    fi
+    if [ -f "${JAVA_LIB_DIR}/classpath" ]; then
+      # Classpath is pre-created and stored in a 'run-classpath' file
+      cp_path="${cp_path}:`format_classpath ${JAVA_LIB_DIR}/classpath ${JAVA_APP_JAR}`"
+    else
+      # No order implied
+      cp_path="${cp_path}:${JAVA_APP_DIR}/*"
+    fi
+  elif [ "x${JAVA_CLASSPATH}" != x ]; then
+    # Given from the outside
+    cp_path="${JAVA_CLASSPATH}"
+  fi
+  echo "${cp_path}"
+}
+
+# Set process name if possible
+get_exec_args() {
+  EXEC_ARGS=""
+  if [ "x${JAVA_APP_NAME}" != x ]; then
+    # Not all shells support the 'exec -a newname' syntax..
+    `exec -a test true 2>/dev/null`
+    if [ "$?" = 0 ] ; then
+      echo "-a '${JAVA_APP_NAME}'"
+    else
+      # Lets switch to bash if you have it installed...
+      if [ -f "/bin/bash" ] ; then
+        exec "/bin/bash" $0 $@
+      fi
+    fi
+  fi
+}
+
+# Ensure that the running UID has the "jboss" passwd metadata
+# XXX: Maybe we should make this an entrypoint for the image?
+function configure_passwd() {
+  sed "/^jboss/s/[^:]*/$(id -u)/3" /etc/passwd > "$HOME/passwd"
+}
+
+# Start JVM
+startup() {
+  echo "This is the Red Hat UBI8 OpenJDK 1.8 Runtime container.
+  For usage, please see https://github.com/jboss-container-images/openjdk"
+: '  # Initialize environment
+  load_env
+
+  configure_passwd
+
+  local args
+  cd ${JAVA_APP_DIR}
+  if [ "x${JAVA_MAIN_CLASS}" != x ] ; then
+     args="${JAVA_MAIN_CLASS}"
+  else
+     args="-jar ${JAVA_APP_JAR}"
+  fi
+  log_info "exec $(get_exec_args) java $(get_java_options) -cp \"$(get_classpath)\" ${args} $* ${JAVA_ARGS}"
+  exec $(get_exec_args) java $(get_java_options) -cp "$(get_classpath)" ${args} $* '
+}
+
+# =============================================================================
+# Fire up
+startup $*

--- a/modules/run-runtime/bash/backward_compatibility.sh
+++ b/modules/run-runtime/bash/backward_compatibility.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+# run scripts for images built using openshift-openjdk-s2i-1.8
+set -u
+set -e
+
+ln -s /opt/jboss/container/java/run /opt/run-java
+
+chown -h jboss:root /opt/run-java/run

--- a/modules/run-runtime/bash/configure.sh
+++ b/modules/run-runtime/bash/configure.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+# Configure module
+set -e
+
+SCRIPT_DIR=$(dirname $0)
+ARTIFACTS_DIR=${SCRIPT_DIR}/artifacts
+
+chown -R jboss:root $SCRIPT_DIR
+chmod -R ug+rwX $SCRIPT_DIR
+chmod ug+x ${ARTIFACTS_DIR}/opt/jboss/container/java/run/*
+
+pushd ${ARTIFACTS_DIR}
+cp -pr * /
+popd
+
+mkdir -p /deployments/data \
+ && chmod -R "ug+rwX" /deployments/data \
+ && chown -R jboss:root /deployments/data

--- a/modules/run-runtime/bash/module.yaml
+++ b/modules/run-runtime/bash/module.yaml
@@ -1,0 +1,71 @@
+schema_version: 1
+name: jboss.container.java.run-runtime.bash
+version: '1.0'
+description: ^
+  Provides support for running Java applications.  Basic usage is
+  $JBOSS_CONTAINER_JAVA_RUN_MODULE/run-java.sh.
+
+envs:
+- name: JBOSS_CONTAINER_JAVA_RUN_MODULE
+  value: /opt/jboss/container/java/run
+
+- name: JAVA_APP_DIR
+  description: ^
+    The directory where the application resides. All paths in your application
+    are relative to this directory.
+  example: "myapplication/"
+
+- name: JAVA_MAIN_CLASS
+  description: ^
+    A main class to use as argument for `java`. When this environment variable
+    is given, all jar files in **JAVA_APP_DIR** are added to the classpath as
+    well as **JAVA_LIB_DIR**.
+  example: "com.example.MainClass"
+
+- name: JAVA_LIB_DIR
+  description: ^
+    Directory holding the Java jar files as well an optional `classpath` file
+    which holds the classpath. Either as a single line classpath (colon
+    separated) or with jar files listed line-by-line. If not set
+    **JAVA_LIB_DIR** is the same as **JAVA_APP_DIR**.
+
+- name: JAVA_DATA_DIR
+  description: ^
+    The location of the directory which should be used by the application for
+    reading/writing application data.  Users should override the default if
+    their application should use a different directory, e.g. if a persistent
+    volume is used to persist data across restarts.
+  value: "/deployments/data"
+  example: "/var/cache/application"
+
+- name: JAVA_CLASSPATH
+  description: ^
+    The classpath to use. If not given, the startup script checks for a file
+    `**JAVA_APP_DIR/classpath**` and use its content literally as classpath. If
+    this file doesn't exists all jars in the app dir are added
+    (`classes:**JAVA_APP_DIR/***`).
+
+- name: JAVA_ARGS
+  description: Arguments passed to the `java` application.
+
+- name: LD_PRELOAD
+  value: libnss_wrapper.so
+- name: NSS_WRAPPER_PASSWD
+  value: /home/jboss/passwd
+- name: NSS_WRAPPER_GROUP
+  value: /etc/group
+
+execute:
+- script: configure.sh
+- script: backward_compatibility.sh
+
+modules:
+  install:
+  - name: jboss.container.user
+  - name: jboss.container.java.jvm.bash
+  - name: jboss.container.util.logging.bash
+  - name: jboss.container.openjdk.jre
+
+packages:
+  install:
+  - nss_wrapper

--- a/modules/s2i-runtime/bash/artifacts/opt/jboss/container/java/s2i/maven-overrides
+++ b/modules/s2i-runtime/bash/artifacts/opt/jboss/container/java/s2i/maven-overrides
@@ -1,0 +1,12 @@
+# Overrides basic functionality by looking fore settings.xml in <source>/configuration
+function maven_init_var_MAVEN_SETTINGS_XML() {
+  if [ -f "${MAVEN_SETTINGS_XML}" ]; then
+    :
+  elif [ -f "${S2I_SOURCE_DIR}/configuration/settings.xml" ]; then
+    MAVEN_SETTINGS_XML="${S2I_SOURCE_DIR}/configuration/settings.xml"
+  else
+    MAVEN_SETTINGS_XML="${_MAVEN_S2I_SETTINGS_XML}"
+    mkdir -p $(dirname "${MAVEN_SETTINGS_XML}")
+    cp "${JBOSS_CONTAINER_MAVEN_DEFAULT_MODULE}/jboss-settings.xml" "${MAVEN_SETTINGS_XML}"
+  fi
+}

--- a/modules/s2i-runtime/bash/artifacts/opt/jboss/container/java/s2i/maven-s2i-overrides
+++ b/modules/s2i-runtime/bash/artifacts/opt/jboss/container/java/s2i/maven-s2i-overrides
@@ -1,0 +1,74 @@
+
+source "${JBOSS_CONTAINER_UTIL_LOGGING_MODULE}/logging.sh"
+
+# inject our overridden maven_*() functions
+function maven_s2i_source_maven_overrides() {
+  source "${JBOSS_CONTAINER_JAVA_S2I_MODULE}/maven-overrides"
+}
+
+# Accommodate fabric8
+function maven_s2i_custom_binary_build() {
+  if [ -f "${S2I_SOURCE_DIR}/Dockerfile" ]; then
+    # This is a S2I binary build coming from fabric8-maven-plugin
+    log_info "S2I binary build from fabric8-maven-plugin detected"
+    if [ -d "${S2I_SOURCE_DIR}/maven" ]; then
+      binary_dir="${S2I_SOURCE_DIR}/maven"
+    elif [ -d "${S2I_SOURCE_DIR}/${S2I_SOURCE_DEPLOYMENTS_DIR}" ]; then
+      binary_dir="${S2I_SOURCE_DIR}/${S2I_SOURCE_DEPLOYMENTS_DIR}"
+    elif [ $(find "${S2I_SOURCE_DIR}" -maxdepth 1 -type d | grep -v -e "^${S2I_SOURCE_DIR}$" | wc -l) == 1 ]; then
+      # Found a single directory, take this
+      binary_dir=$(find "${S2I_SOURCE_DIR}" -maxdepth 1 -type d | grep -v -e "^${S2I_SOURCE_DIR}$")
+    else
+      log_error "No single directory found in ${S2I_SOURCE_DIR} but:\n $(ls -l ${S2I_SOURCE_DIR})"
+      return 1
+    fi
+  elif [ -d "${S2I_SOURCE_DIR}/${S2I_SOURCE_DEPLOYMENTS_DIR}" ]; then
+    binary_dir="${S2I_SOURCE_DIR}/${S2I_SOURCE_DEPLOYMENTS_DIR}"
+  else
+    binary_dir="${S2I_SOURCE_DIR}"
+  fi
+  log_info "Copying binaries from ${binary_dir} to ${S2I_TARGET_DEPLOYMENTS_DIR} ..."
+  rsync -rl --out-format='%n' "${binary_dir}"/ "${S2I_TARGET_DEPLOYMENTS_DIR}"
+}
+
+function maven_s2i_deploy_artifacts_override() {
+  if [ -n "${ARTIFACT_COPY_ARGS}" ]; then
+    log_warning "ARTIFACT_COPY_ARGS is deprecated.  Please use S2I_SOURCE_DEPLOYMENTS_FILTER to specify artifact types and MAVEN_S2I_ARTIFACT_DIRS to specify the build output directories to copy from."
+    if [ ! -d "${S2I_TARGET_DEPLOYMENTS_DIR}" ]; then
+      log_info "S2I_TARGET_DEPLOYMENTS_DIR does not exist, creating ${S2I_TARGET_DEPLOYMENTS_DIR}"
+      mkdir -pm 775 "${S2I_TARGET_DEPLOYMENTS_DIR}"
+    fi
+    pushd "$(_maven_s2i_legacy_get_output_dir)" > /dev/null
+    cp -v ${ARTIFACT_COPY_ARGS} "${S2I_TARGET_DEPLOYMENTS_DIR}"
+    popd > /dev/null
+    return $?
+  else
+    unset -f maven_s2i_deploy_artifacts_override
+    eval maven_s2i_deploy_artifacts $*
+    return $?
+  fi
+}
+
+function _maven_s2i_legacy_get_output_dir() {
+  local dir=""
+  # If multi module build and no ARTIFACT_DIR is set --> error
+  if [ x"${MAVEN_S2I_ARTIFACT_DIRS}" = x ]; then
+    echo " ${MAVEN_ARGS}" | grep -q ' -pl'
+    if [ $? -eq 0 ]; then
+       log_error "MAVEN_S2I_ARTIFACT_DIRS must be set for multi module Maven builds"
+       exit 1
+    fi
+    dir="${S2I_SOURCE_DIR}/target"
+  elif [ ${#MAVEN_S2I_ARTIFACT_DIRS[@]} -gt 1 ]; then
+       log_error "MAVEN_S2I_ARTIFACT_DIRS must be set to a single value when using ARTIFACT_COPY_ARGS"
+       exit 1
+  else
+    if [ "${MAVEN_S2I_ARTIFACT_DIRS:0:1}" = "/" ]; then
+       log_error "MAVEN_S2I_ARTIFACT_DIRS \"${MAVEN_S2I_ARTIFACT_DIRS}\" must not be absolute but relative to the source directory"
+       exit 1
+    fi
+    dir="${S2I_SOURCE_DIR}/${MAVEN_S2I_ARTIFACT_DIRS}"
+  fi
+
+  echo ${dir}
+}

--- a/modules/s2i-runtime/bash/artifacts/opt/jboss/container/java/s2i/s2i-core-hooks
+++ b/modules/s2i-runtime/bash/artifacts/opt/jboss/container/java/s2i/s2i-core-hooks
@@ -1,0 +1,7 @@
+
+source "${JBOSS_CONTAINER_UTIL_LOGGING_MODULE}/logging.sh"
+
+# override core variables
+function s2i_core_env_init_hook() {
+  S2I_TARGET_DATA_DIR="${S2I_TARGET_DATA_DIR:-${JAVA_DATA_DIR:-/deployments/data}}"
+}

--- a/modules/s2i-runtime/bash/artifacts/usr/local/s2i/assemble
+++ b/modules/s2i-runtime/bash/artifacts/usr/local/s2i/assemble
@@ -1,0 +1,16 @@
+#!/bin/sh
+
+set -e
+
+source "${JBOSS_CONTAINER_UTIL_LOGGING_MODULE}/logging.sh"
+source "${JBOSS_CONTAINER_MAVEN_S2I_MODULE}/maven-s2i"
+
+# include our s2i_core_*() overrides/extensions
+source "${JBOSS_CONTAINER_JAVA_S2I_MODULE}/s2i-core-hooks"
+
+# inject our overridden maven_s2i_*() functions
+source "${JBOSS_CONTAINER_JAVA_S2I_MODULE}/maven-s2i-overrides"
+
+# invoke the build
+maven_s2i_build
+

--- a/modules/s2i-runtime/bash/artifacts/usr/local/s2i/run
+++ b/modules/s2i-runtime/bash/artifacts/usr/local/s2i/run
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+# Command line arguments given to this script
+args="$*"
+
+source "${JBOSS_CONTAINER_UTIL_LOGGING_MODULE}/logging.sh"
+source "${JBOSS_CONTAINER_S2I_CORE_MODULE}/s2i-core"
+# include our s2i_core_*() overrides/extensions
+source "${JBOSS_CONTAINER_JAVA_S2I_MODULE}/s2i-core-hooks"
+
+# Global S2I variable setup
+s2i_core_env_init
+
+# CLOUD-3387: RHEL7-based images enable maven in the runtime environment. This
+# is not needed for RHEL8-based images.
+if test -r "${JBOSS_CONTAINER_MAVEN_DEFAULT_MODULE}/scl-enable-maven"; then
+    source "${JBOSS_CONTAINER_MAVEN_DEFAULT_MODULE}/scl-enable-maven"
+fi
+
+JAVA_OPTS="${JAVA_OPTS:-${JAVA_OPTIONS}}"
+if [ -f "${JBOSS_CONTAINER_JOLOKIA_MODULE}/jolokia-opts" ]; then
+    # Always include jolokia-opts, which can be empty if switched off via env
+    JAVA_OPTS="${JAVA_OPTS} $(${JBOSS_CONTAINER_JOLOKIA_MODULE}/jolokia-opts)"
+fi
+if [ -f "${JBOSS_CONTAINER_PROMETHEUS_MODULE}/prometheus-opts" ]; then
+    JAVA_OPTS="${JAVA_OPTS} $(source ${JBOSS_CONTAINER_PROMETHEUS_MODULE}/prometheus-opts && get_prometheus_opts)"
+fi
+export JAVA_OPTS
+export JAVA_OPTIONS="$JAVA_OPTS"
+
+if [ -f "${S2I_TARGET_DEPLOYMENTS_DIR}/bin/run.sh" ]; then
+    echo "Starting the application using the bundled ${S2I_TARGET_DEPLOYMENTS_DIR}/bin/run.sh ..."
+    exec ${DEPLOYMENTS_DIR}/bin/run.sh $args ${JAVA_ARGS}
+else
+    echo "Starting the Java application using ${JBOSS_CONTAINER_JAVA_RUN_MODULE}/run-java.sh $args..."
+    exec "${JBOSS_CONTAINER_JAVA_RUN_MODULE}/run-java.sh" $args ${JAVA_ARGS}
+fi

--- a/modules/s2i-runtime/bash/artifacts/usr/local/s2i/s2i-setup
+++ b/modules/s2i-runtime/bash/artifacts/usr/local/s2i/s2i-setup
@@ -1,0 +1,13 @@
+
+# DEPRECATED: provided for backward compatibility
+
+source "${JBOSS_CONTAINER_UTIL_LOGGING_MODULE}/logging.sh"
+source "${JBOSS_CONTAINER_S2I_CORE_MODULE}/s2i-core"
+# include our s2i_core_*() overrides/extensions
+source "${JBOSS_CONTAINER_JAVA_S2I_MODULE}/s2i-core-hooks"
+
+log_warning "s2i-setup script has been deprecated and will be removed in a future release."
+
+s2i_core_init
+
+source "${JBOSS_CONTAINER_MAVEN_DEFAULT_MODULE}/scl-enable-maven"

--- a/modules/s2i-runtime/bash/artifacts/usr/local/s2i/usage
+++ b/modules/s2i-runtime/bash/artifacts/usr/local/s2i/usage
@@ -1,0 +1,2 @@
+#!/bin/sh
+cat $(dirname $0)/usage.txt

--- a/modules/s2i-runtime/bash/configure.sh
+++ b/modules/s2i-runtime/bash/configure.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+# Configure module
+set -e
+
+SCRIPT_DIR=$(dirname $0)
+ARTIFACTS_DIR=${SCRIPT_DIR}/artifacts
+
+chown -R jboss:root $SCRIPT_DIR
+chmod -R ug+rwX $SCRIPT_DIR
+chmod ug+x ${ARTIFACTS_DIR}/opt/jboss/container/java/s2i/*
+chmod ug+x ${ARTIFACTS_DIR}/usr/local/s2i/*
+
+pushd ${ARTIFACTS_DIR}
+cp -pr * /
+popd

--- a/modules/s2i-runtime/bash/module.yaml
+++ b/modules/s2i-runtime/bash/module.yaml
@@ -1,0 +1,19 @@
+schema_version: 1
+name: jboss.container.java.s2i-runtime.bash
+version: '1.0'
+description: Customization of common Maven S2I for Java S2I image.
+
+envs:
+- name: JBOSS_CONTAINER_JAVA_S2I_MODULE
+  value: /opt/jboss/container/java/s2i
+- name: S2I_SOURCE_DEPLOYMENTS_FILTER
+  value: "*.jar"
+
+execute:
+- script: configure.sh
+
+modules:
+  install:
+  - name: jboss.container.maven-runtime.s2i
+  - name: jboss.container.java.run-runtime.bash
+  - name: jboss.container.util.logging.bash

--- a/modules/s2i-runtime/core/api/README.html
+++ b/modules/s2i-runtime/core/api/README.html
@@ -1,0 +1,612 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<!--[if IE]><meta http-equiv="X-UA-Compatible" content="IE=edge"><![endif]-->
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<meta name="generator" content="Asciidoctor 1.5.4">
+<title>jboss.container.s2i.core.api</title>
+<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Open+Sans:300,300italic,400,400italic,600,600italic%7CNoto+Serif:400,400italic,700,700italic%7CDroid+Sans+Mono:400,700">
+<style>
+/* Asciidoctor default stylesheet | MIT License | http://asciidoctor.org */
+/* Remove comment around @import statement below when using as a custom stylesheet */
+/*@import "https://fonts.googleapis.com/css?family=Open+Sans:300,300italic,400,400italic,600,600italic%7CNoto+Serif:400,400italic,700,700italic%7CDroid+Sans+Mono:400,700";*/
+article,aside,details,figcaption,figure,footer,header,hgroup,main,nav,section,summary{display:block}
+audio,canvas,video{display:inline-block}
+audio:not([controls]){display:none;height:0}
+[hidden],template{display:none}
+script{display:none!important}
+html{font-family:sans-serif;-ms-text-size-adjust:100%;-webkit-text-size-adjust:100%}
+body{margin:0}
+a{background:transparent}
+a:focus{outline:thin dotted}
+a:active,a:hover{outline:0}
+h1{font-size:2em;margin:.67em 0}
+abbr[title]{border-bottom:1px dotted}
+b,strong{font-weight:bold}
+dfn{font-style:italic}
+hr{-moz-box-sizing:content-box;box-sizing:content-box;height:0}
+mark{background:#ff0;color:#000}
+code,kbd,pre,samp{font-family:monospace;font-size:1em}
+pre{white-space:pre-wrap}
+q{quotes:"\201C" "\201D" "\2018" "\2019"}
+small{font-size:80%}
+sub,sup{font-size:75%;line-height:0;position:relative;vertical-align:baseline}
+sup{top:-.5em}
+sub{bottom:-.25em}
+img{border:0}
+svg:not(:root){overflow:hidden}
+figure{margin:0}
+fieldset{border:1px solid silver;margin:0 2px;padding:.35em .625em .75em}
+legend{border:0;padding:0}
+button,input,select,textarea{font-family:inherit;font-size:100%;margin:0}
+button,input{line-height:normal}
+button,select{text-transform:none}
+button,html input[type="button"],input[type="reset"],input[type="submit"]{-webkit-appearance:button;cursor:pointer}
+button[disabled],html input[disabled]{cursor:default}
+input[type="checkbox"],input[type="radio"]{box-sizing:border-box;padding:0}
+input[type="search"]{-webkit-appearance:textfield;-moz-box-sizing:content-box;-webkit-box-sizing:content-box;box-sizing:content-box}
+input[type="search"]::-webkit-search-cancel-button,input[type="search"]::-webkit-search-decoration{-webkit-appearance:none}
+button::-moz-focus-inner,input::-moz-focus-inner{border:0;padding:0}
+textarea{overflow:auto;vertical-align:top}
+table{border-collapse:collapse;border-spacing:0}
+*,*:before,*:after{-moz-box-sizing:border-box;-webkit-box-sizing:border-box;box-sizing:border-box}
+html,body{font-size:100%}
+body{background:#fff;color:rgba(0,0,0,.8);padding:0;margin:0;font-family:"Noto Serif","DejaVu Serif",serif;font-weight:400;font-style:normal;line-height:1;position:relative;cursor:auto}
+a:hover{cursor:pointer}
+img,object,embed{max-width:100%;height:auto}
+object,embed{height:100%}
+img{-ms-interpolation-mode:bicubic}
+.left{float:left!important}
+.right{float:right!important}
+.text-left{text-align:left!important}
+.text-right{text-align:right!important}
+.text-center{text-align:center!important}
+.text-justify{text-align:justify!important}
+.hide{display:none}
+body{-webkit-font-smoothing:antialiased}
+img,object,svg{display:inline-block;vertical-align:middle}
+textarea{height:auto;min-height:50px}
+select{width:100%}
+.center{margin-left:auto;margin-right:auto}
+.spread{width:100%}
+p.lead,.paragraph.lead>p,#preamble>.sectionbody>.paragraph:first-of-type p{font-size:1.21875em;line-height:1.6}
+.subheader,.admonitionblock td.content>.title,.audioblock>.title,.exampleblock>.title,.imageblock>.title,.listingblock>.title,.literalblock>.title,.stemblock>.title,.openblock>.title,.paragraph>.title,.quoteblock>.title,table.tableblock>.title,.verseblock>.title,.videoblock>.title,.dlist>.title,.olist>.title,.ulist>.title,.qlist>.title,.hdlist>.title{line-height:1.45;color:#7a2518;font-weight:400;margin-top:0;margin-bottom:.25em}
+div,dl,dt,dd,ul,ol,li,h1,h2,h3,#toctitle,.sidebarblock>.content>.title,h4,h5,h6,pre,form,p,blockquote,th,td{margin:0;padding:0;direction:ltr}
+a{color:#2156a5;text-decoration:underline;line-height:inherit}
+a:hover,a:focus{color:#1d4b8f}
+a img{border:none}
+p{font-family:inherit;font-weight:400;font-size:1em;line-height:1.6;margin-bottom:1.25em;text-rendering:optimizeLegibility}
+p aside{font-size:.875em;line-height:1.35;font-style:italic}
+h1,h2,h3,#toctitle,.sidebarblock>.content>.title,h4,h5,h6{font-family:"Open Sans","DejaVu Sans",sans-serif;font-weight:300;font-style:normal;color:#ba3925;text-rendering:optimizeLegibility;margin-top:1em;margin-bottom:.5em;line-height:1.0125em}
+h1 small,h2 small,h3 small,#toctitle small,.sidebarblock>.content>.title small,h4 small,h5 small,h6 small{font-size:60%;color:#e99b8f;line-height:0}
+h1{font-size:2.125em}
+h2{font-size:1.6875em}
+h3,#toctitle,.sidebarblock>.content>.title{font-size:1.375em}
+h4,h5{font-size:1.125em}
+h6{font-size:1em}
+hr{border:solid #ddddd8;border-width:1px 0 0;clear:both;margin:1.25em 0 1.1875em;height:0}
+em,i{font-style:italic;line-height:inherit}
+strong,b{font-weight:bold;line-height:inherit}
+small{font-size:60%;line-height:inherit}
+code{font-family:"Droid Sans Mono","DejaVu Sans Mono",monospace;font-weight:400;color:rgba(0,0,0,.9)}
+ul,ol,dl{font-size:1em;line-height:1.6;margin-bottom:1.25em;list-style-position:outside;font-family:inherit}
+ul,ol,ul.no-bullet,ol.no-bullet{margin-left:1.5em}
+ul li ul,ul li ol{margin-left:1.25em;margin-bottom:0;font-size:1em}
+ul.square li ul,ul.circle li ul,ul.disc li ul{list-style:inherit}
+ul.square{list-style-type:square}
+ul.circle{list-style-type:circle}
+ul.disc{list-style-type:disc}
+ul.no-bullet{list-style:none}
+ol li ul,ol li ol{margin-left:1.25em;margin-bottom:0}
+dl dt{margin-bottom:.3125em;font-weight:bold}
+dl dd{margin-bottom:1.25em}
+abbr,acronym{text-transform:uppercase;font-size:90%;color:rgba(0,0,0,.8);border-bottom:1px dotted #ddd;cursor:help}
+abbr{text-transform:none}
+blockquote{margin:0 0 1.25em;padding:.5625em 1.25em 0 1.1875em;border-left:1px solid #ddd}
+blockquote cite{display:block;font-size:.9375em;color:rgba(0,0,0,.6)}
+blockquote cite:before{content:"\2014 \0020"}
+blockquote cite a,blockquote cite a:visited{color:rgba(0,0,0,.6)}
+blockquote,blockquote p{line-height:1.6;color:rgba(0,0,0,.85)}
+@media only screen and (min-width:768px){h1,h2,h3,#toctitle,.sidebarblock>.content>.title,h4,h5,h6{line-height:1.2}
+h1{font-size:2.75em}
+h2{font-size:2.3125em}
+h3,#toctitle,.sidebarblock>.content>.title{font-size:1.6875em}
+h4{font-size:1.4375em}}
+table{background:#fff;margin-bottom:1.25em;border:solid 1px #dedede}
+table thead,table tfoot{background:#f7f8f7;font-weight:bold}
+table thead tr th,table thead tr td,table tfoot tr th,table tfoot tr td{padding:.5em .625em .625em;font-size:inherit;color:rgba(0,0,0,.8);text-align:left}
+table tr th,table tr td{padding:.5625em .625em;font-size:inherit;color:rgba(0,0,0,.8)}
+table tr.even,table tr.alt,table tr:nth-of-type(even){background:#f8f8f7}
+table thead tr th,table tfoot tr th,table tbody tr td,table tr td,table tfoot tr td{display:table-cell;line-height:1.6}
+body{tab-size:4}
+h1,h2,h3,#toctitle,.sidebarblock>.content>.title,h4,h5,h6{line-height:1.2;word-spacing:-.05em}
+h1 strong,h2 strong,h3 strong,#toctitle strong,.sidebarblock>.content>.title strong,h4 strong,h5 strong,h6 strong{font-weight:400}
+.clearfix:before,.clearfix:after,.float-group:before,.float-group:after{content:" ";display:table}
+.clearfix:after,.float-group:after{clear:both}
+*:not(pre)>code{font-size:.9375em;font-style:normal!important;letter-spacing:0;padding:.1em .5ex;word-spacing:-.15em;background-color:#f7f7f8;-webkit-border-radius:4px;border-radius:4px;line-height:1.45;text-rendering:optimizeSpeed}
+pre,pre>code{line-height:1.45;color:rgba(0,0,0,.9);font-family:"Droid Sans Mono","DejaVu Sans Mono",monospace;font-weight:400;text-rendering:optimizeSpeed}
+.keyseq{color:rgba(51,51,51,.8)}
+kbd{font-family:"Droid Sans Mono","DejaVu Sans Mono",monospace;display:inline-block;color:rgba(0,0,0,.8);font-size:.65em;line-height:1.45;background-color:#f7f7f7;border:1px solid #ccc;-webkit-border-radius:3px;border-radius:3px;-webkit-box-shadow:0 1px 0 rgba(0,0,0,.2),0 0 0 .1em white inset;box-shadow:0 1px 0 rgba(0,0,0,.2),0 0 0 .1em #fff inset;margin:0 .15em;padding:.2em .5em;vertical-align:middle;position:relative;top:-.1em;white-space:nowrap}
+.keyseq kbd:first-child{margin-left:0}
+.keyseq kbd:last-child{margin-right:0}
+.menuseq,.menu{color:rgba(0,0,0,.8)}
+b.button:before,b.button:after{position:relative;top:-1px;font-weight:400}
+b.button:before{content:"[";padding:0 3px 0 2px}
+b.button:after{content:"]";padding:0 2px 0 3px}
+p a>code:hover{color:rgba(0,0,0,.9)}
+#header,#content,#footnotes,#footer{width:100%;margin-left:auto;margin-right:auto;margin-top:0;margin-bottom:0;max-width:62.5em;*zoom:1;position:relative;padding-left:.9375em;padding-right:.9375em}
+#header:before,#header:after,#content:before,#content:after,#footnotes:before,#footnotes:after,#footer:before,#footer:after{content:" ";display:table}
+#header:after,#content:after,#footnotes:after,#footer:after{clear:both}
+#content{margin-top:1.25em}
+#content:before{content:none}
+#header>h1:first-child{color:rgba(0,0,0,.85);margin-top:2.25rem;margin-bottom:0}
+#header>h1:first-child+#toc{margin-top:8px;border-top:1px solid #ddddd8}
+#header>h1:only-child,body.toc2 #header>h1:nth-last-child(2){border-bottom:1px solid #ddddd8;padding-bottom:8px}
+#header .details{border-bottom:1px solid #ddddd8;line-height:1.45;padding-top:.25em;padding-bottom:.25em;padding-left:.25em;color:rgba(0,0,0,.6);display:-ms-flexbox;display:-webkit-flex;display:flex;-ms-flex-flow:row wrap;-webkit-flex-flow:row wrap;flex-flow:row wrap}
+#header .details span:first-child{margin-left:-.125em}
+#header .details span.email a{color:rgba(0,0,0,.85)}
+#header .details br{display:none}
+#header .details br+span:before{content:"\00a0\2013\00a0"}
+#header .details br+span.author:before{content:"\00a0\22c5\00a0";color:rgba(0,0,0,.85)}
+#header .details br+span#revremark:before{content:"\00a0|\00a0"}
+#header #revnumber{text-transform:capitalize}
+#header #revnumber:after{content:"\00a0"}
+#content>h1:first-child:not([class]){color:rgba(0,0,0,.85);border-bottom:1px solid #ddddd8;padding-bottom:8px;margin-top:0;padding-top:1rem;margin-bottom:1.25rem}
+#toc{border-bottom:1px solid #efefed;padding-bottom:.5em}
+#toc>ul{margin-left:.125em}
+#toc ul.sectlevel0>li>a{font-style:italic}
+#toc ul.sectlevel0 ul.sectlevel1{margin:.5em 0}
+#toc ul{font-family:"Open Sans","DejaVu Sans",sans-serif;list-style-type:none}
+#toc li{line-height:1.3334;margin-top:.3334em}
+#toc a{text-decoration:none}
+#toc a:active{text-decoration:underline}
+#toctitle{color:#7a2518;font-size:1.2em}
+@media only screen and (min-width:768px){#toctitle{font-size:1.375em}
+body.toc2{padding-left:15em;padding-right:0}
+#toc.toc2{margin-top:0!important;background-color:#f8f8f7;position:fixed;width:15em;left:0;top:0;border-right:1px solid #efefed;border-top-width:0!important;border-bottom-width:0!important;z-index:1000;padding:1.25em 1em;height:100%;overflow:auto}
+#toc.toc2 #toctitle{margin-top:0;margin-bottom:.8rem;font-size:1.2em}
+#toc.toc2>ul{font-size:.9em;margin-bottom:0}
+#toc.toc2 ul ul{margin-left:0;padding-left:1em}
+#toc.toc2 ul.sectlevel0 ul.sectlevel1{padding-left:0;margin-top:.5em;margin-bottom:.5em}
+body.toc2.toc-right{padding-left:0;padding-right:15em}
+body.toc2.toc-right #toc.toc2{border-right-width:0;border-left:1px solid #efefed;left:auto;right:0}}
+@media only screen and (min-width:1280px){body.toc2{padding-left:20em;padding-right:0}
+#toc.toc2{width:20em}
+#toc.toc2 #toctitle{font-size:1.375em}
+#toc.toc2>ul{font-size:.95em}
+#toc.toc2 ul ul{padding-left:1.25em}
+body.toc2.toc-right{padding-left:0;padding-right:20em}}
+#content #toc{border-style:solid;border-width:1px;border-color:#e0e0dc;margin-bottom:1.25em;padding:1.25em;background:#f8f8f7;-webkit-border-radius:4px;border-radius:4px}
+#content #toc>:first-child{margin-top:0}
+#content #toc>:last-child{margin-bottom:0}
+#footer{max-width:100%;background-color:rgba(0,0,0,.8);padding:1.25em}
+#footer-text{color:rgba(255,255,255,.8);line-height:1.44}
+.sect1{padding-bottom:.625em}
+@media only screen and (min-width:768px){.sect1{padding-bottom:1.25em}}
+.sect1+.sect1{border-top:1px solid #efefed}
+#content h1>a.anchor,h2>a.anchor,h3>a.anchor,#toctitle>a.anchor,.sidebarblock>.content>.title>a.anchor,h4>a.anchor,h5>a.anchor,h6>a.anchor{position:absolute;z-index:1001;width:1.5ex;margin-left:-1.5ex;display:block;text-decoration:none!important;visibility:hidden;text-align:center;font-weight:400}
+#content h1>a.anchor:before,h2>a.anchor:before,h3>a.anchor:before,#toctitle>a.anchor:before,.sidebarblock>.content>.title>a.anchor:before,h4>a.anchor:before,h5>a.anchor:before,h6>a.anchor:before{content:"\00A7";font-size:.85em;display:block;padding-top:.1em}
+#content h1:hover>a.anchor,#content h1>a.anchor:hover,h2:hover>a.anchor,h2>a.anchor:hover,h3:hover>a.anchor,#toctitle:hover>a.anchor,.sidebarblock>.content>.title:hover>a.anchor,h3>a.anchor:hover,#toctitle>a.anchor:hover,.sidebarblock>.content>.title>a.anchor:hover,h4:hover>a.anchor,h4>a.anchor:hover,h5:hover>a.anchor,h5>a.anchor:hover,h6:hover>a.anchor,h6>a.anchor:hover{visibility:visible}
+#content h1>a.link,h2>a.link,h3>a.link,#toctitle>a.link,.sidebarblock>.content>.title>a.link,h4>a.link,h5>a.link,h6>a.link{color:#ba3925;text-decoration:none}
+#content h1>a.link:hover,h2>a.link:hover,h3>a.link:hover,#toctitle>a.link:hover,.sidebarblock>.content>.title>a.link:hover,h4>a.link:hover,h5>a.link:hover,h6>a.link:hover{color:#a53221}
+.audioblock,.imageblock,.literalblock,.listingblock,.stemblock,.videoblock{margin-bottom:1.25em}
+.admonitionblock td.content>.title,.audioblock>.title,.exampleblock>.title,.imageblock>.title,.listingblock>.title,.literalblock>.title,.stemblock>.title,.openblock>.title,.paragraph>.title,.quoteblock>.title,table.tableblock>.title,.verseblock>.title,.videoblock>.title,.dlist>.title,.olist>.title,.ulist>.title,.qlist>.title,.hdlist>.title{text-rendering:optimizeLegibility;text-align:left;font-family:"Noto Serif","DejaVu Serif",serif;font-size:1rem;font-style:italic}
+table.tableblock>caption.title{white-space:nowrap;overflow:visible;max-width:0}
+.paragraph.lead>p,#preamble>.sectionbody>.paragraph:first-of-type p{color:rgba(0,0,0,.85)}
+table.tableblock #preamble>.sectionbody>.paragraph:first-of-type p{font-size:inherit}
+.admonitionblock>table{border-collapse:separate;border:0;background:none;width:100%}
+.admonitionblock>table td.icon{text-align:center;width:80px}
+.admonitionblock>table td.icon img{max-width:none}
+.admonitionblock>table td.icon .title{font-weight:bold;font-family:"Open Sans","DejaVu Sans",sans-serif;text-transform:uppercase}
+.admonitionblock>table td.content{padding-left:1.125em;padding-right:1.25em;border-left:1px solid #ddddd8;color:rgba(0,0,0,.6)}
+.admonitionblock>table td.content>:last-child>:last-child{margin-bottom:0}
+.exampleblock>.content{border-style:solid;border-width:1px;border-color:#e6e6e6;margin-bottom:1.25em;padding:1.25em;background:#fff;-webkit-border-radius:4px;border-radius:4px}
+.exampleblock>.content>:first-child{margin-top:0}
+.exampleblock>.content>:last-child{margin-bottom:0}
+.sidebarblock{border-style:solid;border-width:1px;border-color:#e0e0dc;margin-bottom:1.25em;padding:1.25em;background:#f8f8f7;-webkit-border-radius:4px;border-radius:4px}
+.sidebarblock>:first-child{margin-top:0}
+.sidebarblock>:last-child{margin-bottom:0}
+.sidebarblock>.content>.title{color:#7a2518;margin-top:0;text-align:center}
+.exampleblock>.content>:last-child>:last-child,.exampleblock>.content .olist>ol>li:last-child>:last-child,.exampleblock>.content .ulist>ul>li:last-child>:last-child,.exampleblock>.content .qlist>ol>li:last-child>:last-child,.sidebarblock>.content>:last-child>:last-child,.sidebarblock>.content .olist>ol>li:last-child>:last-child,.sidebarblock>.content .ulist>ul>li:last-child>:last-child,.sidebarblock>.content .qlist>ol>li:last-child>:last-child{margin-bottom:0}
+.literalblock pre,.listingblock pre:not(.highlight),.listingblock pre[class="highlight"],.listingblock pre[class^="highlight "],.listingblock pre.CodeRay,.listingblock pre.prettyprint{background:#f7f7f8}
+.sidebarblock .literalblock pre,.sidebarblock .listingblock pre:not(.highlight),.sidebarblock .listingblock pre[class="highlight"],.sidebarblock .listingblock pre[class^="highlight "],.sidebarblock .listingblock pre.CodeRay,.sidebarblock .listingblock pre.prettyprint{background:#f2f1f1}
+.literalblock pre,.literalblock pre[class],.listingblock pre,.listingblock pre[class]{-webkit-border-radius:4px;border-radius:4px;word-wrap:break-word;padding:1em;font-size:.8125em}
+.literalblock pre.nowrap,.literalblock pre[class].nowrap,.listingblock pre.nowrap,.listingblock pre[class].nowrap{overflow-x:auto;white-space:pre;word-wrap:normal}
+@media only screen and (min-width:768px){.literalblock pre,.literalblock pre[class],.listingblock pre,.listingblock pre[class]{font-size:.90625em}}
+@media only screen and (min-width:1280px){.literalblock pre,.literalblock pre[class],.listingblock pre,.listingblock pre[class]{font-size:1em}}
+.literalblock.output pre{color:#f7f7f8;background-color:rgba(0,0,0,.9)}
+.listingblock pre.highlightjs{padding:0}
+.listingblock pre.highlightjs>code{padding:1em;-webkit-border-radius:4px;border-radius:4px}
+.listingblock pre.prettyprint{border-width:0}
+.listingblock>.content{position:relative}
+.listingblock code[data-lang]:before{display:none;content:attr(data-lang);position:absolute;font-size:.75em;top:.425rem;right:.5rem;line-height:1;text-transform:uppercase;color:#999}
+.listingblock:hover code[data-lang]:before{display:block}
+.listingblock.terminal pre .command:before{content:attr(data-prompt);padding-right:.5em;color:#999}
+.listingblock.terminal pre .command:not([data-prompt]):before{content:"$"}
+table.pyhltable{border-collapse:separate;border:0;margin-bottom:0;background:none}
+table.pyhltable td{vertical-align:top;padding-top:0;padding-bottom:0;line-height:1.45}
+table.pyhltable td.code{padding-left:.75em;padding-right:0}
+pre.pygments .lineno,table.pyhltable td:not(.code){color:#999;padding-left:0;padding-right:.5em;border-right:1px solid #ddddd8}
+pre.pygments .lineno{display:inline-block;margin-right:.25em}
+table.pyhltable .linenodiv{background:none!important;padding-right:0!important}
+.quoteblock{margin:0 1em 1.25em 1.5em;display:table}
+.quoteblock>.title{margin-left:-1.5em;margin-bottom:.75em}
+.quoteblock blockquote,.quoteblock blockquote p{color:rgba(0,0,0,.85);font-size:1.15rem;line-height:1.75;word-spacing:.1em;letter-spacing:0;font-style:italic;text-align:justify}
+.quoteblock blockquote{margin:0;padding:0;border:0}
+.quoteblock blockquote:before{content:"\201c";float:left;font-size:2.75em;font-weight:bold;line-height:.6em;margin-left:-.6em;color:#7a2518;text-shadow:0 1px 2px rgba(0,0,0,.1)}
+.quoteblock blockquote>.paragraph:last-child p{margin-bottom:0}
+.quoteblock .attribution{margin-top:.5em;margin-right:.5ex;text-align:right}
+.quoteblock .quoteblock{margin-left:0;margin-right:0;padding:.5em 0;border-left:3px solid rgba(0,0,0,.6)}
+.quoteblock .quoteblock blockquote{padding:0 0 0 .75em}
+.quoteblock .quoteblock blockquote:before{display:none}
+.verseblock{margin:0 1em 1.25em 1em}
+.verseblock pre{font-family:"Open Sans","DejaVu Sans",sans;font-size:1.15rem;color:rgba(0,0,0,.85);font-weight:300;text-rendering:optimizeLegibility}
+.verseblock pre strong{font-weight:400}
+.verseblock .attribution{margin-top:1.25rem;margin-left:.5ex}
+.quoteblock .attribution,.verseblock .attribution{font-size:.9375em;line-height:1.45;font-style:italic}
+.quoteblock .attribution br,.verseblock .attribution br{display:none}
+.quoteblock .attribution cite,.verseblock .attribution cite{display:block;letter-spacing:-.025em;color:rgba(0,0,0,.6)}
+.quoteblock.abstract{margin:0 0 1.25em 0;display:block}
+.quoteblock.abstract blockquote,.quoteblock.abstract blockquote p{text-align:left;word-spacing:0}
+.quoteblock.abstract blockquote:before,.quoteblock.abstract blockquote p:first-of-type:before{display:none}
+table.tableblock{max-width:100%;border-collapse:separate}
+table.tableblock td>.paragraph:last-child p>p:last-child,table.tableblock th>p:last-child,table.tableblock td>p:last-child{margin-bottom:0}
+table.tableblock,th.tableblock,td.tableblock{border:0 solid #dedede}
+table.grid-all th.tableblock,table.grid-all td.tableblock{border-width:0 1px 1px 0}
+table.grid-all tfoot>tr>th.tableblock,table.grid-all tfoot>tr>td.tableblock{border-width:1px 1px 0 0}
+table.grid-cols th.tableblock,table.grid-cols td.tableblock{border-width:0 1px 0 0}
+table.grid-all *>tr>.tableblock:last-child,table.grid-cols *>tr>.tableblock:last-child{border-right-width:0}
+table.grid-rows th.tableblock,table.grid-rows td.tableblock{border-width:0 0 1px 0}
+table.grid-all tbody>tr:last-child>th.tableblock,table.grid-all tbody>tr:last-child>td.tableblock,table.grid-all thead:last-child>tr>th.tableblock,table.grid-rows tbody>tr:last-child>th.tableblock,table.grid-rows tbody>tr:last-child>td.tableblock,table.grid-rows thead:last-child>tr>th.tableblock{border-bottom-width:0}
+table.grid-rows tfoot>tr>th.tableblock,table.grid-rows tfoot>tr>td.tableblock{border-width:1px 0 0 0}
+table.frame-all{border-width:1px}
+table.frame-sides{border-width:0 1px}
+table.frame-topbot{border-width:1px 0}
+th.halign-left,td.halign-left{text-align:left}
+th.halign-right,td.halign-right{text-align:right}
+th.halign-center,td.halign-center{text-align:center}
+th.valign-top,td.valign-top{vertical-align:top}
+th.valign-bottom,td.valign-bottom{vertical-align:bottom}
+th.valign-middle,td.valign-middle{vertical-align:middle}
+table thead th,table tfoot th{font-weight:bold}
+tbody tr th{display:table-cell;line-height:1.6;background:#f7f8f7}
+tbody tr th,tbody tr th p,tfoot tr th,tfoot tr th p{color:rgba(0,0,0,.8);font-weight:bold}
+p.tableblock>code:only-child{background:none;padding:0}
+p.tableblock{font-size:1em}
+td>div.verse{white-space:pre}
+ol{margin-left:1.75em}
+ul li ol{margin-left:1.5em}
+dl dd{margin-left:1.125em}
+dl dd:last-child,dl dd:last-child>:last-child{margin-bottom:0}
+ol>li p,ul>li p,ul dd,ol dd,.olist .olist,.ulist .ulist,.ulist .olist,.olist .ulist{margin-bottom:.625em}
+ul.unstyled,ol.unnumbered,ul.checklist,ul.none{list-style-type:none}
+ul.unstyled,ol.unnumbered,ul.checklist{margin-left:.625em}
+ul.checklist li>p:first-child>.fa-square-o:first-child,ul.checklist li>p:first-child>.fa-check-square-o:first-child{width:1em;font-size:.85em}
+ul.checklist li>p:first-child>input[type="checkbox"]:first-child{width:1em;position:relative;top:1px}
+ul.inline{margin:0 auto .625em auto;margin-left:-1.375em;margin-right:0;padding:0;list-style:none;overflow:hidden}
+ul.inline>li{list-style:none;float:left;margin-left:1.375em;display:block}
+ul.inline>li>*{display:block}
+.unstyled dl dt{font-weight:400;font-style:normal}
+ol.arabic{list-style-type:decimal}
+ol.decimal{list-style-type:decimal-leading-zero}
+ol.loweralpha{list-style-type:lower-alpha}
+ol.upperalpha{list-style-type:upper-alpha}
+ol.lowerroman{list-style-type:lower-roman}
+ol.upperroman{list-style-type:upper-roman}
+ol.lowergreek{list-style-type:lower-greek}
+.hdlist>table,.colist>table{border:0;background:none}
+.hdlist>table>tbody>tr,.colist>table>tbody>tr{background:none}
+td.hdlist1,td.hdlist2{vertical-align:top;padding:0 .625em}
+td.hdlist1{font-weight:bold;padding-bottom:1.25em}
+.literalblock+.colist,.listingblock+.colist{margin-top:-.5em}
+.colist>table tr>td:first-of-type{padding:0 .75em;line-height:1}
+.colist>table tr>td:last-of-type{padding:.25em 0}
+.thumb,.th{line-height:0;display:inline-block;border:solid 4px #fff;-webkit-box-shadow:0 0 0 1px #ddd;box-shadow:0 0 0 1px #ddd}
+.imageblock.left,.imageblock[style*="float: left"]{margin:.25em .625em 1.25em 0}
+.imageblock.right,.imageblock[style*="float: right"]{margin:.25em 0 1.25em .625em}
+.imageblock>.title{margin-bottom:0}
+.imageblock.thumb,.imageblock.th{border-width:6px}
+.imageblock.thumb>.title,.imageblock.th>.title{padding:0 .125em}
+.image.left,.image.right{margin-top:.25em;margin-bottom:.25em;display:inline-block;line-height:0}
+.image.left{margin-right:.625em}
+.image.right{margin-left:.625em}
+a.image{text-decoration:none;display:inline-block}
+a.image object{pointer-events:none}
+sup.footnote,sup.footnoteref{font-size:.875em;position:static;vertical-align:super}
+sup.footnote a,sup.footnoteref a{text-decoration:none}
+sup.footnote a:active,sup.footnoteref a:active{text-decoration:underline}
+#footnotes{padding-top:.75em;padding-bottom:.75em;margin-bottom:.625em}
+#footnotes hr{width:20%;min-width:6.25em;margin:-.25em 0 .75em 0;border-width:1px 0 0 0}
+#footnotes .footnote{padding:0 .375em 0 .225em;line-height:1.3334;font-size:.875em;margin-left:1.2em;text-indent:-1.05em;margin-bottom:.2em}
+#footnotes .footnote a:first-of-type{font-weight:bold;text-decoration:none}
+#footnotes .footnote:last-of-type{margin-bottom:0}
+#content #footnotes{margin-top:-.625em;margin-bottom:0;padding:.75em 0}
+.gist .file-data>table{border:0;background:#fff;width:100%;margin-bottom:0}
+.gist .file-data>table td.line-data{width:99%}
+div.unbreakable{page-break-inside:avoid}
+.big{font-size:larger}
+.small{font-size:smaller}
+.underline{text-decoration:underline}
+.overline{text-decoration:overline}
+.line-through{text-decoration:line-through}
+.aqua{color:#00bfbf}
+.aqua-background{background-color:#00fafa}
+.black{color:#000}
+.black-background{background-color:#000}
+.blue{color:#0000bf}
+.blue-background{background-color:#0000fa}
+.fuchsia{color:#bf00bf}
+.fuchsia-background{background-color:#fa00fa}
+.gray{color:#606060}
+.gray-background{background-color:#7d7d7d}
+.green{color:#006000}
+.green-background{background-color:#007d00}
+.lime{color:#00bf00}
+.lime-background{background-color:#00fa00}
+.maroon{color:#600000}
+.maroon-background{background-color:#7d0000}
+.navy{color:#000060}
+.navy-background{background-color:#00007d}
+.olive{color:#606000}
+.olive-background{background-color:#7d7d00}
+.purple{color:#600060}
+.purple-background{background-color:#7d007d}
+.red{color:#bf0000}
+.red-background{background-color:#fa0000}
+.silver{color:#909090}
+.silver-background{background-color:#bcbcbc}
+.teal{color:#006060}
+.teal-background{background-color:#007d7d}
+.white{color:#bfbfbf}
+.white-background{background-color:#fafafa}
+.yellow{color:#bfbf00}
+.yellow-background{background-color:#fafa00}
+span.icon>.fa{cursor:default}
+.admonitionblock td.icon [class^="fa icon-"]{font-size:2.5em;text-shadow:1px 1px 2px rgba(0,0,0,.5);cursor:default}
+.admonitionblock td.icon .icon-note:before{content:"\f05a";color:#19407c}
+.admonitionblock td.icon .icon-tip:before{content:"\f0eb";text-shadow:1px 1px 2px rgba(155,155,0,.8);color:#111}
+.admonitionblock td.icon .icon-warning:before{content:"\f071";color:#bf6900}
+.admonitionblock td.icon .icon-caution:before{content:"\f06d";color:#bf3400}
+.admonitionblock td.icon .icon-important:before{content:"\f06a";color:#bf0000}
+.conum[data-value]{display:inline-block;color:#fff!important;background-color:rgba(0,0,0,.8);-webkit-border-radius:100px;border-radius:100px;text-align:center;font-size:.75em;width:1.67em;height:1.67em;line-height:1.67em;font-family:"Open Sans","DejaVu Sans",sans-serif;font-style:normal;font-weight:bold}
+.conum[data-value] *{color:#fff!important}
+.conum[data-value]+b{display:none}
+.conum[data-value]:after{content:attr(data-value)}
+pre .conum[data-value]{position:relative;top:-.125em}
+b.conum *{color:inherit!important}
+.conum:not([data-value]):empty{display:none}
+dt,th.tableblock,td.content,div.footnote{text-rendering:optimizeLegibility}
+h1,h2,p,td.content,span.alt{letter-spacing:-.01em}
+p strong,td.content strong,div.footnote strong{letter-spacing:-.005em}
+p,blockquote,dt,td.content,span.alt{font-size:1.0625rem}
+p{margin-bottom:1.25rem}
+.sidebarblock p,.sidebarblock dt,.sidebarblock td.content,p.tableblock{font-size:1em}
+.exampleblock>.content{background-color:#fffef7;border-color:#e0e0dc;-webkit-box-shadow:0 1px 4px #e0e0dc;box-shadow:0 1px 4px #e0e0dc}
+.print-only{display:none!important}
+@media print{@page{margin:1.25cm .75cm}
+*{-webkit-box-shadow:none!important;box-shadow:none!important;text-shadow:none!important}
+a{color:inherit!important;text-decoration:underline!important}
+a.bare,a[href^="#"],a[href^="mailto:"]{text-decoration:none!important}
+a[href^="http:"]:not(.bare):after,a[href^="https:"]:not(.bare):after{content:"(" attr(href) ")";display:inline-block;font-size:.875em;padding-left:.25em}
+abbr[title]:after{content:" (" attr(title) ")"}
+pre,blockquote,tr,img,object,svg{page-break-inside:avoid}
+thead{display:table-header-group}
+svg{max-width:100%}
+p,blockquote,dt,td.content{font-size:1em;orphans:3;widows:3}
+h2,h3,#toctitle,.sidebarblock>.content>.title{page-break-after:avoid}
+#toc,.sidebarblock,.exampleblock>.content{background:none!important}
+#toc{border-bottom:1px solid #ddddd8!important;padding-bottom:0!important}
+.sect1{padding-bottom:0!important}
+.sect1+.sect1{border:0!important}
+#header>h1:first-child{margin-top:1.25rem}
+body.book #header{text-align:center}
+body.book #header>h1:first-child{border:0!important;margin:2.5em 0 1em 0}
+body.book #header .details{border:0!important;display:block;padding:0!important}
+body.book #header .details span:first-child{margin-left:0!important}
+body.book #header .details br{display:block}
+body.book #header .details br+span:before{content:none!important}
+body.book #toc{border:0!important;text-align:left!important;padding:0!important;margin:0!important}
+body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-break-before:always}
+.listingblock code[data-lang]:before{display:block}
+#footer{background:none!important;padding:0 .9375em}
+#footer-text{color:rgba(0,0,0,.6)!important;font-size:.9em}
+.hide-on-print{display:none!important}
+.print-only{display:block!important}
+.hide-for-print{display:none!important}
+.show-for-print{display:inherit!important}}
+</style>
+</head>
+<body class="article">
+<div id="header">
+<h1><a href="./module.yaml">jboss.container.s2i.core.api</a></h1>
+</div>
+<div id="content">
+<div id="preamble">
+<div class="sectionbody">
+<div class="paragraph">
+<p>Defines environment variables and labels used by s2i.</p>
+</div>
+<div id="toc" class="toc">
+<div id="toctitle" class="title">Table of Contents</div>
+<ul class="sectlevel1">
+<li><a href="#_labels">Labels</a></li>
+<li><a href="#_environment_variables">Environment Variables</a></li>
+<li><a href="#_resources">Resources</a></li>
+<li><a href="#_rpm_packages">RPM Packages</a>
+<ul class="sectlevel2">
+<li><a href="#_installed_rpm_packages">Installed RPM Packages</a></li>
+<li><a href="#_rpm_package_repositories">RPM Package Repositories</a></li>
+</ul>
+</li>
+<li><a href="#_modules">Modules</a>
+<ul class="sectlevel2">
+<li><a href="#_included_modules">Included Modules</a></li>
+<li><a href="#_module_repositories">Module Repositories</a></li>
+</ul>
+</li>
+</ul>
+</div>
+</div>
+</div>
+<div class="sect1">
+<h2 id="_labels">Labels</h2>
+<div class="sectionbody">
+<div class="paragraph">
+<p>The following labels will be defined on the image:</p>
+</div>
+<div class="dlist">
+<dl>
+<dt class="hdlist1">io.openshift.s2i.destination</dt>
+<dd>
+<p>/tmp</p>
+</dd>
+<dt class="hdlist1">io.openshift.s2i.scripts-url</dt>
+<dd>
+<p>image:///usr/local/s2i</p>
+</dd>
+<dt class="hdlist1">org.jboss.container.deployments-dir</dt>
+<dd>
+<p>/deployments</p>
+</dd>
+</dl>
+</div>
+</div>
+</div>
+<div class="sect1">
+<h2 id="_environment_variables">Environment Variables</h2>
+<div class="sectionbody">
+<div class="paragraph">
+<p>The following environment variables are used to configure the functionality provided by this module:</p>
+</div>
+<table class="tableblock frame-all grid-all spread">
+<colgroup>
+<col style="width: 33.3333%;">
+<col style="width: 33.3333%;">
+<col style="width: 33.3334%;">
+</colgroup>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Name</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Description</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Example</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock">S2I_ARTIFACTS_DIR</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">^ Location mount for artifacts persisted with <strong>save-artifacts</strong> script, which are used with incremental builds.  This should not be overridden by end users.</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">${S2I_DESTINATION_DIR}/artifacts}</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock">S2I_DESTINATION_DIR</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">^ Root directory for S2I mount, as specified by the <strong>io.openshift.s2i.destination</strong> label.  This should not be overridden by end users.</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">/tmp</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock">S2I_IMAGE_SOURCE_MOUNTS</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">^ Comma separated list of relative paths in source directory which should be included in the image.  List may include wildcards, which are expanded using find.  By default, the contents of mounted directories are processed similarly to source folders, where the contents of $S2I_SOURCE_CONFIGURATION_DIR, $S2I_SOURCE_DATA_DIR, and $S2I_SOURCE_DEPLOYMENTS_DIR are copied to their respective target directories.  Alternatively, if an <strong>install.sh</strong> file is located in the root of the mount point, it is executed instead.  Deprecates CUSTOM_INSTALL_DIRECTORIES.</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">extras/*</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock">S2I_SOURCE_CONFIGURATION_DIR</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">^ Relative path to directory containing application configuration files to be copied over to the product configuration directory, see <strong>S2I_TARGET_CONFIGURATION_DIR</strong>.  Defaults to <strong>configuration</strong>.</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">configuration</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock">S2I_SOURCE_DATA_DIR</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">^ Relative path to directory containing application data files to be copied over to the product data directory, see <strong>S2I_TARGET_DATA_DIR</strong>.  Defaults to <strong>data</strong>.</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">data</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock">S2I_SOURCE_DEPLOYMENTS_DIR</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">^ Relative path to directory containing binary files to be copied over to the product deployment directory, see <strong>S2I_TARGET_DEPLOYMENTS_DIR</strong>.  Defaults to <strong>deployments</strong>.</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">deployments</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock">S2I_SOURCE_DIR</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">^ Location of mount for source code to be built.  This should not be overridden by end users.</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">${S2I_DESTINATION_DIR}/src}</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock">S2I_TARGET_CONFIGURATION_DIR</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">^ Absolute path to which files located in $S2I_SOURCE_DIR/$S2I_SOURCE_CONFIGURATION_DIR are copied.</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">/opt/eap/standalone/configuration</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock">S2I_TARGET_DATA_DIR</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">^ Absolute path to which files located in $S2I_SOURCE_DIR/$S2I_SOURCE_DATA_DIR are copied.</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">/opt/eap/standalone/data</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock">S2I_TARGET_DEPLOYMENTS_DIR</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">^ Absolute path to which files located in $S2I_SOURCE_DIR/$S2I_SOURCE_DEPLOYMENTS_DIR are copied. Additionally, this is the directory to which build output is copied</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">/deployments</p></td>
+</tr>
+</tbody>
+</table>
+<div class="paragraph">
+<p>The following environment variables will be configured on the image:</p>
+</div>
+<table class="tableblock frame-all grid-all spread">
+<colgroup>
+<col style="width: 50%;">
+<col style="width: 50%;">
+</colgroup>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Name</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Value</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+</div>
+<div class="sect1">
+<h2 id="_resources">Resources</h2>
+<div class="sectionbody">
+<div class="paragraph">
+<p>No additional resources will be installed through this module.</p>
+</div>
+</div>
+</div>
+<div class="sect1">
+<h2 id="_rpm_packages">RPM Packages</h2>
+<div class="sectionbody">
+<div class="sect2">
+<h3 id="_installed_rpm_packages">Installed RPM Packages</h3>
+<div class="paragraph">
+<p>No RPMs will be installed by this module.</p>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_rpm_package_repositories">RPM Package Repositories</h3>
+<div class="paragraph">
+<p>No additional RPM package repositories are required to install listed RPMs.</p>
+</div>
+</div>
+</div>
+</div>
+<div class="sect1">
+<h2 id="_modules">Modules</h2>
+<div class="sectionbody">
+<div class="sect2">
+<h3 id="_included_modules">Included Modules</h3>
+<div class="paragraph">
+<p>No additional modules will be installed through this module.</p>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_module_repositories">Module Repositories</h3>
+<div class="paragraph">
+<p>No module repositories defined.</p>
+</div>
+</div>
+</div>
+</div>
+</div>
+<div id="footer">
+<div id="footer-text">
+Last updated 2018-07-12 12:06:35 BST
+</div>
+</div>
+</body>
+</html>

--- a/modules/s2i-runtime/core/api/module.yaml
+++ b/modules/s2i-runtime/core/api/module.yaml
@@ -1,0 +1,116 @@
+schema_version: 1
+name: jboss.container.s2i-runtime.core.api
+version: '1.0'
+description: ^
+  Defines environment variables and labels used by S2I.  Modules implementing
+  S2I capabilities should use these variables accordingly.
+
+labels:
+- name: "io.openshift.s2i.scripts-url"
+  value: "image:///usr/local/s2i"
+- name: io.openshift.s2i.destination
+  value: "/tmp"
+- name: org.jboss.container.deployments-dir
+  value: "/deployments"
+
+envs:
+- name: S2I_DESTINATION_DIR
+  description: ^
+    Root directory for S2I mount, as specified by the
+    **io.openshift.s2i.destination** label.  This should not be overridden by
+    end users.
+  example: /tmp
+
+- name: S2I_ARTIFACTS_DIR
+  description: ^
+    Location mount for artifacts persisted with **save-artifacts** script, which
+    are used with incremental builds.  This should not be overridden by end users.
+  example: "${S2I_DESTINATION_DIR}/artifacts}"
+
+- name: S2I_SOURCE_DIR
+  description: ^
+    Location of mount for source code to be built.  This should not be
+    overridden by end users.
+  example: "${S2I_DESTINATION_DIR}/src}"
+
+- name: S2I_SOURCE_CONFIGURATION_DIR
+  description: ^
+    Relative path to directory containing application configuration files to be
+    copied over to the product configuration directory, see
+    **S2I_TARGET_CONFIGURATION_DIR**.  Defaults to **configuration**.
+  example: configuration
+
+- name: S2I_TARGET_CONFIGURATION_DIR
+  description: ^
+    Absolute path to which files located in
+    $S2I_SOURCE_DIR/$S2I_SOURCE_CONFIGURATION_DIR are copied.
+  example: /opt/eap/standalone/configuration
+
+- name: S2I_SOURCE_DATA_DIR
+  description: ^
+    Relative path to directory containing application data files to be copied
+    over to the product data directory, see **S2I_TARGET_DATA_DIR**.  Defaults
+    to **data**.
+  example: data
+
+- name: S2I_TARGET_DATA_DIR
+  description: ^
+    Absolute path to which files located in
+    $S2I_SOURCE_DIR/$S2I_SOURCE_DATA_DIR are copied.
+  example: /opt/eap/standalone/data
+
+- name: S2I_SOURCE_DEPLOYMENTS_DIR
+  description: ^
+    Relative path to directory containing binary files to be copied over to the
+    product deployment directory, see **S2I_TARGET_DEPLOYMENTS_DIR**.  Defaults
+    to **deployments**.
+  example: deployments
+
+- name: S2I_SOURCE_DEPLOYMENTS_FILTER
+  description: >
+    Space separated list of filters to be applied when copying deployments.
+    Defaults to ** * **
+  value: "*"
+  example: "*.jar *.war *.ear"
+
+- name: S2I_TARGET_DEPLOYMENTS_DIR
+  description: ^
+    Absolute path to which files located in
+    $S2I_SOURCE_DIR/$S2I_SOURCE_DEPLOYMENTS_DIR are copied. Additionally, this
+    is the directory to which build output is copied
+  example: /deployments
+
+- name: S2I_IMAGE_SOURCE_MOUNTS
+  description: ^
+    Comma separated list of relative paths in source directory which should be
+    included in the image.  List may include wildcards, which are expanded
+    using find.  By default, the contents of mounted directories are processed
+    similarly to source folders, where the contents of
+    $S2I_SOURCE_CONFIGURATION_DIR, $S2I_SOURCE_DATA_DIR, and
+    $S2I_SOURCE_DEPLOYMENTS_DIR are copied to their respective target
+    directories.  Alternatively, if an **install.sh** file is located in the
+    root of the mount point, it is executed instead.  Deprecates
+    CUSTOM_INSTALL_DIRECTORIES.
+  example: extras/*
+
+- name: S2I_ENABLE_INCREMENTAL_BUILDS
+  description: ^
+    Do not remove source and intermediate build files so they can be saved for
+    use with future builds.  Defaults to true.
+  example: "true"
+
+# deprecated
+- name: APP_DATADIR
+  description: Deprecated by **S2I_SOURCE_DATA_DIR**.
+- name: DEPLOYMENTS_DIR
+  description: Deprecated by **S2I_TARGET_DEPLOYMENTS_DIR**.
+- name: DATA_DIR
+  description: Deprecated by **S2I_TARGET_DATA_DIR**.
+- name: JAVA_DATA_DIR
+  description: Deprecated by **S2I_TARGET_DATA_DIR**.
+- name: CUSTOM_INSTALL_DIRECTORIES
+  description: Deprecated by **S2I_IMAGE_SOURCE_MOUNTS**.
+
+run:
+  cmd:
+  - "/usr/local/s2i/run"

--- a/modules/s2i-runtime/core/bash/artifacts/opt/jboss/container/s2i/core/s2i-core
+++ b/modules/s2i-runtime/core/bash/artifacts/opt/jboss/container/s2i/core/s2i-core
@@ -1,0 +1,159 @@
+# include dependencies
+source "${JBOSS_CONTAINER_UTIL_LOGGING_MODULE}/logging.sh"
+
+# initializes the environment used by common s2i_core_*() functions
+function s2i_core_init() {
+  # ensure all files are created with correct permissions for runtime
+  umask ug+rwx
+
+  # initialize core s2i environmet variables
+  s2i_core_env_init
+  
+  # setup file permissions for injected content
+  if [ -d "${S2I_ARTIFACTS_DIR}" ]; then
+    chmod -R ug+rwX "${S2I_ARTIFACTS_DIR}"
+  fi
+  if [ -d "${S2I_SOURCE_DIR}" ]; then
+    chmod -R ug+rwX "${S2I_SOURCE_DIR}"
+  fi
+}
+
+function s2i_core_env_init() {
+  # initialize core s2i environmet variables
+  s2i_core_env_init_hook
+  S2I_DESTINATION_DIR="${S2I_DESTINATION_DIR:-/tmp}"
+  S2I_ARTIFACTS_DIR="${S2I_DESTINATION_DIR}/artifacts"
+  S2I_SOURCE_DIR="${S2I_DESTINATION_DIR}/src"
+  S2I_SOURCE_CONFIGURATION_DIR="${S2I_SOURCE_CONFIGURATION_DIR:-configuration}"
+  S2I_SOURCE_DATA_DIR="${S2I_SOURCE_DATA_DIR:-${APP_DATADIR:-data}}"
+  S2I_SOURCE_DEPLOYMENTS_DIR="${S2I_SOURCE_DEPLOYMENTS_DIR:-deployments}"
+  S2I_TARGET_DEPLOYMENTS_DIR="${S2I_TARGET_DEPLOYMENTS_DIR:-${DEPLOYMENTS_DIR:-/deployments}}"
+  S2I_TARGET_CONFIGURATION_DIR="${S2I_TARGET_CONFIGURATION_DIR:-${S2I_TARGET_DEPLOYMENTS_DIR}}"
+  S2I_TARGET_DATA_DIR="${S2I_TARGET_DATA_DIR:-${JAVA_DATA_DIR:-${DATA_DIR:-${S2I_TARGET_DEPLOYMENTS_DIR}}}}"
+  S2I_IMAGE_SOURCE_MOUNTS="${S2I_IMAGE_SOURCE_MOUNTS:-${CUSTOM_INSTALL_DIRECTORIES}}"
+  S2I_ENABLE_INCREMENTAL_BUILDS="${S2I_ENABLE_INCREMENTAL_BUILDS:-true}"
+  
+  s2i_core_env_backward_compatibility
+}
+
+# extensions may override this method to initialize environment variables
+# to suit their own needs.
+function s2i_core_env_init_hook() {
+  : 
+}
+
+# make sure any "old" variables are setup appropriately
+function s2i_core_env_backward_compatibility() {
+  export APP_DATADIR="$S2I_SOURCE_DATA_DIR"
+  export DEPLOYMENTS_DIR="$S2I_TARGET_DEPLOYMENTS_DIR"
+  export DATA_DIR="$S2I_TARGET_DATA_DIR"
+  export JAVA_DATA_DIR="$S2I_TARGET_DATA_DIR"
+  export CUSTOM_INSTALL_DIRECTORIES="$S2I_IMAGE_SOURCE_MOUNTS"
+}
+
+# copy configuration files
+# $1 - the base directory to which $S2I_SOURCE_CONFIGURATION_DIR is appended
+function s2i_core_copy_configuration() {
+  if [ -d "${1}/${S2I_SOURCE_CONFIGURATION_DIR}" ]; then
+    if [ -z "${S2I_TARGET_CONFIGURATION_DIR}" ]; then
+      log_warning "Unable to copy configuration files.  No target directory specified for S2I_TARGET_CONFIGURATION_DIR"
+    else
+      if [ ! -d "${S2I_TARGET_CONFIGURATION_DIR}" ]; then
+        log_info "S2I_TARGET_CONFIGURATION_DIR does not exist, creating ${S2I_TARGET_CONFIGURATION_DIR}"
+        mkdir -pm 775 "${S2I_TARGET_CONFIGURATION_DIR}"
+      fi
+      log_info "Copying configuration from $(realpath --relative-to ${S2I_SOURCE_DIR} ${1}/${S2I_SOURCE_CONFIGURATION_DIR}) to ${S2I_TARGET_CONFIGURATION_DIR}..."
+      rsync -rl --out-format='%n' "${1}/${S2I_SOURCE_CONFIGURATION_DIR}"/ "${S2I_TARGET_CONFIGURATION_DIR}"
+    fi
+  fi 
+}
+
+# copy data files
+# $1 - the base directory to which $S2I_SOURCE_DATA_DIR is appended
+function s2i_core_copy_data() {
+  if [ -d "${1}/${S2I_SOURCE_DATA_DIR}" ]; then
+    if [ -z "${S2I_TARGET_DATA_DIR}" ]; then
+      log_warning "Unable to copy data files.  No target directory specified for S2I_TARGET_DATA_DIR"
+    else
+      if [ ! -d "${S2I_TARGET_DATA_DIR}" ]; then
+        log_info "S2I_TARGET_DATA_DIR does not exist, creating ${S2I_TARGET_DATA_DIR}"
+        mkdir -pm 775 "${S2I_TARGET_DATA_DIR}"
+      fi
+      log_info "Copying app data from $(realpath --relative-to ${S2I_SOURCE_DIR} ${1}/${S2I_SOURCE_DATA_DIR}) to ${S2I_TARGET_DATA_DIR}..."
+      rsync -rl --out-format='%n' "${1}/${S2I_SOURCE_DATA_DIR}"/ "${S2I_TARGET_DATA_DIR}"
+      # s2i used to be more forgiving, but the build will fail if this call
+      # fails.  emit a warning and allow the build to succeed
+      chmod -R g+rwX "${S2I_TARGET_DATA_DIR}" || log_warning "Errors occurred while adding read/write permissions to S2I_TARGET_DATA_DIR ($S2I_TARGET_DATA_DIR)."
+    fi
+  fi 
+}
+
+# copy deployment (binary) files
+# $1 - the base directory to which $S2I_SOURCE_DEPLOYMENTS_DIR is appended
+function s2i_core_copy_deployments() {
+  if [ -d "${1}/${S2I_SOURCE_DEPLOYMENTS_DIR}" ]; then
+    if [ -z "${S2I_TARGET_DEPLOYMENTS_DIR}" ]; then
+      log_warning "Unable to copy deployment files.  No target directory specified for S2I_TARGET_DEPLOYMENTS_DIR"
+    else
+      if [ ! -d "${S2I_TARGET_DEPLOYMENTS_DIR}" ]; then
+        log_info "S2I_TARGET_DEPLOYMENTS_DIR does not exist, creating ${S2I_TARGET_DEPLOYMENTS_DIR}"
+        mkdir -pm 775 "${S2I_TARGET_DEPLOYMENTS_DIR}"
+      fi
+      local relative_source=$(realpath --relative-to "${S2I_SOURCE_DIR}" "${1}/${S2I_SOURCE_DEPLOYMENTS_DIR}")
+      log_info "Copying deployments from $relative_source to ${S2I_TARGET_DEPLOYMENTS_DIR}..."
+      for filter in ${S2I_SOURCE_DEPLOYMENTS_FILTER:-*}; do
+        find "${S2I_SOURCE_DIR}/${relative_source}/" -maxdepth 1 -name "${filter}" | xargs -I '{}' -r cp -Lrv '{}' "${S2I_TARGET_DEPLOYMENTS_DIR}"
+      done
+    fi
+  fi 
+}
+
+# extension may override this method to provide additional copy functions
+# $1 - the base directory
+function s2i_core_copy_artifacts_hook() {
+  :
+}
+
+# main entry point for copying artifacts from the build to the target
+# $1 - the base directory
+function s2i_core_copy_artifacts() {
+  s2i_core_copy_configuration $*
+  s2i_core_copy_data $*
+  s2i_core_copy_deployments $*
+  s2i_core_copy_artifacts_hook $*
+}
+
+# processes any directories mounted into the build.  see S2I_IMAGE_SOURCE_MOUNTS
+function s2i_core_process_image_mounts() {
+  if [ "x${S2I_IMAGE_SOURCE_MOUNTS}" = "x" ]; then
+    return 0
+  fi
+
+  log_info "Processing ImageSource mounts: $S2I_IMAGE_SOURCE_MOUNTS"
+  IFS=',' read -a install_dir_entries <<< $S2I_IMAGE_SOURCE_MOUNTS
+  for install_dir_entry in "${install_dir_entries[@]}"; do
+    for install_dir in $(find ${S2I_SOURCE_DIR}/$install_dir_entry -maxdepth 0 2>/dev/null); do
+      log_info "Processing ImageSource from $install_dir"
+      chmod -R ug+x ${install_dir}
+      if [ -f ${install_dir}/install.sh ]; then
+        ${install_dir}/install.sh "${install_dir}"
+      else
+        s2i_core_copy_artifacts "${install_dir}"
+      fi
+    done
+  done
+}
+
+function s2i_core_cleanup() {
+  if [ -n "$(find ${S2I_SOURCE_DIR} -maxdepth 0 -type d ! -empty 2> /dev/null)" ]; then
+    log_info "Cleaning up source directory (${S2I_SOURCE_DIR})"
+    rm -rf ${S2I_SOURCE_DIR}
+  fi
+  if [ "${S2I_ENABLE_INCREMENTAL_BUILDS,,}" == "true" ]; then
+    return 0
+  fi
+  if [ -n "$(find ${S2I_ARTIFACTS_DIR} -maxdepth 0 -type d ! -empty 2> /dev/null)" ]; then
+    log_info "Cleaning up artifacts directory (${S2I_ARTIFACTS_DIR})"
+    rm -rf ${S2I_ARTIFACTS_DIR}
+  fi
+}

--- a/modules/s2i-runtime/core/bash/configure.sh
+++ b/modules/s2i-runtime/core/bash/configure.sh
@@ -1,0 +1,22 @@
+#!/bin/sh
+# Configure module
+set -e
+
+SCRIPT_DIR=$(dirname $0)
+ARTIFACTS_DIR=${SCRIPT_DIR}/artifacts
+
+chown -R jboss:root $SCRIPT_DIR
+chmod -R ug+rwX $SCRIPT_DIR
+chmod ug+x ${ARTIFACTS_DIR}/opt/jboss/container/s2i/core/*
+
+pushd ${ARTIFACTS_DIR}
+cp -pr * /
+popd
+
+mkdir -p /usr/local/s2i \
+ && chmod 775 /usr/local/s2i \
+ && chown -R jboss:root /usr/local/s2i
+
+mkdir -p /deployments \
+ && chmod -R "ug+rwX" /deployments \
+ && chown -R jboss:root /deployments

--- a/modules/s2i-runtime/core/bash/module.yaml
+++ b/modules/s2i-runtime/core/bash/module.yaml
@@ -1,0 +1,19 @@
+schema_version: 1
+name: jboss.container.s2i-runtime.core.bash
+version: '1.0'
+description: "Provides support for core s2i capabilities."
+
+envs:
+- name: JBOSS_CONTAINER_S2I_CORE_MODULE
+  value: /opt/jboss/container/s2i/core/
+
+execute:
+- script: configure.sh
+
+modules:
+  install:
+  - name: jboss.container.s2i-runtime.core.api
+
+packages:
+  install:
+  - findutils

--- a/ubi8-openjdk-11-runtime.yaml
+++ b/ubi8-openjdk-11-runtime.yaml
@@ -39,6 +39,7 @@ modules:
   install:
   - name: jboss.container.openjdk.jre
     version: "11"
+  - name: jboss.container.java.s2i-runtime.bash
 
 help:
   add: true

--- a/ubi8-openjdk-8-runtime.yaml
+++ b/ubi8-openjdk-8-runtime.yaml
@@ -39,6 +39,7 @@ modules:
   install:
   - name: jboss.container.openjdk.jre
     version: "8"
+  - name: jboss.container.java.s2i-runtime.bash
 
 help:
   add: true


### PR DESCRIPTION
Could you please review the changes?
$ podman run --rm -ti localhost/ubi8/openjdk-8-runtime:latest rpm -qa | grep "java"
java-1.8.0-openjdk-headless-1.8.0.282.b08-2.el8_3.x86_64
tzdata-java-2021a-1.el8.noarch
javapackages-filesystem-5.3.0-1.module+el8+2447+6f56d9a6.noarch

$ podman run --rm -ti localhost/ubi8/openjdk-8-runtime:latest rpm -qa | grep "maven"
$ podman run --rm -ti localhost/ubi8/openjdk-8-runtime:latest rpm -qa | grep "prometheus"
$ podman run --rm -ti localhost/ubi8/openjdk-8-runtime:latest
Starting the Java application using /opt/jboss/container/java/run/run-java.sh ...
This is the Red Hat UBI8 OpenJDK 1.8 Runtime container.
  For usage, please see https://github.com/jboss-container-images/openjdk
