### PR TITLE
Stop referencing Image :latest tags

### DIFF
--- a/templates/community-image-streams.json
+++ b/templates/community-image-streams.json
@@ -106,7 +106,7 @@
                         },
                         "from": {
                             "kind": "DockerImage",
-                            "name": "registry.access.redhat.com/ubi8/openjdk-8:latest"
+                            "name": "registry.access.redhat.com/ubi8/openjdk-8:1.3"
                         }
                     },
                     {
@@ -126,7 +126,7 @@
                         },
                         "from": {
                             "kind": "DockerImage",
-                            "name": "registry.access.redhat.com/ubi8/openjdk-8:latest"
+                            "name": "registry.access.redhat.com/ubi8/openjdk-8:1.3"
                         }
                     },
                     {
@@ -146,7 +146,7 @@
                         },
                         "from": {
                             "kind": "DockerImage",
-                            "name": "registry.access.redhat.com/ubi8/openjdk-11:latest"
+                            "name": "registry.access.redhat.com/ubi8/openjdk-11:1.3"
                         }
                     },
                     {
@@ -166,7 +166,7 @@
                         },
                         "from": {
                             "kind": "DockerImage",
-                            "name": "registry.access.redhat.com/ubi8/openjdk-11:latest"
+                            "name": "registry.access.redhat.com/ubi8/openjdk-11:1.3"
                         }
                     },
                     {

--- a/templates/image-streams-aarch64.json
+++ b/templates/image-streams-aarch64.json
@@ -118,7 +118,7 @@
                         },
                         "from": {
                             "kind": "DockerImage",
-                            "name": "registry.redhat.io/ubi8/openjdk-8:latest"
+                            "name": "registry.redhat.io/ubi8/openjdk-8:1.1"
                         }
                     },
                     {
@@ -138,7 +138,7 @@
                         },
                         "from": {
                             "kind": "DockerImage",
-                            "name": "registry.redhat.io/ubi8/openjdk-11:latest"
+                            "name": "registry.redhat.io/ubi8/openjdk-11:1.1"
                         }
                     },
                     {

--- a/templates/image-streams-ppc64le.json
+++ b/templates/image-streams-ppc64le.json
@@ -276,7 +276,7 @@
                         },
                         "from": {
                             "kind": "DockerImage",
-                            "name": "registry.redhat.io/ubi8/openjdk-8:latest"
+                            "name": "registry.redhat.io/ubi8/openjdk-8:1.1"
                         }
                     },
                     {
@@ -296,7 +296,7 @@
                         },
                         "from": {
                             "kind": "DockerImage",
-                            "name": "registry.redhat.io/redhat-openjdk-18/openjdk18-openshift:latest"
+                            "name": "registry.redhat.io/redhat-openjdk-18/openjdk18-openshift:1.8"
                         }
                     },
                     {
@@ -316,7 +316,7 @@
                         },
                         "from": {
                             "kind": "DockerImage",
-                            "name": "registry.redhat.io/redhat-openjdk-18/openjdk18-openshift:latest"
+                            "name": "registry.redhat.io/redhat-openjdk-18/openjdk18-openshift:1.8"
                         }
                     },
                     {
@@ -336,7 +336,7 @@
                         },
                         "from": {
                             "kind": "DockerImage",
-                            "name": "registry.redhat.io/ubi8/openjdk-11:latest"
+                            "name": "registry.redhat.io/ubi8/openjdk-11:1.3"
                         }
                     },
                     {
@@ -356,7 +356,7 @@
                         },
                         "from": {
                             "kind": "DockerImage",
-                            "name": "registry.redhat.io/openjdk/openjdk-11-rhel7:latest"
+                            "name": "registry.redhat.io/openjdk/openjdk-11-rhel7:1.1"
                         }
                     },
                     {
@@ -376,7 +376,7 @@
                         },
                         "from": {
                             "kind": "DockerImage",
-                            "name": "registry.redhat.io/openjdk/openjdk-11-rhel7:latest"
+                            "name": "registry.redhat.io/openjdk/openjdk-11-rhel7:1.1"
                         }
                     },
                     {

--- a/templates/image-streams-s390x.json
+++ b/templates/image-streams-s390x.json
@@ -430,7 +430,7 @@
                         },
                         "from": {
                             "kind": "DockerImage",
-                            "name": "registry.redhat.io/ubi8/openjdk-8:latest"
+                            "name": "registry.redhat.io/ubi8/openjdk-8:1.3"
                         }
                     },
                     {
@@ -450,7 +450,7 @@
                         },
                         "from": {
                             "kind": "DockerImage",
-                            "name": "registry.redhat.io/redhat-openjdk-18/openjdk18-openshift:latest"
+                            "name": "registry.redhat.io/redhat-openjdk-18/openjdk18-openshift:1.8"
                         }
                     },
                     {
@@ -530,7 +530,7 @@
                         },
                         "from": {
                             "kind": "DockerImage",
-                            "name": "registry.redhat.io/ubi8/openjdk-11:latest"
+                            "name": "registry.redhat.io/ubi8/openjdk-11:1.3"
                         }
                     },
                     {
@@ -550,7 +550,7 @@
                         },
                         "from": {
                             "kind": "DockerImage",
-                            "name": "registry.redhat.io/openjdk/openjdk-11-rhel7:latest"
+                            "name": "registry.redhat.io/openjdk/openjdk-11-rhel7:1.1"
                         }
                     },
                     {

--- a/templates/image-streams.json
+++ b/templates/image-streams.json
@@ -414,7 +414,7 @@
                         },
                         "from": {
                             "kind": "DockerImage",
-                            "name": "registry.redhat.io/ubi8/openjdk-8:latest"
+                            "name": "registry.redhat.io/ubi8/openjdk-8:1.3"
                         }
                     },
                     {
@@ -434,7 +434,7 @@
                         },
                         "from": {
                             "kind": "DockerImage",
-                            "name": "registry.redhat.io/redhat-openjdk-18/openjdk18-openshift:latest"
+                            "name": "registry.redhat.io/redhat-openjdk-18/openjdk18-openshift:1.8"
                         }
                     },
                     {
@@ -454,7 +454,7 @@
                         },
                         "from": {
                             "kind": "DockerImage",
-                            "name": "registry.redhat.io/redhat-openjdk-18/openjdk18-openshift:latest"
+                            "name": "registry.redhat.io/redhat-openjdk-18/openjdk18-openshift:1.8"
                         }
                     },
                     {
@@ -474,7 +474,7 @@
                         },
                         "from": {
                             "kind": "DockerImage",
-                            "name": "registry.redhat.io/ubi8/openjdk-11:latest"
+                            "name": "registry.redhat.io/ubi8/openjdk-11:1.3"
                         }
                     },
                     {
@@ -494,7 +494,7 @@
                         },
                         "from": {
                             "kind": "DockerImage",
-                            "name": "registry.redhat.io/openjdk/openjdk-11-rhel7:latest"
+                            "name": "registry.redhat.io/openjdk/openjdk-11-rhel7:1.1"
                         }
                     },
                     {
@@ -514,7 +514,7 @@
                         },
                         "from": {
                             "kind": "DockerImage",
-                            "name": "registry.redhat.io/openjdk/openjdk-11-rhel7:latest"
+                            "name": "registry.redhat.io/openjdk/openjdk-11-rhel7:1.1"
                         }
                     },
                     {


### PR DESCRIPTION
Substitute every reference to an OpenJDK Image (not ImageStream) :latest
tag with the current latest major.minor version instead.

ImageStream tag definitions are not modified, so where ":latest"
ImageStream tags already exist, they should continue to do so, just
referring to the back-end Images by different tags.

For OpenShift end-users, there should be no impact, as the ImageStreams
themselves retain the same tags pointing at (ultimately) the same
images.

This is in preparation for moving the OpenJDK images to "multi-stream",
a consequence of which is the image ":latest" tags will stop being
published in the Container Catalog. I'm pushing it now, to give it a
chance to percolate through OpenShift installations ahead of that
switch.

This does not impact the OpenJ9 images.