### PR TITLE
[OPENJDK-131] Review container maxMetaspaceSize tuning

### DIFF
--- a/modules/jvm/bash/artifacts/opt/jboss/container/java/jvm/java-default-options
+++ b/modules/jvm/bash/artifacts/opt/jboss/container/java/jvm/java-default-options
@@ -135,10 +135,11 @@ gc_config() {
   local maxHeapFreeRatio=${GC_MAX_HEAP_FREE_RATIO:-20}
   local timeRatio=${GC_TIME_RATIO:-4}
   local adaptiveSizePolicyWeight=${GC_ADAPTIVE_SIZE_POLICY_WEIGHT:-90}
-  local maxMetaspaceSize=${GC_MAX_METASPACE_SIZE:-100}
   local gcOptions="${GC_CONTAINER_OPTIONS:--XX:+UseParallelOldGC}"
   # for compat reasons we don't set a default value for metaspaceSize
   local metaspaceSize
+  # We also don't set a default value for maxMetaspaceSize
+  local maxMetaspaceSize=${GC_MAX_METASPACE_SIZE}
 
   if [ -n "${GC_METASPACE_SIZE}" ]; then
     metaspaceSize=${GC_METASPACE_SIZE}
@@ -154,7 +155,10 @@ gc_config() {
   allOptions+="-XX:MaxHeapFreeRatio=${maxHeapFreeRatio} "
   allOptions+="-XX:GCTimeRatio=${timeRatio} "
   allOptions+="-XX:AdaptiveSizePolicyWeight=${adaptiveSizePolicyWeight} "
-  allOptions+="-XX:MaxMetaspaceSize=${maxMetaspaceSize}m "
+  # if no value was specified for maxMetaSpaceSize we should skip passing it entirely
+  if [ -n "${maxMetaspaceSize}" ]; then
+    allOptions+="-XX:MaxMetaspaceSize=${maxMetaspaceSize}m "
+  fi
   if [ -n "${metaspaceSize}" ]; then
     allOptions+="-XX:MetaspaceSize=${metaspaceSize}m "
   fi

--- a/tests/features/java/gc.feature
+++ b/tests/features/java/gc.feature
@@ -7,36 +7,36 @@ Feature: Openshift OpenJDK GC tests
 
   Scenario: Check default GC configuration
     Given s2i build https://github.com/jboss-openshift/openshift-quickstarts from undertow-servlet
-    Then s2i build log should contain Using MAVEN_OPTS -XX:+UseParallelOldGC -XX:MinHeapFreeRatio=10 -XX:MaxHeapFreeRatio=20 -XX:GCTimeRatio=4 -XX:AdaptiveSizePolicyWeight=90 -XX:MaxMetaspaceSize=100m
-    And container log should contain -XX:+UseParallelOldGC -XX:MinHeapFreeRatio=10 -XX:MaxHeapFreeRatio=20 -XX:GCTimeRatio=4 -XX:AdaptiveSizePolicyWeight=90 -XX:MaxMetaspaceSize=100m
+    Then s2i build log should contain Using MAVEN_OPTS -XX:+UseParallelOldGC -XX:MinHeapFreeRatio=10 -XX:MaxHeapFreeRatio=20 -XX:GCTimeRatio=4 -XX:AdaptiveSizePolicyWeight=90
+    And container log should contain -XX:+UseParallelOldGC -XX:MinHeapFreeRatio=10 -XX:MaxHeapFreeRatio=20 -XX:GCTimeRatio=4 -XX:AdaptiveSizePolicyWeight=90
 
   Scenario: Check GC_MIN_HEAP_FREE_RATIO GC configuration
     Given s2i build https://github.com/jboss-openshift/openshift-quickstarts from undertow-servlet
        | variable                         | value  |
        | GC_MIN_HEAP_FREE_RATIO           | 5      |
-    Then s2i build log should contain Using MAVEN_OPTS -XX:+UseParallelOldGC -XX:MinHeapFreeRatio=5 -XX:MaxHeapFreeRatio=20 -XX:GCTimeRatio=4 -XX:AdaptiveSizePolicyWeight=90 -XX:MaxMetaspaceSize=100m
-    And container log should contain -XX:+UseParallelOldGC -XX:MinHeapFreeRatio=5 -XX:MaxHeapFreeRatio=20 -XX:GCTimeRatio=4 -XX:AdaptiveSizePolicyWeight=90 -XX:MaxMetaspaceSize=100m
+    Then s2i build log should contain Using MAVEN_OPTS -XX:+UseParallelOldGC -XX:MinHeapFreeRatio=5 -XX:MaxHeapFreeRatio=20 -XX:GCTimeRatio=4 -XX:AdaptiveSizePolicyWeight=90
+    And container log should contain -XX:+UseParallelOldGC -XX:MinHeapFreeRatio=5 -XX:MaxHeapFreeRatio=20 -XX:GCTimeRatio=4 -XX:AdaptiveSizePolicyWeight=90
 
   Scenario: Check GC_MAX_HEAP_FREE_RATIO GC configuration
     Given s2i build https://github.com/jboss-openshift/openshift-quickstarts from undertow-servlet
        | variable                         | value  |
        | GC_MAX_HEAP_FREE_RATIO           | 50     |
-    Then s2i build log should contain Using MAVEN_OPTS -XX:+UseParallelOldGC -XX:MinHeapFreeRatio=10 -XX:MaxHeapFreeRatio=50 -XX:GCTimeRatio=4 -XX:AdaptiveSizePolicyWeight=90 -XX:MaxMetaspaceSize=100m
-    And container log should contain -XX:+UseParallelOldGC -XX:MinHeapFreeRatio=10 -XX:MaxHeapFreeRatio=50 -XX:GCTimeRatio=4 -XX:AdaptiveSizePolicyWeight=90 -XX:MaxMetaspaceSize=100m
+    Then s2i build log should contain Using MAVEN_OPTS -XX:+UseParallelOldGC -XX:MinHeapFreeRatio=10 -XX:MaxHeapFreeRatio=50 -XX:GCTimeRatio=4 -XX:AdaptiveSizePolicyWeight=90
+    And container log should contain -XX:+UseParallelOldGC -XX:MinHeapFreeRatio=10 -XX:MaxHeapFreeRatio=50 -XX:GCTimeRatio=4 -XX:AdaptiveSizePolicyWeight=90
 
   Scenario: Check GC_TIME_RATIO GC configuration
     Given s2i build https://github.com/jboss-openshift/openshift-quickstarts from undertow-servlet
        | variable                         | value  |
        | GC_TIME_RATIO                    | 5      |
-    Then s2i build log should contain Using MAVEN_OPTS -XX:+UseParallelOldGC -XX:MinHeapFreeRatio=10 -XX:MaxHeapFreeRatio=20 -XX:GCTimeRatio=5 -XX:AdaptiveSizePolicyWeight=90 -XX:MaxMetaspaceSize=100m
-    And container log should contain -XX:+UseParallelOldGC -XX:MinHeapFreeRatio=10 -XX:MaxHeapFreeRatio=20 -XX:GCTimeRatio=5 -XX:AdaptiveSizePolicyWeight=90 -XX:MaxMetaspaceSize=100m
+    Then s2i build log should contain Using MAVEN_OPTS -XX:+UseParallelOldGC -XX:MinHeapFreeRatio=10 -XX:MaxHeapFreeRatio=20 -XX:GCTimeRatio=5 -XX:AdaptiveSizePolicyWeight=90
+    And container log should contain -XX:+UseParallelOldGC -XX:MinHeapFreeRatio=10 -XX:MaxHeapFreeRatio=20 -XX:GCTimeRatio=5 -XX:AdaptiveSizePolicyWeight=90
 
   Scenario: Check GC_ADAPTIVE_SIZE_POLICY_WEIGHT GC configuration
     Given s2i build https://github.com/jboss-openshift/openshift-quickstarts from undertow-servlet
        | variable                         | value  |
        | GC_ADAPTIVE_SIZE_POLICY_WEIGHT   | 80     |
-    Then s2i build log should contain Using MAVEN_OPTS -XX:+UseParallelOldGC -XX:MinHeapFreeRatio=10 -XX:MaxHeapFreeRatio=20 -XX:GCTimeRatio=4 -XX:AdaptiveSizePolicyWeight=80 -XX:MaxMetaspaceSize=100m
-    And container log should contain -XX:+UseParallelOldGC -XX:MinHeapFreeRatio=10 -XX:MaxHeapFreeRatio=20 -XX:GCTimeRatio=4 -XX:AdaptiveSizePolicyWeight=80 -XX:MaxMetaspaceSize=100m
+    Then s2i build log should contain Using MAVEN_OPTS -XX:+UseParallelOldGC -XX:MinHeapFreeRatio=10 -XX:MaxHeapFreeRatio=20 -XX:GCTimeRatio=4 -XX:AdaptiveSizePolicyWeight=80
+    And container log should contain -XX:+UseParallelOldGC -XX:MinHeapFreeRatio=10 -XX:MaxHeapFreeRatio=20 -XX:GCTimeRatio=4 -XX:AdaptiveSizePolicyWeight=80
 
   Scenario: Check GC_MAX_METASPACE_SIZE GC configuration
     Given s2i build https://github.com/jboss-openshift/openshift-quickstarts from undertow-servlet


### PR DESCRIPTION
This PR addresses https://issues.redhat.com/browse/OPENJDK-131 , from reading through the linked issues it is unnecessary to set the default max metaspace. Currently we set it by default to 100m if no max metaspace argument was passed, this PR removes that and defaults to not passing the argument at all. The tests have been adjusted accordingly.

