### PR TITLE
Changes to add CMD for runtime images

### DIFF
--- a/modules/jre/run/artifacts/opt/jboss/container/java/run
+++ b/modules/jre/run/artifacts/opt/jboss/container/java/run
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+# Start JVM
+startup() {
+  echo "This is the Red Hat UBI8 OpenJDK ${JAVA_VERSION} Runtime container."
+}
+
+# =============================================================================
+# Fire up
+startup $*

--- a/modules/jre/run/configure.sh
+++ b/modules/jre/run/configure.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+# Configure module
+set -e
+
+SCRIPT_DIR=$(dirname $0)
+ARTIFACTS_DIR=${SCRIPT_DIR}/artifacts
+
+chown -R jboss:root $SCRIPT_DIR
+chmod -R ug+rwX $SCRIPT_DIR
+chmod ug+x ${ARTIFACTS_DIR}/opt/jboss/container/java/*
+
+pushd ${ARTIFACTS_DIR}
+cp -pr * /
+popd
+
+mkdir -p /deployments/data \
+ && chmod -R "ug+rwX" /deployments/data \
+ && chown -R jboss:root /deployments/data

--- a/modules/jre/run/module.yaml
+++ b/modules/jre/run/module.yaml
@@ -1,0 +1,17 @@
+schema_version: 1
+name: jboss.container.java.jre.run
+version: '1.0'
+description: ^
+  Provides support for running Java applications.  Basic usage is
+  $JBOSS_CONTAINER_JAVA_RUN_MODULE/run-java.sh.
+
+envs:
+- name: JBOSS_CONTAINER_JAVA_RUN_MODULE
+  value: /opt/jboss/container/java/run
+
+execute:
+- script: configure.sh
+
+run:
+  cmd:
+  - "/opt/jboss/container/java/run"

--- a/ubi8-openjdk-11-runtime.yaml
+++ b/ubi8-openjdk-11-runtime.yaml
@@ -39,6 +39,7 @@ modules:
   install:
   - name: jboss.container.openjdk.jre
     version: "11"
+  - name: jboss.container.java.jre.run
 
 help:
   add: true

--- a/ubi8-openjdk-8-runtime.yaml
+++ b/ubi8-openjdk-8-runtime.yaml
@@ -39,6 +39,7 @@ modules:
   install:
   - name: jboss.container.openjdk.jre
     version: "8"
+  - name: jboss.container.java.jre.run
 
 help:
   add: true


### PR DESCRIPTION
***Could you please review the changes?***


# Case-1 : ubi8/openjdk-8-runtime
```
$ podman inspect --format "{{.Config.Cmd}}" localhost/ubi8/openjdk-8-runtime:latest
    [/opt/jboss/container/java/run]

$ podman run --rm -ti localhost/ubi8/openjdk-8-runtime:latest
    Starting the Java application using /opt/jboss/container/java/run/run-java.sh ...
    This is the Red Hat UBI8 OpenJDK 1.8.0 Runtime container.

$ podman run --rm -ti localhost/ubi8/openjdk-8-runtime:latest rpm -qa | grep "prometheus"
$ podman run --rm -ti localhost/ubi8/openjdk-8-runtime:latest rpm -qa | grep "maven"
$ podman run --rm -ti localhost/ubi8/openjdk-8-runtime:latest rpm -qa | grep "java"
    java-1.8.0-openjdk-headless-1.8.0.282.b08-2.el8_3.x86_64
    tzdata-java-2021a-1.el8.noarch
    javapackages-filesystem-5.3.0-1.module+el8+2447+6f56d9a6.noarch
```

# Case-2: ubi8/openjdk-11-runtime
```
$ podman inspect --format "{{.Config.Cmd}}" localhost/ubi8/openjdk-11-runtime:latest
    [/opt/jboss/container/java/run]

$ podman run --rm -ti localhost/ubi8/openjdk-11-runtime:latest
    Starting the Java application using /opt/jboss/container/java/run/run-java.sh ...
    This is the Red Hat UBI8 OpenJDK 11 Runtime container.

$ podman run --rm -ti localhost/ubi8/openjdk-11-runtime:latest rpm -qa | grep "maven"
$ podman run --rm -ti localhost/ubi8/openjdk-11-runtime:latest rpm -qa | grep "prometheus"
$ podman run --rm -ti localhost/ubi8/openjdk-11-runtime:latest rpm -qa | grep "java"
    javapackages-filesystem-5.3.0-1.module+el8+2447+6f56d9a6.noarch
    java-11-openjdk-headless-11.0.10.0.9-4.el8_3.x86_64
    tzdata-java-2021a-1.el8.noarch
```
Also, 
```
$ podman images --filter dangling=false
REPOSITORY                               TAG  		  SIZE
localhost/ubi8/openjdk-8-runtime         1.3              314 MB
localhost/ubi8/openjdk-8-runtime         latest           314 MB
localhost/ubi8/openjdk-11-runtime        latest           370 MB
localhost/ubi8/openjdk-11-runtime        1.3              370 MB
localhost/ubi8/openjdk-11                latest           474 MB
localhost/ubi8/openjdk-11                1.3              474 MB
localhost/ubi8/openjdk-8                 latest           479 MB
localhost/ubi8/openjdk-8                 1.3              479 MB
```