### PR TITLE
Tag two tests for the runtime images

### DIFF
--- a/tests/features/java/openjdk.feature
+++ b/tests/features/java/openjdk.feature
@@ -5,6 +5,8 @@ Feature: Container only has one OpenJDK version installed
   @redhat-openjdk-18/openjdk18-openshift
   @openjdk/openjdk-1.8-ubi8
   @openj9/openj9-8-rhel8
+  @ubi8/openjdk-8
+  @ubi8/openjdk-8-runtime
   Scenario: Check that only OpenJDK 8 is installed
     When container is started with args
     | arg     | value   |
@@ -14,6 +16,8 @@ Feature: Container only has one OpenJDK version installed
   @openjdk/openjdk-11-rhel7
   @openjdk/openjdk-11-ubi8
   @openj9/openj9-11-rhel8
+  @ubi8/openjdk-11
+  @ubi8/openjdk-11-runtime
   Scenario: Check that only OpenJDK 11 is installed
     When container is started with args
     | arg     | value   |


### PR DESCRIPTION
And the ubi8-based images which had been missed.