### PR TITLE
Bump container versions to 1.10

### DIFF
--- a/openjdk-11-rhel7.yaml
+++ b/openjdk-11-rhel7.yaml
@@ -4,7 +4,7 @@ schema_version: 1
 
 from: "registry.redhat.io/rhel7/rhel"
 name: &name "openjdk/openjdk-11-rhel7"
-version: &version "1.9"
+version: &version "1.10"
 description: "Source To Image (S2I) image for Red Hat OpenShift providing OpenJDK 11"
 
 labels:

--- a/openjdk18-openshift.yaml
+++ b/openjdk18-openshift.yaml
@@ -4,7 +4,7 @@ schema_version: 1
 
 from: "registry.redhat.io/rhel7/rhel"
 name: &name "redhat-openjdk-18/openjdk18-openshift"
-version: &version "1.9"
+version: &version "1.10"
 description: "Source To Image (S2I) image for Red Hat OpenShift providing OpenJDK 8"
 
 labels:

--- a/ubi8-openjdk-11-runtime.yaml
+++ b/ubi8-openjdk-11-runtime.yaml
@@ -4,7 +4,7 @@ schema_version: 1
 
 from: "registry.access.redhat.com/ubi8/ubi-minimal"
 name: &name "ubi8/openjdk-11-runtime"
-version: &version "1.9"
+version: &version "1.10"
 description: "Image for Red Hat OpenShift providing OpenJDK 11 runtime"
 
 labels:

--- a/ubi8-openjdk-11.yaml
+++ b/ubi8-openjdk-11.yaml
@@ -4,7 +4,7 @@ schema_version: 1
 
 from: "registry.access.redhat.com/ubi8/ubi-minimal"
 name: &name "ubi8/openjdk-11"
-version: &version "1.9"
+version: &version "1.10"
 description: "Source To Image (S2I) image for Red Hat OpenShift providing OpenJDK 11"
 
 labels:

--- a/ubi8-openjdk-8-runtime.yaml
+++ b/ubi8-openjdk-8-runtime.yaml
@@ -4,7 +4,7 @@ schema_version: 1
 
 from: "registry.access.redhat.com/ubi8/ubi-minimal"
 name: &name "ubi8/openjdk-8-runtime"
-version: &version "1.9"
+version: &version "1.10"
 description: "Image for Red Hat OpenShift providing OpenJDK 1.8 runtime"
 
 labels:

--- a/ubi8-openjdk-8.yaml
+++ b/ubi8-openjdk-8.yaml
@@ -4,7 +4,7 @@ schema_version: 1
 
 from: "registry.access.redhat.com/ubi8/ubi-minimal"
 name: &name "ubi8/openjdk-8"
-version: &version "1.9"
+version: &version "1.10"
 description: "Source To Image (S2I) image for Red Hat OpenShift providing OpenJDK 1.8"
 
 labels:


### PR DESCRIPTION
In preparation for next release. Current latest released version
is 1.9 (the runtime images). The next release should include

    [OPENJDK-390] fix JAVA_HOME for runtime images

which means the runtime image version needs to be bumped, so
harmonize them all.