### PR TITLE
Revert GitHub workflows to ubuntu-18.04

### DIFF
--- a/.github/workflows/ubi8-openjdk-11.yml
+++ b/.github/workflows/ubi8-openjdk-11.yml
@@ -7,7 +7,7 @@ env:
 jobs:
   openjdkci:
     name: OpenJDK S2I Build and Test
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     strategy:
       fail-fast: false
     steps:

--- a/.github/workflows/ubi8-openjdk-8.yml
+++ b/.github/workflows/ubi8-openjdk-8.yml
@@ -7,7 +7,7 @@ env:
 jobs:
   openjdkci:
     name: OpenJDK S2I Build and Test
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     strategy:
       fail-fast: false
     steps:


### PR DESCRIPTION
ubuntu-latest points at ubuntu-20.04. Revert to 18.04 to fix CI for
the time being until we transition the configuration over.

This fixed CI in my fork.