### PR TITLE
[OPENJDK-390] fix JAVA_HOME for runtime images

### DIFF
--- a/modules/jre/11/module.yaml
+++ b/modules/jre/11/module.yaml
@@ -14,7 +14,7 @@ labels:
 
 envs:
 - name: "JAVA_HOME"
-  value: "/usr/lib/jvm/java-11"
+  value: "/usr/lib/jvm/jre"
 - name: "JAVA_VENDOR"
   value: "openjdk"
 - name: "JAVA_VERSION"

--- a/modules/jre/8/module.yaml
+++ b/modules/jre/8/module.yaml
@@ -14,7 +14,7 @@ labels:
 
 envs:
 - name: "JAVA_HOME"
-  value: "/usr/lib/jvm/java-1.8.0"
+  value: "/usr/lib/jvm/jre"
 - name: "JAVA_VENDOR"
   value: "openjdk"
 - name: "JAVA_VERSION"

--- a/tests/features/java/openjdk.feature
+++ b/tests/features/java/openjdk.feature
@@ -1,6 +1,6 @@
 # TODO: it would be nice to make the below less specific to 8 & 11. What about when 12
 # is released, etc.
-Feature: Container only has one OpenJDK version installed
+Feature: Miscellaneous OpenJDK-related unit tests
 
   @redhat-openjdk-18/openjdk18-openshift
   @openjdk/openjdk-1.8-ubi8
@@ -19,3 +19,12 @@ Feature: Container only has one OpenJDK version installed
     | arg     | value   |
     | command | rpm -qa |
     Then available container log should not contain java-1.8.0
+
+  @ubi8
+  @openjdk
+  @openj9
+  Scenario: Ensure JAVA_HOME is defined and contains Java
+    When container is started with args
+    | arg     | value                                  |
+    | command | bash -c "$JAVA_HOME/bin/java -version" |
+    Then available container log should contain OpenJDK Runtime Environment


### PR DESCRIPTION
The path /usr/lib/jvm/jre exists in both images, the prior
values do not.

https://issues.redhat.com/browse/OPENJDK-390