### PR TITLE
Added support for Quarkus build layouts

### DIFF
--- a/modules/run/bash/artifacts/opt/jboss/container/java/run/run-java.sh
+++ b/modules/run/bash/artifacts/opt/jboss/container/java/run/run-java.sh
@@ -35,13 +35,23 @@ auto_detect_jar_file() {
   local old_dir=$(pwd)
   cd ${dir}
   if [ $? = 0 ]; then
-    local nr_jars=`ls *.jar 2>/dev/null | grep -v '^original-' | wc -l | tr -d '[[:space:]]'`
-    if [ ${nr_jars} = 1 ]; then
-      ls *.jar | grep -v '^original-'
-      exit 0
-    fi
+    if [ -f "quarkus-app/quarkus-run.jar" ]; then
+        echo quarkus-app/quarkus-run.jar
+    else
+        local nr_jars=`ls *.jar 2>/dev/null | grep -v '^original-' | wc -l | tr -d '[[:space:]]'`
+        if [ ${nr_jars} = 1 ]; then
+            ls *.jar | grep -v '^original-'
+            exit 0
+        fi
 
-    log_error "Neither \$JAVA_MAIN_CLASS nor \$JAVA_APP_JAR is set and ${nr_jars} JARs found in ${dir} (1 expected)"
+        nr_jars=`ls *-runner.jar 2>/dev/null | wc -l | tr -d '[[:space:]]'`
+        if [ ${nr_jars} = 1 ]; then
+            ls *-runner.jar
+            exit 0
+        fi
+
+        log_error "Neither \$JAVA_MAIN_CLASS nor \$JAVA_APP_JAR is set and ${nr_jars} JARs found in ${dir} (1 expected)"
+    fi
     cd ${old_dir}
   else
     log_error "No directory ${dir} found for auto detection"


### PR DESCRIPTION
Quarkus, in its latest version, has 3 different build layouts that
it can create. They are called "legacy-jar", "uber-jar" and the
nwest is called "fast-jar". Of these 3 `run-java.sh` only supports
the "uber-jar". This commit adds support for the other two.

Fixes #206

Thanks for submitting your Pull Request!

Please make sure your PR meets the following requirements:

- [ ] Pull Request title is properly formatted: `[CLOUD-XYA] Subject`
    Sorry, no idea that the proper tag should be

- [ ] Pull Request contains link to the JIRA issue
    Sorry, no JIRA issue, just a GH issue

- [x] Pull Request contains description of the issue
- [x] Pull Request does not include fixes for issues other than the main ticket
- [x] Attached commits represent units of work and are properly formatted
- [x] You have read and agreed to the Developer Certificate of Origin (DCO) (see `CONTRIBUTING.md`)
- [x] Every commit contains `Signed-off-by: Your Name <yourname@example.com>` - use `git commit -s`
