### PR TITLE
Add Runtime ImageStream metadata

### DIFF
--- a/templates/runtime-image-streams.json
+++ b/templates/runtime-image-streams.json
@@ -1,0 +1,79 @@
+{
+    "kind": "List",
+    "apiVersion": "v1",
+    "metadata": {
+        "name": "ubi8-openjdk-runtime-image-stream",
+        "annotations": {
+            "description": "ImageStream definition for Red Hat UBI8 OpenJDK Runtimes.",
+            "openshift.io/provider-display-name": "Red Hat, Inc."
+        }
+    },
+    "items": [
+        {
+            "kind": "ImageStream",
+            "apiVersion": "v1",
+            "metadata": {
+                "name": "ubi8-openjdk-8-runtime",
+                "annotations": {
+                    "openshift.io/display-name": "Red Hat OpenJDK 1.8 Runtime (UBI8)",
+                    "openshift.io/provider-display-name": "Red Hat, Inc."
+                }
+            },
+            "spec": {
+                "tags": [
+                    {
+                        "name": "1.9",
+                        "annotations": {
+                            "openshift.io/display-name": "Red Hat OpenJDK 1.8 Runtime (UBI8)",
+                            "description": "Run Java applications using OpenJDK 1.8 upon UBI8.",
+                            "iconClass": "icon-rh-openjdk",
+                            "tags": "java,openjdk,ubi8",
+                            "version": "1.9"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
+                        },
+                        "from": {
+                            "kind": "DockerImage",
+                            "name": "registry.access.redhat.com/ubi8/openjdk-8-runtime:1.9"
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "kind": "ImageStream",
+            "apiVersion": "v1",
+            "metadata": {
+                "name": "ubi8-openjdk-11-runtime",
+                "annotations": {
+                    "openshift.io/display-name": "Red Hat OpenJDK 11 Runtime (UBI8)",
+                    "openshift.io/provider-display-name": "Red Hat, Inc."
+                }
+            },
+            "spec": {
+                "tags": [
+                    {
+                        "name": "1.9",
+                        "annotations": {
+                            "openshift.io/display-name": "Red Hat OpenJDK 11 Runtime (UBI8)",
+                            "description": "Run Java applications using OpenJDK 11 upon RHEL8.",
+                            "iconClass": "icon-rh-openjdk",
+                            "tags": "java,openjdk,ubi8",
+                            "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts",
+                            "sampleContextDir": "undertow-servlet",
+                            "version": "1.9"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
+                        },
+                        "from": {
+                            "kind": "DockerImage",
+                            "name": "registry.access.redhat.com/ubi8/openjdk-11-runtime:1.9"
+                        }
+                    }
+                ]
+            }
+        }
+    ]
+}


### PR DESCRIPTION
I've verified this is syntactically and semantically OK by loading it into an OCP 4.7 test cluster. However the image URIs are necessarily not correct until the runtime images are GA.

I'm putting them in a totally distinct JSON file so that they are not auto-pulled into OCP's default imagestream metadata until we can review and consider *all* our imagestream metadata with respect to how they are represented and interact in the OCP UI. Since these aren't builder images they shouldn't show up as quickstarts, some DIY is needed to use these.

We can reference this JSON file in the Errata text.