### PR TITLE
OPENJDK-533: test $HOME/passwd can be written to

### DIFF
--- a/modules/run/artifacts/opt/jboss/container/java/run/run-java.sh
+++ b/modules/run/artifacts/opt/jboss/container/java/run/run-java.sh
@@ -220,7 +220,11 @@ get_exec_args() {
 # Ensure that the running UID has the "jboss" passwd metadata
 # XXX: Maybe we should make this an entrypoint for the image?
 function configure_passwd() {
-  sed "/^jboss/s/[^:]*/$(id -u)/3" /etc/passwd > "$HOME/passwd"
+  # OPENJDK-533: this file is only writeable if the image uses the
+  # nss_wrapper module. ubi8/openjdk-17 does not.
+  if [ -w "$HOME/passwd" ]; then
+    sed "/^jboss/s/[^:]*/$(id -u)/3" /etc/passwd > "$HOME/passwd"
+  fi
 }
 
 # Start JVM

--- a/modules/user/configure.sh
+++ b/modules/user/configure.sh
@@ -6,3 +6,7 @@ set -e
 # This ID is registered static ID for the JBoss EAP product
 # on RHEL which makes it safe to use.
 groupadd -r jboss -g 185 && useradd -u 185 -r -g root -G jboss -m -d /home/jboss -s /sbin/nologin -c "JBoss user" jboss
+
+# OPENJDK-533: Some container runtimes (Docker) will fail to start if
+# the running UID cannot chdir to $HOME
+chmod og+x /home/jboss


### PR DESCRIPTION
run-java.sh has a line which attempts to write to $HOME/passwd, which is
part of the solution for backwards compatibility on OCP 3.11
(OPENJDK-312). This was made writeable by a common module but that was
moved to a new nss-wrapper module in OPENJDK-493, which is not installed
in OpenJDK 17 containers.

Two problems result for the OpenJDK-17 image:

1. Starting a downstream (S2I) container with a random UID (OpenShift
   default) terminates when the attempt to write to /home/jboss/passwd
   fails
2. for some container runtimes (at least Docker), the container will
   refuse to start if the running uid can't chdir to /home/jboss

That change also moved changing the /home/jboss permissions. Partially
revert those changes and check to ensure the file can be written before
attempting to.

----

Testing performed:

 • local s2i builds, verified the /home/jboss +x change resolves the docker issue
 • `oc new-app` (OCP 4.x cluster) with a quarkus quickstart, pod runs

I'm surprised that the Behave tests didn't catch these issues, and I'm looking now
to find out why.