### PR TITLE
Revert to rhel-8-* content sets to ensure we trigger rebuilds for CVEs

### DIFF
--- a/content_sets_rhel8.yml
+++ b/content_sets_rhel8.yml
@@ -1,12 +1,12 @@
 x86_64:
-- ubi-8-for-x86_64-baseos-rpms__8
-- ubi-8-for-x86_64-appstream-rpms__8
+- rhel-8-for-x86_64-baseos-rpms
+- rhel-8-for-x86_64-appstream-rpms
 ppc64le:
-- ubi-8-for-ppc64le-appstream-rpms__8
-- ubi-8-for-ppc64le-baseos-rpms__8
+- rhel-8-for-ppc64le-baseos-rpms
+- rhel-8-for-ppc64le-appstream-rpms
 aarch64:
-- ubi-8-for-aarch64-baseos-rpms__8
-- ubi-8-for-aarch64-appstream-rpms__8
+- rhel-8-for-aarch64-baseos-rpms
+- rhel-8-for-aarch64-appstream-rpms
 s390x:
-- ubi-8-for-s390x-baseos-rpms__8
-- ubi-8-for-s390x-appstream-rpms__8
+- rhel-8-for-s390x-baseos-rpms
+- rhel-8-for-s390x-appstream-rpms


### PR DESCRIPTION
RPM Errata that ship CVE fixes for RHEL8 (or the UBI8 subset of it) are pushed to CDN repos named `rhel-8-*`. Those pushes are what trigger the automatic rebuild of downstream containers to pick up the fix. Since the fix is not pushed to the `ubi-8-*` repos using this mechanism (some other out-of-band mechanism syncs ubi-8 repos), automatic rebuilds will never trigger for these containers.

I'm discussing this internally (CLOUDBLD-6558), but in the meantime revert to the rhel-8 content sets so we get back automatic rebuilds.