### PR TITLE
Override koji_target for RHEL7/JDK8 image

### DIFF
--- a/image.yaml
+++ b/image.yaml
@@ -71,3 +71,4 @@ osbs:
   repository:
     name: containers/redhat-openjdk-18
     branch: jb-openjdk-1.8-openshift-rhel-7
+  koji_target: jb-openjdk18-rhel7-1.8-containers-candidate


### PR DESCRIPTION
The default derived name corresponds to a target that is not configured
correctly.

We need to have another pass over the Koji/Brew configuration for these
images, in the meantime, specify the correct target.