### PR TITLE
Add OpenJDK17 container images (test/preview)

### DIFF
--- a/modules/jdk/17/artifacts/opt/jboss/container/openjdk/jdk/jvm-options
+++ b/modules/jdk/17/artifacts/opt/jboss/container/openjdk/jdk/jvm-options
@@ -1,0 +1,10 @@
+
+#!/bin/sh
+# ==============================================================================
+# JDK specific customizations
+#
+# ==============================================================================
+
+function jvm_specific_diagnostics() {
+    echo "-Xlog:gc::utctime -XX:NativeMemoryTracking=summary"
+}

--- a/modules/jdk/17/configure.sh
+++ b/modules/jdk/17/configure.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+# Configure module
+set -e
+
+SCRIPT_DIR=$(dirname $0)
+ARTIFACTS_DIR=${SCRIPT_DIR}/artifacts
+
+chown -R jboss:root $SCRIPT_DIR
+chmod -R ug+rwX $SCRIPT_DIR
+chmod ug+x ${ARTIFACTS_DIR}/opt/jboss/container/openjdk/jdk/*
+
+pushd ${ARTIFACTS_DIR}
+cp -pr * /
+popd
+
+# Set this JDK as the alternative in use
+_arch="$(uname -i)"
+alternatives --set java java-17-openjdk.${_arch}
+alternatives --set javac java-17-openjdk.${_arch}
+alternatives --set java_sdk_openjdk java-17-openjdk.${_arch}
+alternatives --set jre_openjdk java-17-openjdk.${_arch}
+
+# Update securerandom.source for quicker starts (must be done after removing jdk 8, or it will hit the wrong files)
+JAVA_SECURITY_FILE=/usr/lib/jvm/java/conf/security/java.security
+SECURERANDOM=securerandom.source
+if grep -q "^$SECURERANDOM=.*" $JAVA_SECURITY_FILE; then
+    sed -i "s|^$SECURERANDOM=.*|$SECURERANDOM=file:/dev/urandom|" $JAVA_SECURITY_FILE
+else
+    echo $SECURERANDOM=file:/dev/urandom >> $JAVA_SECURITY_FILE
+fi

--- a/modules/jdk/17/module.yaml
+++ b/modules/jdk/17/module.yaml
@@ -1,0 +1,34 @@
+schema_version: 1
+
+name: "jboss.container.openjdk.jdk"
+description: "Installs the JDK for OpenJDK 17."
+version: "17"
+
+labels:
+- name: "org.jboss.product"
+  value: "openjdk"
+- name: "org.jboss.product.version"
+  value: "17"
+- name: "org.jboss.product.openjdk.version"
+  value: "17"
+
+envs:
+- name: "JAVA_HOME"
+  value: "/usr/lib/jvm/java-17"
+- name: "JAVA_VENDOR"
+  value: "openjdk"
+- name: "JAVA_VERSION"
+  value: "17"
+- name: JBOSS_CONTAINER_OPENJDK_JDK_MODULE
+  value: /opt/jboss/container/openjdk/jdk
+
+packages:
+  install:
+  - java-17-openjdk-devel
+
+modules:
+  install:
+  - name: jboss.container.user
+
+execute:
+- script: configure.sh

--- a/modules/jvm/api/module.yaml
+++ b/modules/jvm/api/module.yaml
@@ -55,7 +55,7 @@ envs:
   description: The maximum metaspace size.
   example: "100"
 - name: GC_CONTAINER_OPTIONS
-  description: specify Java GC to use. The value of this variable should contain the necessary JRE command-line options to specify the required GC, which will override the default of `-XX:+UseParallelOldGC`.
+  description: specify Java GC to use. The value of this variable should contain the necessary JRE command-line options to specify the required GC, which will override the default of `-XX:+UseParallelGC`.
   example: -XX:+UseG1GC
 # deprecated
 - name: JAVA_OPTIONS

--- a/modules/jvm/bash/artifacts/opt/jboss/container/java/jvm/java-default-options
+++ b/modules/jvm/bash/artifacts/opt/jboss/container/java/jvm/java-default-options
@@ -135,7 +135,8 @@ gc_config() {
   local maxHeapFreeRatio=${GC_MAX_HEAP_FREE_RATIO:-20}
   local timeRatio=${GC_TIME_RATIO:-4}
   local adaptiveSizePolicyWeight=${GC_ADAPTIVE_SIZE_POLICY_WEIGHT:-90}
-  local gcOptions="${GC_CONTAINER_OPTIONS:--XX:+UseParallelOldGC}"
+  local gcOptions="${GC_CONTAINER_OPTIONS:--XX:+UseParallelGC}"
+
   # for compat reasons we don't set a default value for metaspaceSize
   local metaspaceSize
   # We also don't set a default value for maxMetaspaceSize

--- a/redhat/ubi8-openjdk-17.yaml
+++ b/redhat/ubi8-openjdk-17.yaml
@@ -1,0 +1,27 @@
+osbs:
+  configuration:
+    container:
+      compose:
+        pulp_repos: true
+        packages: []
+        signing_intent: unsigned
+  repository:
+    name: containers/openjdk
+    branch: openjdk-17-ubi8
+  koji_target: openjdk-17-ubi8-containers-candidate
+
+packages:
+  manager: microdnf
+  content_sets:
+    x86_64:
+    - rhel-8-for-x86_64-baseos-rpms__8
+    - rhel-8-for-x86_64-appstream-rpms__8
+    ppc64le:
+    - rhel-8-for-ppc64le-appstream-rpms__8
+    - rhel-8-for-ppc64le-baseos-rpms__8
+    aarch64:
+    - rhel-8-for-aarch64-baseos-rpms__8
+    - rhel-8-for-aarch64-appstream-rpms__8
+    s390x:
+    - rhel-8-for-s390x-baseos-rpms__8
+    - rhel-8-for-s390x-appstream-rpms__8

--- a/tests/features/java.security.feature
+++ b/tests/features/java.security.feature
@@ -1,6 +1,7 @@
 @openjdk
 @ubi8/openjdk-8
 @ubi8/openjdk-11
+@ubi8/openjdk-17
 @redhat-openjdk-18
 Feature: Openshift S2I tests
   Scenario: Check networkaddress.cache.negative.ttl has been set correctly

--- a/tests/features/java/gc.feature
+++ b/tests/features/java/gc.feature
@@ -7,43 +7,43 @@ Feature: Openshift OpenJDK GC tests
 
   Scenario: Check default GC configuration
     Given s2i build https://github.com/jboss-openshift/openshift-quickstarts from undertow-servlet
-    Then s2i build log should contain Using MAVEN_OPTS -XX:+UseParallelOldGC -XX:MinHeapFreeRatio=10 -XX:MaxHeapFreeRatio=20 -XX:GCTimeRatio=4 -XX:AdaptiveSizePolicyWeight=90
-    And container log should contain -XX:+UseParallelOldGC -XX:MinHeapFreeRatio=10 -XX:MaxHeapFreeRatio=20 -XX:GCTimeRatio=4 -XX:AdaptiveSizePolicyWeight=90
+    Then s2i build log should contain Using MAVEN_OPTS -XX:+UseParallelGC -XX:MinHeapFreeRatio=10 -XX:MaxHeapFreeRatio=20 -XX:GCTimeRatio=4 -XX:AdaptiveSizePolicyWeight=90
+    And container log should contain -XX:+UseParallelGC -XX:MinHeapFreeRatio=10 -XX:MaxHeapFreeRatio=20 -XX:GCTimeRatio=4 -XX:AdaptiveSizePolicyWeight=90
 
   Scenario: Check GC_MIN_HEAP_FREE_RATIO GC configuration
     Given s2i build https://github.com/jboss-openshift/openshift-quickstarts from undertow-servlet
        | variable                         | value  |
        | GC_MIN_HEAP_FREE_RATIO           | 5      |
-    Then s2i build log should contain Using MAVEN_OPTS -XX:+UseParallelOldGC -XX:MinHeapFreeRatio=5 -XX:MaxHeapFreeRatio=20 -XX:GCTimeRatio=4 -XX:AdaptiveSizePolicyWeight=90
-    And container log should contain -XX:+UseParallelOldGC -XX:MinHeapFreeRatio=5 -XX:MaxHeapFreeRatio=20 -XX:GCTimeRatio=4 -XX:AdaptiveSizePolicyWeight=90
+    Then s2i build log should contain Using MAVEN_OPTS -XX:+UseParallelGC -XX:MinHeapFreeRatio=5 -XX:MaxHeapFreeRatio=20 -XX:GCTimeRatio=4 -XX:AdaptiveSizePolicyWeight=90
+    And container log should contain -XX:+UseParallelGC -XX:MinHeapFreeRatio=5 -XX:MaxHeapFreeRatio=20 -XX:GCTimeRatio=4 -XX:AdaptiveSizePolicyWeight=90
 
   Scenario: Check GC_MAX_HEAP_FREE_RATIO GC configuration
     Given s2i build https://github.com/jboss-openshift/openshift-quickstarts from undertow-servlet
        | variable                         | value  |
        | GC_MAX_HEAP_FREE_RATIO           | 50     |
-    Then s2i build log should contain Using MAVEN_OPTS -XX:+UseParallelOldGC -XX:MinHeapFreeRatio=10 -XX:MaxHeapFreeRatio=50 -XX:GCTimeRatio=4 -XX:AdaptiveSizePolicyWeight=90
-    And container log should contain -XX:+UseParallelOldGC -XX:MinHeapFreeRatio=10 -XX:MaxHeapFreeRatio=50 -XX:GCTimeRatio=4 -XX:AdaptiveSizePolicyWeight=90
+    Then s2i build log should contain Using MAVEN_OPTS -XX:+UseParallelGC -XX:MinHeapFreeRatio=10 -XX:MaxHeapFreeRatio=50 -XX:GCTimeRatio=4 -XX:AdaptiveSizePolicyWeight=90
+    And container log should contain -XX:+UseParallelGC -XX:MinHeapFreeRatio=10 -XX:MaxHeapFreeRatio=50 -XX:GCTimeRatio=4 -XX:AdaptiveSizePolicyWeight=90
 
   Scenario: Check GC_TIME_RATIO GC configuration
     Given s2i build https://github.com/jboss-openshift/openshift-quickstarts from undertow-servlet
        | variable                         | value  |
        | GC_TIME_RATIO                    | 5      |
-    Then s2i build log should contain Using MAVEN_OPTS -XX:+UseParallelOldGC -XX:MinHeapFreeRatio=10 -XX:MaxHeapFreeRatio=20 -XX:GCTimeRatio=5 -XX:AdaptiveSizePolicyWeight=90
-    And container log should contain -XX:+UseParallelOldGC -XX:MinHeapFreeRatio=10 -XX:MaxHeapFreeRatio=20 -XX:GCTimeRatio=5 -XX:AdaptiveSizePolicyWeight=90
+    Then s2i build log should contain Using MAVEN_OPTS -XX:+UseParallelGC -XX:MinHeapFreeRatio=10 -XX:MaxHeapFreeRatio=20 -XX:GCTimeRatio=5 -XX:AdaptiveSizePolicyWeight=90
+    And container log should contain -XX:+UseParallelGC -XX:MinHeapFreeRatio=10 -XX:MaxHeapFreeRatio=20 -XX:GCTimeRatio=5 -XX:AdaptiveSizePolicyWeight=90
 
   Scenario: Check GC_ADAPTIVE_SIZE_POLICY_WEIGHT GC configuration
     Given s2i build https://github.com/jboss-openshift/openshift-quickstarts from undertow-servlet
        | variable                         | value  |
        | GC_ADAPTIVE_SIZE_POLICY_WEIGHT   | 80     |
-    Then s2i build log should contain Using MAVEN_OPTS -XX:+UseParallelOldGC -XX:MinHeapFreeRatio=10 -XX:MaxHeapFreeRatio=20 -XX:GCTimeRatio=4 -XX:AdaptiveSizePolicyWeight=80
-    And container log should contain -XX:+UseParallelOldGC -XX:MinHeapFreeRatio=10 -XX:MaxHeapFreeRatio=20 -XX:GCTimeRatio=4 -XX:AdaptiveSizePolicyWeight=80
+    Then s2i build log should contain Using MAVEN_OPTS -XX:+UseParallelGC -XX:MinHeapFreeRatio=10 -XX:MaxHeapFreeRatio=20 -XX:GCTimeRatio=4 -XX:AdaptiveSizePolicyWeight=80
+    And container log should contain -XX:+UseParallelGC -XX:MinHeapFreeRatio=10 -XX:MaxHeapFreeRatio=20 -XX:GCTimeRatio=4 -XX:AdaptiveSizePolicyWeight=80
 
   Scenario: Check GC_MAX_METASPACE_SIZE GC configuration
     Given s2i build https://github.com/jboss-openshift/openshift-quickstarts from undertow-servlet
        | variable                 | value  |
        | GC_MAX_METASPACE_SIZE    | 120    |
-    Then s2i build log should contain Using MAVEN_OPTS -XX:+UseParallelOldGC -XX:MinHeapFreeRatio=10 -XX:MaxHeapFreeRatio=20 -XX:GCTimeRatio=4 -XX:AdaptiveSizePolicyWeight=90 -XX:MaxMetaspaceSize=120m
-    And container log should contain -XX:+UseParallelOldGC -XX:MinHeapFreeRatio=10 -XX:MaxHeapFreeRatio=20 -XX:GCTimeRatio=4 -XX:AdaptiveSizePolicyWeight=90 -XX:MaxMetaspaceSize=120m
+    Then s2i build log should contain Using MAVEN_OPTS -XX:+UseParallelGC -XX:MinHeapFreeRatio=10 -XX:MaxHeapFreeRatio=20 -XX:GCTimeRatio=4 -XX:AdaptiveSizePolicyWeight=90 -XX:MaxMetaspaceSize=120m
+    And container log should contain -XX:+UseParallelGC -XX:MinHeapFreeRatio=10 -XX:MaxHeapFreeRatio=20 -XX:GCTimeRatio=4 -XX:AdaptiveSizePolicyWeight=90 -XX:MaxMetaspaceSize=120m
 
   Scenario: Check GC_CONTAINER_OPTIONS configuration
     Given s2i build https://github.com/jboss-openshift/openshift-quickstarts from undertow-servlet
@@ -51,4 +51,4 @@ Feature: Openshift OpenJDK GC tests
        | GC_CONTAINER_OPTIONS | -XX:+UseG1GC |
     Then s2i build log should contain Using MAVEN_OPTS -XX:+UseG1GC
     And container log should contain -XX:+UseG1GC
-    And container log should not contain -XX:+UseParallelOldGC
+    And container log should not contain -XX:+UseParallelGC

--- a/tests/features/java/gc.feature
+++ b/tests/features/java/gc.feature
@@ -1,6 +1,7 @@
 @openjdk
 @ubi8/openjdk-8
 @ubi8/openjdk-11
+@ubi8/openjdk-17
 @redhat-openjdk-18
 @openj9
 Feature: Openshift OpenJDK GC tests

--- a/tests/features/java/java_s2i.feature
+++ b/tests/features/java/java_s2i.feature
@@ -1,6 +1,7 @@
 @openjdk
 @ubi8/openjdk-8
 @ubi8/openjdk-11
+@ubi8/openjdk-17
 @redhat-openjdk-18
 @openj9
 Feature: Openshift OpenJDK S2I tests

--- a/tests/features/java/java_s2i_inc.feature
+++ b/tests/features/java/java_s2i_inc.feature
@@ -1,6 +1,7 @@
 @openjdk
 @ubi8/openjdk-8
 @ubi8/openjdk-11
+@ubi8/openjdk-17
 @redhat-openjdk-18
 @openj9
 Feature: Openshift OpenJDK S2I tests

--- a/tests/features/java/openjdk.feature
+++ b/tests/features/java/openjdk.feature
@@ -12,6 +12,7 @@ Feature: Miscellaneous OpenJDK-related unit tests
     | arg     | value   |
     | command | rpm -qa |
     Then available container log should not contain java-11
+    Then available container log should not contain java-17
 
   @openjdk/openjdk-11-rhel7
   @openjdk/openjdk-11-ubi8
@@ -23,6 +24,15 @@ Feature: Miscellaneous OpenJDK-related unit tests
     | arg     | value   |
     | command | rpm -qa |
     Then available container log should not contain java-1.8.0
+    Then available container log should not contain java-17
+
+  @ubi8/openjdk-17
+  Scenario: Check that only OpenJDK 17 is installed
+    When container is started with args
+    | arg     | value   |
+    | command | rpm -qa |
+    Then available container log should not contain java-1.8.0
+    Then available container log should not contain java-11
 
   @ubi8
   @openjdk

--- a/tests/features/java/ports.feature
+++ b/tests/features/java/ports.feature
@@ -1,6 +1,7 @@
 @openjdk
 @ubi8/openjdk-8
 @ubi8/openjdk-11
+@ubi8/openjdk-17
 @redhat-openjdk-18
 @openj9
 Feature: Openshift OpenJDK port tests

--- a/tests/features/java/runtime.feature
+++ b/tests/features/java/runtime.feature
@@ -3,6 +3,7 @@ Feature: Openshift OpenJDK Runtime tests
   @openjdk
   @ubi8/openjdk-8
   @ubi8/openjdk-11
+  @ubi8/openjdk-17
   @redhat-openjdk-18
   @openj9
   Scenario: Ensure JVM_ARGS is no longer present in the run script
@@ -12,6 +13,7 @@ Feature: Openshift OpenJDK Runtime tests
   @openjdk
   @ubi8/openjdk-8
   @ubi8/openjdk-11
+  @ubi8/openjdk-17
   @redhat-openjdk-18
   @openj9
   Scenario: Ensure JAVA_ARGS are passed through to the running java application
@@ -23,6 +25,7 @@ Feature: Openshift OpenJDK Runtime tests
   @openjdk
   @ubi8/openjdk-8
   @ubi8/openjdk-11
+  @ubi8/openjdk-17
   @redhat-openjdk-18
   # Not @openj9 yet, we do not set any specific options for it yet
   Scenario: Ensure diagnostic options work correctly

--- a/tests/features/openshift.feature
+++ b/tests/features/openshift.feature
@@ -1,6 +1,7 @@
 @openjdk
 @ubi8/openjdk-8
 @ubi8/openjdk-11
+@ubi8/openjdk-17
 @redhat-openjdk-18
 Feature: Tests for all openshift images
 

--- a/tests/features/prometheus.feature
+++ b/tests/features/prometheus.feature
@@ -3,6 +3,7 @@
 @openj9
 @ubi8/openjdk-8
 @ubi8/openjdk-11
+@ubi8/openjdk-17
 Feature: Prometheus agent tests
 
   Scenario: Verify API and defaults

--- a/tests/features/s2i-core.feature
+++ b/tests/features/s2i-core.feature
@@ -1,6 +1,7 @@
 @openjdk
 @ubi8/openjdk-8
 @ubi8/openjdk-11
+@ubi8/openjdk-17
 @redhat-openjdk-18
 @openj9
 Feature: Openshift S2I tests

--- a/ubi8-openjdk-17.yaml
+++ b/ubi8-openjdk-17.yaml
@@ -1,0 +1,55 @@
+# This is an Image descriptor for Cekit
+
+schema_version: 1
+
+from: "ubi8-minimal:8.5"
+name: &name "ubi8/openjdk-17"
+version: &version "1.10"
+description: "Source To Image (S2I) image for Red Hat OpenShift providing OpenJDK 17"
+
+labels:
+- name: "io.k8s.description"
+  value: "Platform for building and running plain Java applications (fat-jar and flat classpath)"
+- name: "io.k8s.display-name"
+  value: "Java Applications"
+- name: "io.openshift.tags"
+  value: "builder,java"
+- name: "maintainer"
+  value: "Red Hat OpenJDK <openjdk@redhat.com>"
+- name: "com.redhat.component"
+  value: "openjdk-17-ubi8-container"
+- name: "usage"
+  value: "https://access.redhat.com/documentation/en-us/red_hat_jboss_middleware_for_openshift/3/html/red_hat_java_s2i_for_openshift/"
+- name: "com.redhat.license_terms"
+  value: "https://www.redhat.com/en/about/red-hat-end-user-license-agreements#UBI"
+
+envs:
+- name: PATH
+  value: $PATH:"/usr/local/s2i"
+- name: "JBOSS_IMAGE_NAME"
+  value: *name
+- name: "JBOSS_IMAGE_VERSION"
+  value: *version
+
+ports:
+- value: 8080
+- value: 8443
+
+modules:
+  repositories:
+  - path: modules
+  install:
+  - name: jboss.container.util.pkg-update
+  - name: jboss.container.openjdk.jdk
+    version: "17"
+  - name: jboss.container.prometheus
+  - name: jboss.container.maven
+    version: "8.2.3.6"
+  - name: jboss.container.java.s2i.bash
+  - name: jboss.container.java.singleton-jdk
+
+help:
+  add: true
+
+packages:
+  manager: microdnf


### PR DESCRIPTION
Adding this to the develop branch now will mean we will get automatic CI builds (internal at least)  which will help with image development.

The commit which adjusts the jolokia test is a pre-requisite so that we can tag the affected non-jolokia tests for the JDK17 image (which does not carry jolokia)

Thanks!