### PR TITLE
[OPENJDK-529] Change OpenJDK17 FROM lines to match other images

### DIFF
--- a/ubi8-openjdk-17-runtime.yaml
+++ b/ubi8-openjdk-17-runtime.yaml
@@ -2,7 +2,7 @@
 
 schema_version: 1
 
-from: "ubi8-minimal:8.5"
+from: "registry.access.redhat.com/ubi8/ubi-minimal"
 name: &name "ubi8/openjdk-17-runtime"
 version: &version "1.10"
 description: "Image for Red Hat OpenShift providing OpenJDK 17 runtime"

--- a/ubi8-openjdk-17.yaml
+++ b/ubi8-openjdk-17.yaml
@@ -2,7 +2,7 @@
 
 schema_version: 1
 
-from: "ubi8-minimal:8.5"
+from: "registry.access.redhat.com/ubi8/ubi-minimal"
 name: &name "ubi8/openjdk-17"
 version: &version "1.10"
 description: "Source To Image (S2I) image for Red Hat OpenShift providing OpenJDK 17"


### PR DESCRIPTION
The JDK17 images are configured with a FROM line of `ubi8-minimal:8.5`,
which

 * was required to build based on UBI 8.5 internally prior to RHEL 8.5 GA
 * doesn't work out-of-the-box with docker, podman etc

Change it to match the other ubi8-based images.

Signed-off-by: Jonathan Dowland <jdowland@redhat.com>