### PR TITLE
[OPENJDK-407]: clean up RPMs that are not in the UBI set

### DIFF
--- a/content_sets_rhel8.yml
+++ b/content_sets_rhel8.yml
@@ -1,12 +1,12 @@
 x86_64:
-- rhel-8-for-x86_64-baseos-rpms
-- rhel-8-for-x86_64-appstream-rpms
+- ubi-8-for-x86_64-baseos-rpms__8
+- ubi-8-for-x86_64-appstream-rpms__8
 ppc64le:
-- rhel-8-for-ppc64le-baseos-rpms
-- rhel-8-for-ppc64le-appstream-rpms
+- ubi-8-for-ppc64le-appstream-rpms__8
+- ubi-8-for-ppc64le-baseos-rpms__8
 aarch64:
-- rhel-8-for-aarch64-baseos-rpms
-- rhel-8-for-aarch64-appstream-rpms
+- ubi-8-for-aarch64-baseos-rpms__8
+- ubi-8-for-aarch64-appstream-rpms__8
 s390x:
-- rhel-8-for-s390x-baseos-rpms
-- rhel-8-for-s390x-appstream-rpms
+- ubi-8-for-s390x-baseos-rpms__8
+- ubi-8-for-s390x-appstream-rpms__8

--- a/ubi8-openjdk-11.yaml
+++ b/ubi8-openjdk-11.yaml
@@ -40,7 +40,7 @@ modules:
   - name: cct_module
     git:
       url: https://github.com/jboss-openshift/cct_module.git
-      ref: 0.41.3
+      ref: 0.41.4
   install:
   - name: jboss.container.microdnf-bz-workaround
   - name: jboss.container.openjdk.jdk

--- a/ubi8-openjdk-11.yaml
+++ b/ubi8-openjdk-11.yaml
@@ -47,7 +47,6 @@ modules:
     version: "11"
   - name: jboss.container.prometheus
   - name: jboss.container.jolokia
-  - name: jboss.container.dnf
   - name: jboss.container.maven
     version: "8.2.3.6"
   - name: jboss.container.java.s2i.bash

--- a/ubi8-openjdk-8.yaml
+++ b/ubi8-openjdk-8.yaml
@@ -47,7 +47,6 @@ modules:
     version: "8"
   - name: jboss.container.prometheus
   - name: jboss.container.jolokia
-  - name: jboss.container.dnf
   - name: jboss.container.maven
     version: "8.2.3.6.8"
   - name: jboss.container.java.s2i.bash

--- a/ubi8-openjdk-8.yaml
+++ b/ubi8-openjdk-8.yaml
@@ -40,7 +40,7 @@ modules:
   - name: cct_module
     git:
       url: https://github.com/jboss-openshift/cct_module.git
-      ref: 0.41.3
+      ref: 0.41.4
   install:
   - name: jboss.container.microdnf-bz-workaround
   - name: jboss.container.openjdk.jdk


### PR DESCRIPTION
The new cct_module version includes the updated maven modules which enable the relevant dnf module without requiring full dnf to be installed. This reduces the number of weak-deps which get pulled in and not removed afterwards. Additionally, the new jboss.container.util.ubi-clean module removes a static list of RPMs known to not be in the UBI set.

https://issues.redhat.com/browse/OPENJDK-407