### PR TITLE
Add OpenJDK 17 images to OpenShift ImageStream templates.

### DIFF
--- a/templates/community-image-streams.json
+++ b/templates/community-image-streams.json
@@ -119,6 +119,40 @@
             "kind": "ImageStream",
             "apiVersion": "image.openshift.io/v1",
             "metadata": {
+                "name": "ubi8-openjdk-17",
+                "annotations": {
+                    "openshift.io/display-name": "Red Hat OpenJDK 17 (UBI8)",
+                    "openshift.io/provider-display-name": "Red Hat, Inc."
+                }
+            },
+            "spec": {
+                "tags": [
+                    {
+                        "name": "1.11",
+                        "annotations": {
+                            "openshift.io/display-name": "Red Hat OpenJDK 17 (UBI8)",
+                            "description": "Build and run Java applications using Maven and OpenJDK 17 upon RHEL8.",
+                            "iconClass": "icon-rh-openjdk",
+                            "tags": "builder,java,openjdk,ubi8",
+                            "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts",
+                            "sampleContextDir": "undertow-servlet",
+                            "version": "1.11"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
+                        },
+                        "from": {
+                            "kind": "DockerImage",
+                            "name": "registry.access.redhat.com/ubi8/openjdk-17:1.11"
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "kind": "ImageStream",
+            "apiVersion": "image.openshift.io/v1",
+            "metadata": {
                 "name": "java",
                 "annotations": {
                     "openshift.io/display-name": "Red Hat OpenJDK",

--- a/templates/image-streams-aarch64.json
+++ b/templates/image-streams-aarch64.json
@@ -127,6 +127,44 @@
             "kind": "ImageStream",
             "apiVersion": "image.openshift.io/v1",
             "metadata": {
+                "name": "ubi8-openjdk-17",
+                "annotations": {
+                    "openshift.io/display-name": "Red Hat OpenJDK 17 (UBI8)",
+                    "openshift.io/provider-display-name": "Red Hat, Inc.",
+                    "version": "1.4.17"
+                },
+                "labels": {
+                    "xpaas": "1.4.17"
+                }
+            },
+            "spec": {
+                "tags": [
+                    {
+                        "name": "1.11",
+                        "annotations": {
+                            "openshift.io/display-name": "Red Hat OpenJDK 17 (UBI8)",
+                            "description": "Build and run Java applications using Maven and OpenJDK 17 upon UBI8.",
+                            "iconClass": "icon-rh-openjdk",
+                            "tags": "builder,java,openjdk,ubi8,hidden",
+                            "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts",
+                            "sampleContextDir": "undertow-servlet",
+                            "version": "1.11"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
+                        },
+                        "from": {
+                            "kind": "DockerImage",
+                            "name": "registry.access.redhat.com/ubi8/openjdk-17:1.11"
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "kind": "ImageStream",
+            "apiVersion": "image.openshift.io/v1",
+            "metadata": {
                 "name": "java",
                 "annotations": {
                     "openshift.io/display-name": "Red Hat OpenJDK",

--- a/templates/image-streams-ppc64le.json
+++ b/templates/image-streams-ppc64le.json
@@ -325,6 +325,44 @@
             "kind": "ImageStream",
             "apiVersion": "image.openshift.io/v1",
             "metadata": {
+                "name": "ubi8-openjdk-17",
+                "annotations": {
+                    "openshift.io/display-name": "Red Hat OpenJDK 17 (UBI8)",
+                    "openshift.io/provider-display-name": "Red Hat, Inc.",
+                    "version": "1.4.17"
+                },
+                "labels": {
+                    "xpaas": "1.4.17"
+                }
+            },
+            "spec": {
+                "tags": [
+                    {
+                        "name": "1.11",
+                        "annotations": {
+                            "openshift.io/display-name": "Red Hat OpenJDK 17 (UBI8)",
+                            "description": "Build and run Java applications using Maven and OpenJDK 17 upon UBI8.",
+                            "iconClass": "icon-rh-openjdk",
+                            "tags": "builder,java,openjdk,ubi8,hidden",
+                            "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts",
+                            "sampleContextDir": "undertow-servlet",
+                            "version": "1.11"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
+                        },
+                        "from": {
+                            "kind": "DockerImage",
+                            "name": "registry.access.redhat.com/ubi8/openjdk-17:1.11"
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "kind": "ImageStream",
+            "apiVersion": "image.openshift.io/v1",
+            "metadata": {
                 "name": "java",
                 "annotations": {
                     "openshift.io/display-name": "Red Hat OpenJDK",

--- a/templates/image-streams-s390x.json
+++ b/templates/image-streams-s390x.json
@@ -325,6 +325,44 @@
             "kind": "ImageStream",
             "apiVersion": "image.openshift.io/v1",
             "metadata": {
+                "name": "ubi8-openjdk-17",
+                "annotations": {
+                    "openshift.io/display-name": "Red Hat OpenJDK 17 (UBI8)",
+                    "openshift.io/provider-display-name": "Red Hat, Inc.",
+                    "version": "1.4.17"
+                },
+                "labels": {
+                    "xpaas": "1.4.17"
+                }
+            },
+            "spec": {
+                "tags": [
+                    {
+                        "name": "1.11",
+                        "annotations": {
+                            "openshift.io/display-name": "Red Hat OpenJDK 17 (UBI8)",
+                            "description": "Build and run Java applications using Maven and OpenJDK 17 upon UBI8.",
+                            "iconClass": "icon-rh-openjdk",
+                            "tags": "builder,java,openjdk,ubi8,hidden",
+                            "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts",
+                            "sampleContextDir": "undertow-servlet",
+                            "version": "1.11"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
+                        },
+                        "from": {
+                            "kind": "DockerImage",
+                            "name": "registry.access.redhat.com/ubi8/openjdk-17:1.11"
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "kind": "ImageStream",
+            "apiVersion": "image.openshift.io/v1",
+            "metadata": {
                 "name": "openj9-8-rhel7",
                 "annotations": {
                     "openshift.io/display-name": "OpenJ9 1.8.0 (RHEL7)",
@@ -629,6 +667,26 @@
                         "from": {
                             "kind": "DockerImage",
                             "name": "registry.redhat.io/openjdk/openjdk-11-rhel7:latest"
+                        }
+                    },
+                    {
+                        "name": "openjdk-17-ubi8",
+                        "annotations": {
+                            "openshift.io/display-name": "Red Hat OpenJDK 17 (UBI 8)",
+                            "description": "Build and run Java applications using Maven and OpenJDK 17.",
+                            "iconClass": "icon-rh-openjdk",
+                            "tags": "builder,java,openjdk",
+                            "supports": "java:17,java",
+                            "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts",
+                            "sampleContextDir": "undertow-servlet",
+                            "version": "17"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
+                        },
+                        "from": {
+                            "kind": "DockerImage",
+                            "name": "registry.access.redhat.com/ubi8/openjdk-17:latest"
                         }
                     },
                     {

--- a/templates/image-streams.json
+++ b/templates/image-streams.json
@@ -425,6 +425,44 @@
             "kind": "ImageStream",
             "apiVersion": "image.openshift.io/v1",
             "metadata": {
+                "name": "ubi8-openjdk-17",
+                "annotations": {
+                    "openshift.io/display-name": "Red Hat OpenJDK 17 (UBI8)",
+                    "openshift.io/provider-display-name": "Red Hat, Inc.",
+                    "version": "1.4.17"
+                },
+                "labels": {
+                    "xpaas": "1.4.17"
+                }
+            },
+            "spec": {
+                "tags": [
+                    {
+                        "name": "1.11",
+                        "annotations": {
+                            "openshift.io/display-name": "Red Hat OpenJDK 17 (UBI8)",
+                            "description": "Build and run Java applications using Maven and OpenJDK 17 upon RHEL8.",
+                            "iconClass": "icon-rh-openjdk",
+                            "tags": "builder,java,openjdk,ubi8,hidden",
+                            "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts",
+                            "sampleContextDir": "undertow-servlet",
+                            "version": "1.11"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
+                        },
+                        "from": {
+                            "kind": "DockerImage",
+                            "name": "registry.access.redhat.com/ubi8/openjdk-17:1.11"
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "kind": "ImageStream",
+            "apiVersion": "image.openshift.io/v1",
+            "metadata": {
                 "name": "openjdk-11-rhel8",
                 "annotations": {
                     "openshift.io/display-name": "Red Hat OpenJDK 11 (RHEL8)",

--- a/templates/openjdk-web-basic-s2i.json
+++ b/templates/openjdk-web-basic-s2i.json
@@ -29,7 +29,7 @@
             "required": true
         },
         {
-            "description": "The version of Java to use, e.g. 8, 11, latest. (Corresponds to the 'java' ImageStream tag.)",
+            "description": "The version of Java to use, e.g. 8, 11, 17, latest. (Corresponds to the 'java' ImageStream tag.)",
             "displayName": "Java Version",
             "name": "JAVA_IMAGE_STREAM_TAG",
             "value": "latest",


### PR DESCRIPTION
Could you please review?
These changes are done by branching out from 'release' branch.