### PR TITLE
Multistage-build with cekit to create JRE-headless runtime image.

### DIFF
--- a/ubi8-openjdk-8-runtime-multistage.yaml
+++ b/ubi8-openjdk-8-runtime-multistage.yaml
@@ -1,0 +1,56 @@
+# This is an Image descriptor for Cekit
+- from: "registry.access.redhat.com/ubi8/ubi-minimal"
+  name: &name "ubi8/openjdk-8-runtime"
+  version: &version "1.3"
+  description: "Image for Red Hat OpenShift providing OpenJDK 1.8 runtime"
+
+  labels:
+  - name: "io.k8s.description"
+    value: "Platform for running plain Java applications (fat-jar and flat classpath)"
+  - name: "io.k8s.display-name"
+    value: "Java Applications"
+  - name: "io.openshift.tags"
+    value: "java"
+  - name: "maintainer"
+    value: "Red Hat OpenJDK <openjdk@redhat.com>"
+  - name: "com.redhat.component"
+    value: "openjdk-8-runtime-ubi8-container"
+  - name: "usage"
+    value: "https://access.redhat.com/documentation/en-us/red_hat_jboss_middleware_for_openshift/3/html/red_hat_java_s2i_for_openshift/"
+  - name: "com.redhat.license_terms"
+    value: "https://www.redhat.com/en/about/red-hat-end-user-license-agreements#UBI"
+
+  envs:
+  - name: "JBOSS_IMAGE_NAME"
+    value: *name
+  - name: "JBOSS_IMAGE_VERSION"
+    value: *version
+
+  ports:
+  - value: 8080
+  - value: 8443
+
+  modules:
+    repositories:
+    - path: modules
+    install:
+    - name: jboss.container.openjdk.jre
+      version: "8"
+
+  help:
+    add: true
+
+  packages:
+    manager: microdnf
+
+- name: "ubi8/openjdk-8-runtime-multistage-build"
+  from: ubi8/openjdk-8-runtime
+  description: "Provides support for running Java applications.  Basic usage is
+  $JBOSS_CONTAINER_JAVA_RUN_MODULE/run-java.sh."
+  version: "1.0"
+
+  modules:
+    repositories:
+    - path: modules
+    install:
+    - name: jboss.container.java.jre.run


### PR DESCRIPTION
I have just made an attempt to get a multistage-build using cekit to create JRE headless RuntimeImage.
I myself feel there is lot to improve. Considering this as a starting point I am raising this PR. Could you please take a look?

This is how build went through:

```
$ cekit --redhat --descriptor ubi8-openjdk-8-runtime-multistage.yaml  build podman
2021-04-16 16:02:12,836 tools.py:238        INFO  You are running on known platform: Fedora 33 (Workstation Edition)
2021-04-16 16:02:12,930 builder.py:72         INFO  Generating files for podman engine
2021-04-16 16:02:12,930 base.py:63         INFO  Initializing image descriptor...
2021-04-16 16:02:12,936 base.py:98         INFO  Descriptor contains multiple elements, assuming multi-stage image
2021-04-16 16:02:12,936 base.py:99         INFO  Found 1 builder image(s) and one target image
.
.
.
Copying blob cd31316ad00b done  
Copying config ed5b3fc9b8 done  
Writing manifest to image destination
Storing signatures
--> ed5b3fc9b89
ed5b3fc9b89285b5a6b52adcb635ddf5701e7d7a5e17e149e871be7091f8fd2c
2021-04-16 16:02:38,856 podman.py:57         INFO  Image built and available under following tags: ubi8/openjdk-8-runtime-multistage-build:1.0, ubi8/openjdk-8-runtime-multistage-build:latest
2021-04-16 16:02:38,856 cli.py:336        INFO  Finished!

```

In general, the multi-stage build approach expectations are :
1. Multistage build is expected to yield an image with smallest possible size
2. Debugging is made easy
3. Should be able to build the selected modules

Further, my observations are :
1. Size of the JRE headless RuntimeImage remained same. To me it looks fair, because we are not building any intermediate artifacts which can be copied from one stage to another. 

```
$ podman images
REPOSITORY                                                     TAG         IMAGE ID      CREATED         SIZE
localhost/ubi8/openjdk-8-runtime                               latest      98e177adf564  11 seconds ago  314 MB
localhost/ubi8/openjdk-8-runtime                               1.3         98e177adf564  11 seconds ago  314 MB
localhost/ubi8/openjdk-8-runtime-multistage-build              latest      ed5b3fc9b892  3 minutes ago   314 MB
localhost/ubi8/openjdk-8-runtime-multistage-build              1.0         ed5b3fc9b892  3 minutes ago   314 MB
```
```
$ podman run --rm -ti localhost/ubi8/openjdk-8-runtime-multistage-build java -version
openjdk version "1.8.0_282"
OpenJDK Runtime Environment (build 1.8.0_282-b08)
OpenJDK 64-Bit Server VM (build 25.282-b08, mixed mode)`
```
```
$ podman inspect --format "{{.Config.Cmd}}" localhost/ubi8/openjdk-8-runtime-multistage-build
[/opt/jboss/container/java/run]
```