### PR TITLE
Add Runtime ImageStream metadata

### DIFF
--- a/templates/runtime-image-streams.json
+++ b/templates/runtime-image-streams.json
@@ -1,0 +1,79 @@
+{
+    "kind": "List",
+    "apiVersion": "v1",
+    "metadata": {
+        "name": "ubi8-openjdk-runtime-image-stream",
+        "annotations": {
+            "description": "ImageStream definition for Red Hat UBI8 OpenJDK Runtimes.",
+            "openshift.io/provider-display-name": "Red Hat, Inc."
+        }
+    },
+    "items": [
+        {
+            "kind": "ImageStream",
+            "apiVersion": "v1",
+            "metadata": {
+                "name": "ubi8-openjdk-8-runtime",
+                "annotations": {
+                    "openshift.io/display-name": "Red Hat OpenJDK 1.8 Runtime (UBI8)",
+                    "openshift.io/provider-display-name": "Red Hat, Inc."
+                }
+            },
+            "spec": {
+                "tags": [
+                    {
+                        "name": "1.9",
+                        "annotations": {
+                            "openshift.io/display-name": "Red Hat OpenJDK 1.8 Runtime (UBI8)",
+                            "description": "Run Java applications using OpenJDK 1.8 upon UBI8.",
+                            "iconClass": "icon-rh-openjdk",
+                            "tags": "java,openjdk,ubi8",
+                            "version": "1.9"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
+                        },
+                        "from": {
+                            "kind": "DockerImage",
+                            "name": "registry.access.redhat.com/ubi8/openjdk-8-runtime:1.9"
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "kind": "ImageStream",
+            "apiVersion": "v1",
+            "metadata": {
+                "name": "ubi8-openjdk-11-runtime",
+                "annotations": {
+                    "openshift.io/display-name": "Red Hat OpenJDK 11 Runtime (UBI8)",
+                    "openshift.io/provider-display-name": "Red Hat, Inc."
+                }
+            },
+            "spec": {
+                "tags": [
+                    {
+                        "name": "1.9",
+                        "annotations": {
+                            "openshift.io/display-name": "Red Hat OpenJDK 11 Runtime (UBI8)",
+                            "description": "Run Java applications using OpenJDK 11 upon RHEL8.",
+                            "iconClass": "icon-rh-openjdk",
+                            "tags": "java,openjdk,ubi8",
+                            "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts",
+                            "sampleContextDir": "undertow-servlet",
+                            "version": "1.9"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
+                        },
+                        "from": {
+                            "kind": "DockerImage",
+                            "name": "registry.access.redhat.com/ubi8/openjdk-11-runtime:1.9"
+                        }
+                    }
+                ]
+            }
+        }
+    ]
+}


### PR DESCRIPTION
This is a cherry-pick over to the `release` branch.

I'd like to move away from the `release` branch starting from the next
actual container `release` (1.9). My intention is to get `develop` into
the right state, build, and when we ship, tag the `develop` branch at
that point with `1.9`. From that point forward we would work entirely
from the `develop` branch.

A chicken-and-egg issue here is I need a stable URI to reference in the
errata to ship the runtime images, and I'd rather not use the `develop`
branch. We currently use the `release` branch for the latest correct
metadata for OpenShift, so it seems the appropriate place for this too
for now.