### PR TITLE
Initial Jdk17 runtime image

### DIFF
--- a/modules/jre/17/artifacts/opt/jboss/container/openjdk/jre/jvm-options
+++ b/modules/jre/17/artifacts/opt/jboss/container/openjdk/jre/jvm-options
@@ -1,0 +1,10 @@
+
+#!/bin/sh
+# ==============================================================================
+# JDK specific customizations
+#
+# ==============================================================================
+
+function jvm_specific_diagnostics() {
+    echo "-Xlog:gc::utctime -XX:NativeMemoryTracking=summary"
+}

--- a/modules/jre/17/configure.sh
+++ b/modules/jre/17/configure.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+# Configure module
+set -e
+
+SCRIPT_DIR=$(dirname $0)
+echo $SCRIPT_DIR
+ARTIFACTS_DIR=${SCRIPT_DIR}/artifacts
+echo $ARTIFACTS_DIR
+
+chown -R jboss:root $SCRIPT_DIR
+chmod -R ug+rwX $SCRIPT_DIR
+chmod ug+x ${ARTIFACTS_DIR}/opt/jboss/container/openjdk/jre/*
+
+pushd ${ARTIFACTS_DIR}
+cp -pr * /
+popd
+
+# Set this JDK as the alternative in use
+_arch="$(uname -i)"
+alternatives --set java java-17-openjdk.${_arch}

--- a/modules/jre/17/module.yaml
+++ b/modules/jre/17/module.yaml
@@ -1,0 +1,34 @@
+schema_version: 1
+
+name: "jboss.container.openjdk.jre"
+description: "Installs only the JRE headless for OpenJDK 17."
+version: "17"
+
+labels:
+- name: "org.jboss.product"
+  value: "openjdk"
+- name: "org.jboss.product.version"
+  value: "17"
+- name: "org.jboss.product.openjdk.version"
+  value: "17"
+
+envs:
+- name: "JAVA_HOME"
+  value: "/usr/lib/jvm/jre"
+- name: "JAVA_VENDOR"
+  value: "openjdk"
+- name: "JAVA_VERSION"
+  value: "17"
+- name: JBOSS_CONTAINER_OPENJDK_JRE_MODULE
+  value: /opt/jboss/container/openjdk/jre
+
+packages:
+  install:
+  - java-17-openjdk-headless
+
+modules:
+  install:
+  - name: jboss.container.user
+
+execute:
+- script: configure.sh

--- a/redhat/ubi8-openjdk-17-runtime.yaml
+++ b/redhat/ubi8-openjdk-17-runtime.yaml
@@ -1,0 +1,26 @@
+osbs:
+  configuration:
+    container:
+      compose:
+        pulp_repos: true
+        packages: []
+        signing_intent: unsigned
+  repository:
+    name: containers/openjdk
+    branch: openjdk-17-runtime-ubi8
+
+packages:
+  manager: microdnf
+  content_sets:
+    x86_64:
+    - rhel-8-for-x86_64-baseos-rpms__8
+    - rhel-8-for-x86_64-appstream-rpms__8
+    ppc64le:
+    - rhel-8-for-ppc64le-appstream-rpms__8
+    - rhel-8-for-ppc64le-baseos-rpms__8
+    aarch64:
+    - rhel-8-for-aarch64-baseos-rpms__8
+    - rhel-8-for-aarch64-appstream-rpms__8
+    s390x:
+    - rhel-8-for-s390x-baseos-rpms__8
+    - rhel-8-for-s390x-appstream-rpms__8

--- a/ubi8-openjdk-17-runtime.yaml
+++ b/ubi8-openjdk-17-runtime.yaml
@@ -1,0 +1,49 @@
+# This is an Image descriptor for Cekit
+
+schema_version: 1
+
+from: "registry.access.redhat.com/ubi8/ubi-minimal"
+name: &name "ubi8/openjdk-17-runtime"
+version: &version "1.10"
+description: "Image for Red Hat OpenShift providing OpenJDK 17 runtime"
+
+labels:
+- name: "io.k8s.description"
+  value: "Platform for running plain Java applications (fat-jar and flat classpath)"
+- name: "io.k8s.display-name"
+  value: "Java Applications"
+- name: "io.openshift.tags"
+  value: "java"
+- name: "maintainer"
+  value: "Red Hat OpenJDK <openjdk@redhat.com>"
+- name: "com.redhat.component"
+  value: "openjdk-17-runtime-ubi8-container"
+- name: "usage"
+  value: "https://access.redhat.com/documentation/en-us/red_hat_jboss_middleware_for_openshift/3/html/red_hat_java_s2i_for_openshift/"
+- name: "com.redhat.license_terms"
+  value: "https://www.redhat.com/en/about/red-hat-end-user-license-agreements#UBI"
+
+envs:
+- name: "JBOSS_IMAGE_NAME"
+  value: *name
+- name: "JBOSS_IMAGE_VERSION"
+  value: *version
+
+ports:
+- value: 8080
+- value: 8443
+
+modules:
+  repositories:
+  - path: modules
+  install:
+  - name: jboss.container.util.pkg-update
+  - name: jboss.container.openjdk.jre
+    version: "17"
+  - name: jboss.container.java.jre.run
+
+help:
+  add: true
+
+packages:
+  manager: microdnf

--- a/ubi8-openjdk-17-runtime.yaml
+++ b/ubi8-openjdk-17-runtime.yaml
@@ -2,7 +2,7 @@
 
 schema_version: 1
 
-from: "registry.access.redhat.com/ubi8/ubi-minimal"
+from: "ubi8-minimal:8.5"
 name: &name "ubi8/openjdk-17-runtime"
 version: &version "1.10"
 description: "Image for Red Hat OpenShift providing OpenJDK 17 runtime"


### PR DESCRIPTION
Following the initial OpenJDK 17 builder image, here's the runtime.