### PR TITLE
[OPENJDK-530] Align redhat/*17* with other images

### DIFF
--- a/redhat/ubi8-openjdk-17-runtime.yaml
+++ b/redhat/ubi8-openjdk-17-runtime.yaml
@@ -4,7 +4,7 @@ osbs:
       compose:
         pulp_repos: true
         packages: []
-        signing_intent: unsigned
+        signing_intent: release
   repository:
     name: containers/openjdk
     branch: openjdk-17-runtime-ubi8
@@ -13,14 +13,14 @@ packages:
   manager: microdnf
   content_sets:
     x86_64:
-    - rhel-8-for-x86_64-baseos-rpms__8
-    - rhel-8-for-x86_64-appstream-rpms__8
+    - rhel-8-for-x86_64-baseos-rpms
+    - rhel-8-for-x86_64-appstream-rpms
     ppc64le:
-    - rhel-8-for-ppc64le-appstream-rpms__8
-    - rhel-8-for-ppc64le-baseos-rpms__8
+    - rhel-8-for-ppc64le-baseos-rpms
+    - rhel-8-for-ppc64le-appstream-rpms
     aarch64:
-    - rhel-8-for-aarch64-baseos-rpms__8
-    - rhel-8-for-aarch64-appstream-rpms__8
+    - rhel-8-for-aarch64-baseos-rpms
+    - rhel-8-for-aarch64-appstream-rpms
     s390x:
-    - rhel-8-for-s390x-baseos-rpms__8
-    - rhel-8-for-s390x-appstream-rpms__8
+    - rhel-8-for-s390x-baseos-rpms
+    - rhel-8-for-s390x-appstream-rpms

--- a/redhat/ubi8-openjdk-17.yaml
+++ b/redhat/ubi8-openjdk-17.yaml
@@ -4,24 +4,23 @@ osbs:
       compose:
         pulp_repos: true
         packages: []
-        signing_intent: unsigned
+        signing_intent: release
   repository:
     name: containers/openjdk
     branch: openjdk-17-ubi8
-  koji_target: openjdk-17-ubi8-containers-candidate
 
 packages:
   manager: microdnf
   content_sets:
     x86_64:
-    - rhel-8-for-x86_64-baseos-rpms__8
-    - rhel-8-for-x86_64-appstream-rpms__8
+    - rhel-8-for-x86_64-baseos-rpms
+    - rhel-8-for-x86_64-appstream-rpms
     ppc64le:
-    - rhel-8-for-ppc64le-appstream-rpms__8
-    - rhel-8-for-ppc64le-baseos-rpms__8
+    - rhel-8-for-ppc64le-baseos-rpms
+    - rhel-8-for-ppc64le-appstream-rpms
     aarch64:
-    - rhel-8-for-aarch64-baseos-rpms__8
-    - rhel-8-for-aarch64-appstream-rpms__8
+    - rhel-8-for-aarch64-baseos-rpms
+    - rhel-8-for-aarch64-appstream-rpms
     s390x:
-    - rhel-8-for-s390x-baseos-rpms__8
-    - rhel-8-for-s390x-appstream-rpms__8
+    - rhel-8-for-s390x-baseos-rpms
+    - rhel-8-for-s390x-appstream-rpms


### PR DESCRIPTION
The redhat/ubi8/openjdk-17-* files are configure for pre-release and
need to be updated to align with the other images post-release.