### PR TITLE
[OPENJDK-407] use UBI content sets + a test

### DIFF
--- a/redhat/ubi8-openjdk-11-runtime.yaml
+++ b/redhat/ubi8-openjdk-11-runtime.yaml
@@ -14,14 +14,14 @@ packages:
   manager: microdnf
   content_sets:
     x86_64:
-    - rhel-8-for-x86_64-baseos-rpms
-    - rhel-8-for-x86_64-appstream-rpms
+    - ubi-8-for-x86_64-baseos-rpms__8
+    - ubi-8-for-x86_64-appstream-rpms__8
     ppc64le:
-    - rhel-8-for-ppc64le-baseos-rpms
-    - rhel-8-for-ppc64le-appstream-rpms
+    - ubi-8-for-ppc64le-appstream-rpms__8
+    - ubi-8-for-ppc64le-baseos-rpms__8
     aarch64:
-    - rhel-8-for-aarch64-baseos-rpms
-    - rhel-8-for-aarch64-appstream-rpms
+    - ubi-8-for-aarch64-baseos-rpms__8
+    - ubi-8-for-aarch64-appstream-rpms__8
     s390x:
-    - rhel-8-for-s390x-baseos-rpms
-    - rhel-8-for-s390x-appstream-rpms
+    - ubi-8-for-s390x-baseos-rpms__8
+    - ubi-8-for-s390x-appstream-rpms__8

--- a/redhat/ubi8-openjdk-11.yaml
+++ b/redhat/ubi8-openjdk-11.yaml
@@ -16,14 +16,14 @@ packages:
   manager: microdnf
   content_sets:
     x86_64:
-    - rhel-8-for-x86_64-baseos-rpms
-    - rhel-8-for-x86_64-appstream-rpms
+    - ubi-8-for-x86_64-baseos-rpms__8
+    - ubi-8-for-x86_64-appstream-rpms__8
     ppc64le:
-    - rhel-8-for-ppc64le-baseos-rpms
-    - rhel-8-for-ppc64le-appstream-rpms
+    - ubi-8-for-ppc64le-appstream-rpms__8
+    - ubi-8-for-ppc64le-baseos-rpms__8
     aarch64:
-    - rhel-8-for-aarch64-baseos-rpms
-    - rhel-8-for-aarch64-appstream-rpms
+    - ubi-8-for-aarch64-baseos-rpms__8
+    - ubi-8-for-aarch64-appstream-rpms__8
     s390x:
-    - rhel-8-for-s390x-baseos-rpms
-    - rhel-8-for-s390x-appstream-rpms
+    - ubi-8-for-s390x-baseos-rpms__8
+    - ubi-8-for-s390x-appstream-rpms__8

--- a/redhat/ubi8-openjdk-8-runtime.yaml
+++ b/redhat/ubi8-openjdk-8-runtime.yaml
@@ -14,14 +14,14 @@ packages:
   manager: microdnf
   content_sets:
     x86_64:
-    - rhel-8-for-x86_64-baseos-rpms
-    - rhel-8-for-x86_64-appstream-rpms
+    - ubi-8-for-x86_64-baseos-rpms__8
+    - ubi-8-for-x86_64-appstream-rpms__8
     ppc64le:
-    - rhel-8-for-ppc64le-baseos-rpms
-    - rhel-8-for-ppc64le-appstream-rpms
+    - ubi-8-for-ppc64le-appstream-rpms__8
+    - ubi-8-for-ppc64le-baseos-rpms__8
     aarch64:
-    - rhel-8-for-aarch64-baseos-rpms
-    - rhel-8-for-aarch64-appstream-rpms
+    - ubi-8-for-aarch64-baseos-rpms__8
+    - ubi-8-for-aarch64-appstream-rpms__8
     s390x:
-    - rhel-8-for-s390x-baseos-rpms
-    - rhel-8-for-s390x-appstream-rpms
+    - ubi-8-for-s390x-baseos-rpms__8
+    - ubi-8-for-s390x-appstream-rpms__8

--- a/redhat/ubi8-openjdk-8.yaml
+++ b/redhat/ubi8-openjdk-8.yaml
@@ -16,14 +16,14 @@ packages:
   manager: microdnf
   content_sets:
     x86_64:
-    - rhel-8-for-x86_64-baseos-rpms
-    - rhel-8-for-x86_64-appstream-rpms
+    - ubi-8-for-x86_64-baseos-rpms__8
+    - ubi-8-for-x86_64-appstream-rpms__8
     ppc64le:
-    - rhel-8-for-ppc64le-baseos-rpms
-    - rhel-8-for-ppc64le-appstream-rpms
+    - ubi-8-for-ppc64le-appstream-rpms__8
+    - ubi-8-for-ppc64le-baseos-rpms__8
     aarch64:
-    - rhel-8-for-aarch64-baseos-rpms
-    - rhel-8-for-aarch64-appstream-rpms
+    - ubi-8-for-aarch64-baseos-rpms__8
+    - ubi-8-for-aarch64-appstream-rpms__8
     s390x:
-    - rhel-8-for-s390x-baseos-rpms
-    - rhel-8-for-s390x-appstream-rpms
+    - ubi-8-for-s390x-baseos-rpms__8
+    - ubi-8-for-s390x-appstream-rpms__8

--- a/tests/features/java/openjdk.feature
+++ b/tests/features/java/openjdk.feature
@@ -32,3 +32,13 @@ Feature: Miscellaneous OpenJDK-related unit tests
     | arg     | value                                  |
     | command | bash -c "$JAVA_HOME/bin/java -version" |
     Then available container log should contain OpenJDK Runtime Environment
+
+  @ubi8
+  Scenario: Check that certain non-UBI packages are not installed
+    When container is started with args
+    | arg     | value   |
+    | command | rpm -qa |
+    Then available container log should not contain grub
+    Then available container log should not contain dejavu-sans-mono-fonts
+    Then available container log should not contain os-prober
+    Then available container log should not contain rpm-plugin-systemd-inhibit


### PR DESCRIPTION
Don't install RHEL-8 RPMs that are not in the UBI content sets.