### PR TITLE
[OPENJDK-528] rework singleton-jdk to use a single RPM transaction

### DIFF
--- a/modules/singleton-jdk/configure.sh
+++ b/modules/singleton-jdk/configure.sh
@@ -13,8 +13,4 @@ fi
 
 # Clean up any java-* packages that have been installed that do not match
 # our stated JAVA_VERSION-JAVA_VENDOR (e.g.: 11-openjdk; 1.8.0-openj9)
-rpm -qa java-\* | while read pkg; do
-    if ! echo "$pkg" | grep -q "^java-${JAVA_VERSION}-${JAVA_VENDOR}"; then
-        rpm -e --nodeps "$pkg"
-    fi
-done
+rpm -e --nodeps $(rpm -qa java-* | grep -v "^java-${JAVA_VERSION}-${JAVA_VENDOR}")

--- a/tests/features/java/openjdk.feature
+++ b/tests/features/java/openjdk.feature
@@ -52,3 +52,27 @@ Feature: Miscellaneous OpenJDK-related unit tests
     Then available container log should not contain dejavu-sans-mono-fonts
     Then available container log should not contain os-prober
     Then available container log should not contain rpm-plugin-systemd-inhibit
+
+  @ubi8/openjdk-8
+  Scenario: Check that directories from other JDKs are not present (JDK8)
+    When container is started with args
+    | arg     | value   |
+    | command | ls -1 /usr/lib/jvm |
+    Then available container log should not contain java-11
+    And  available container log should not contain java-17
+
+  @ubi8/openjdk-11
+  Scenario: Check that directories from other JDKs are not present (JDK11)
+    When container is started with args
+    | arg     | value   |
+    | command | ls -1 /usr/lib/jvm |
+    Then available container log should not contain java-1.8.0
+    Then available container log should not contain java-17
+
+  @ubi8/openjdk-17
+  Scenario: Check that directories from other JDKs are not present (JDK17)
+    When container is started with args
+    | arg     | value   |
+    | command | ls -1 /usr/lib/jvm |
+    Then available container log should not contain java-1.8.0
+    Then available container log should not contain java-11


### PR DESCRIPTION
https://issues.redhat.com/browse/OPENJDK-528


The singleton jdk module loops over the output of `rpm -qa` and invokes `rpm -e --nodeps` once per matching line. If a stray JDK is going to be removed, this happens to remove the -devel package before the -headless (normally -headless would go first because -devel depends on it). The can result in some empty directories remaining in /usr/lib/jvm.

Rewrite that loop to call `rpm -e --nodeps` once with all the packages to remove so they're in a single transaction.
