### PR TITLE
[OPENJDK-37] Delay removing Jolokia to the next release

### DIFF
--- a/openjdk-11-rhel7.yaml
+++ b/openjdk-11-rhel7.yaml
@@ -41,6 +41,8 @@ modules:
     version: "11"
   - name: jboss.container.prometheus
     version: "7"
+  - name: jboss.container.jolokia
+    version: "7"
   - name: jboss.container.java.s2i.bash
   - name: jboss.container.maven
     version: "7.0.3.6"

--- a/openjdk18-openshift.yaml
+++ b/openjdk18-openshift.yaml
@@ -42,6 +42,8 @@ modules:
     version: "8"
   - name: jboss.container.prometheus
     version: "7"
+  - name: jboss.container.jolokia
+    version: "7"
   - name: jboss.container.java.s2i.bash
   - name: jboss.container.maven
     version: "7.0.3.6"

--- a/templates/openjdk-web-basic-s2i.json
+++ b/templates/openjdk-web-basic-s2i.json
@@ -260,6 +260,11 @@
                                 ],
                                 "ports": [
                                     {
+                                        "name": "jolokia",
+                                        "containerPort": 8778,
+                                        "protocol": "TCP"
+                                    },
+                                    {
                                         "name": "http",
                                         "containerPort": 8080,
                                         "protocol": "TCP"

--- a/tests/arq/src/test/resources/openjdk18-mysql-persistent-s2i.json
+++ b/tests/arq/src/test/resources/openjdk18-mysql-persistent-s2i.json
@@ -460,6 +460,11 @@
                                 ],
                                 "ports": [
                                     {
+                                        "name": "jolokia",
+                                        "containerPort": 8778,
+                                        "protocol": "TCP"
+                                    },
+                                    {
                                         "name": "http",
                                         "containerPort": 8080,
                                         "protocol": "TCP"

--- a/tests/arq/src/test/resources/openjdk18-mysql-s2i.json
+++ b/tests/arq/src/test/resources/openjdk18-mysql-s2i.json
@@ -454,6 +454,11 @@
                                 ],
                                 "ports": [
                                     {
+                                        "name": "jolokia",
+                                        "containerPort": 8778,
+                                        "protocol": "TCP"
+                                    },
+                                    {
                                         "name": "http",
                                         "containerPort": 8080,
                                         "protocol": "TCP"

--- a/tests/arq/src/test/resources/openjdk18-postgresql-persistent-s2i.json
+++ b/tests/arq/src/test/resources/openjdk18-postgresql-persistent-s2i.json
@@ -445,6 +445,11 @@
                                 ],
                                 "ports": [
                                     {
+                                        "name": "jolokia",
+                                        "containerPort": 8778,
+                                        "protocol": "TCP"
+                                    },
+                                    {
                                         "name": "http",
                                         "containerPort": 8080,
                                         "protocol": "TCP"

--- a/tests/arq/src/test/resources/openjdk18-postgresql-s2i.json
+++ b/tests/arq/src/test/resources/openjdk18-postgresql-s2i.json
@@ -439,6 +439,11 @@
                                 ],
                                 "ports": [
                                     {
+                                        "name": "jolokia",
+                                        "containerPort": 8778,
+                                        "protocol": "TCP"
+                                    },
+                                    {
                                         "name": "http",
                                         "containerPort": 8080,
                                         "protocol": "TCP"

--- a/tests/arq/src/test/resources/openjdk18-web-https-s2i.json
+++ b/tests/arq/src/test/resources/openjdk18-web-https-s2i.json
@@ -367,6 +367,11 @@
                                 ],
                                 "ports": [
                                     {
+                                        "name": "jolokia",
+                                        "containerPort": 8778,
+                                        "protocol": "TCP"
+                                    },
+                                    {
                                         "name": "http",
                                         "containerPort": 8080,
                                         "protocol": "TCP"

--- a/tests/features/java/ports.feature
+++ b/tests/features/java/ports.feature
@@ -8,7 +8,9 @@ Feature: Openshift OpenJDK port tests
   Scenario: Check ports are available
     Given s2i build https://github.com/jboss-openshift/openshift-quickstarts from undertow-servlet
     Then check that port 8080 is open
+    Then check that port 8778 is open
     Then inspect container
        | path                    | value       |
        | /Config/ExposedPorts    | 8080/tcp    |
        | /Config/ExposedPorts    | 8443/tcp    |
+       | /Config/ExposedPorts    | 8778/tcp    |

--- a/tests/features/java/runtime.feature
+++ b/tests/features/java/runtime.feature
@@ -32,3 +32,4 @@ Feature: Openshift OpenJDK Runtime tests
        | JAVA_DIAGNOSTICS | true                |
     Then container log should contain /deployments/undertow-servlet.jar Hello from CTF test
       And container log should contain -XX:NativeMemoryTracking=summary
+      And container log should contain Jolokia: Agent started

--- a/ubi8-openjdk-11.yaml
+++ b/ubi8-openjdk-11.yaml
@@ -42,6 +42,7 @@ modules:
   - name: jboss.container.openjdk.jdk
     version: "11"
   - name: jboss.container.prometheus
+  - name: jboss.container.jolokia
   - name: jboss.container.maven
     version: "8.2.3.6"
   - name: jboss.container.java.s2i.bash

--- a/ubi8-openjdk-8.yaml
+++ b/ubi8-openjdk-8.yaml
@@ -42,6 +42,7 @@ modules:
   - name: jboss.container.openjdk.jdk
     version: "8"
   - name: jboss.container.prometheus
+  - name: jboss.container.jolokia
   - name: jboss.container.maven
     version: "8.2.3.6.8"
   - name: jboss.container.java.s2i.bash


### PR DESCRIPTION
I'm very keen to do this, but I think it's worthy of reconsideration in light of one new development, and either way we need to make sure we document this well, and we aren't in a position to get docs/blogs out about it quickly right now, but I do not want to delay the other pending stuff in `develop`. So I propose we drop this for 1.9, ship 1.9, then do this for 2.0.

https://issues.redhat.com/browse/OPENJDK-37