### PR TITLE
Update imagestreams in release

### DIFF
--- a/templates/community-image-streams.json
+++ b/templates/community-image-streams.json
@@ -208,6 +208,26 @@
                         }
                     },
                     {
+                        "name": "openjdk-17-ubi8",
+                        "annotations": {
+                            "openshift.io/display-name": "Red Hat OpenJDK 17 (UBI 8)",
+                            "description": "Build and run Java applications using Maven and OpenJDK 17 upon UBI8.",
+                            "iconClass": "icon-rh-openjdk",
+                            "tags": "builder,java,openjdk",
+                            "supports": "java:17,java",
+                            "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts",
+                            "sampleContextDir": "undertow-servlet",
+                            "version": "17"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
+                        },
+                        "from": {
+                            "kind": "DockerImage",
+                            "name": "registry.access.redhat.com/ubi8/openjdk-17:latest"
+                        }
+                    },
+                    {
                         "name": "latest",
                         "annotations": {
                             "openshift.io/display-name": "Java (Latest)",
@@ -224,7 +244,7 @@
                         },
                         "from": {
                             "kind": "ImageStreamTag",
-                            "name": "openjdk-11-ubi8"
+                            "name": "openjdk-17-ubi8"
                         }
                     }
                 ]

--- a/templates/community-image-streams.json
+++ b/templates/community-image-streams.json
@@ -11,7 +11,7 @@
     "items": [
         {
             "kind": "ImageStream",
-            "apiVersion": "v1",
+            "apiVersion": "image.openshift.io/v1",
             "metadata": {
                 "name": "ubi8-openjdk-8",
                 "annotations": {
@@ -64,7 +64,7 @@
         },
         {
             "kind": "ImageStream",
-            "apiVersion": "v1",
+            "apiVersion": "image.openshift.io/v1",
             "metadata": {
                 "name": "ubi8-openjdk-11",
                 "annotations": {
@@ -117,7 +117,7 @@
         },
         {
             "kind": "ImageStream",
-            "apiVersion": "v1",
+            "apiVersion": "image.openshift.io/v1",
             "metadata": {
                 "name": "java",
                 "annotations": {

--- a/templates/image-streams-aarch64.json
+++ b/templates/image-streams-aarch64.json
@@ -11,7 +11,7 @@
     "items": [
         {
             "kind": "ImageStream",
-            "apiVersion": "v1",
+            "apiVersion": "image.openshift.io/v1",
             "metadata": {
                 "name": "ubi8-openjdk-8",
                 "annotations": {
@@ -68,7 +68,7 @@
         },
         {
             "kind": "ImageStream",
-            "apiVersion": "v1",
+            "apiVersion": "image.openshift.io/v1",
             "metadata": {
                 "name": "ubi8-openjdk-11",
                 "annotations": {
@@ -125,7 +125,7 @@
         },
         {
             "kind": "ImageStream",
-            "apiVersion": "v1",
+            "apiVersion": "image.openshift.io/v1",
             "metadata": {
                 "name": "java",
                 "annotations": {

--- a/templates/image-streams-aarch64.json
+++ b/templates/image-streams-aarch64.json
@@ -180,6 +180,26 @@
                         }
                     },
                     {
+                        "name": "openjdk-17-ubi8",
+                        "annotations": {
+                            "openshift.io/display-name": "Red Hat OpenJDK 17 (UBI 8)",
+                            "description": "Build and run Java applications using Maven and OpenJDK 17.",
+                            "iconClass": "icon-rh-openjdk",
+                            "tags": "builder,java,openjdk",
+                            "supports": "java:17,java",
+                            "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts",
+                            "sampleContextDir": "undertow-servlet",
+                            "version": "17"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
+                        },
+                        "from": {
+                            "kind": "DockerImage",
+                            "name": "registry.redhat.io/ubi8/openjdk-17:latest"
+                        }
+                    },
+                    {
                         "name": "latest",
                         "annotations": {
                             "openshift.io/display-name": "Java (Latest)",
@@ -196,7 +216,7 @@
                         },
                         "from": {
                             "kind": "ImageStreamTag",
-                            "name": "openjdk-11-ubi8"
+                            "name": "openjdk-17-ubi8"
                         }
                     }
                 ]

--- a/templates/image-streams-ppc64le.json
+++ b/templates/image-streams-ppc64le.json
@@ -378,6 +378,46 @@
                         }
                     },
                     {
+                        "name": "openj9-8-el8",
+                        "annotations": {
+                            "openshift.io/display-name": "OpenJ9 1.8.0 (RHEL 8)",
+                            "description": "Build and run Java applications using Maven and OpenJ9 1.8.0.",
+                            "iconClass": "icon-rh-openj9",
+                            "tags": "builder,java,openj9",
+                            "supports": "java:8,java",
+                            "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts",
+                            "sampleContextDir": "undertow-servlet",
+                            "version": "8"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
+                        },
+                        "from": {
+                            "kind": "DockerImage",
+                            "name": "registry.redhat.io/openj9/openj9-8-rhel8:latest"
+                        }
+                    },
+                    {
+                        "name": "openj9-8-el7",
+                        "annotations": {
+                            "openshift.io/display-name": "OpenJ9 1.8.0 (RHEL 7)",
+                            "description": "Build and run Java applications using Maven and OpenJ9 1.8.0.",
+                            "iconClass": "icon-rh-openj9",
+                            "tags": "builder,java,openj9",
+                            "supports": "java:8,java",
+                            "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts",
+                            "sampleContextDir": "undertow-servlet",
+                            "version": "8"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
+                        },
+                        "from": {
+                            "kind": "DockerImage",
+                            "name": "registry.redhat.io/openj9/openj9-8-rhel7:latest"
+                        }
+                    },
+                    {
                         "name": "8",
                         "annotations": {
                             "openshift.io/display-name": "Red Hat OpenJDK 8",
@@ -435,6 +475,46 @@
                         "from": {
                             "kind": "DockerImage",
                             "name": "registry.redhat.io/openjdk/openjdk-11-rhel7:latest"
+                        }
+                    },
+                    {
+                        "name": "openj9-11-el8",
+                        "annotations": {
+                            "openshift.io/display-name": "Red Hat OpenJ9 11 (RHEL 8)",
+                            "description": "Build and run Java applications using Maven and OpenJ9 11.",
+                            "iconClass": "icon-rh-openj9",
+                            "tags": "builder,java,openj9",
+                            "supports": "java:11,java",
+                            "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts",
+                            "sampleContextDir": "undertow-servlet",
+                            "version": "11"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
+                        },
+                        "from": {
+                            "kind": "DockerImage",
+                            "name": "registry.redhat.io/openj9/openj9-11-rhel8:latest"
+                        }
+                    },
+                    {
+                        "name": "openj9-11-el7",
+                        "annotations": {
+                            "openshift.io/display-name": "Red Hat OpenJ9 11 (RHEL 7)",
+                            "description": "Build and run Java applications using Maven and OpenJ9 11.",
+                            "iconClass": "icon-rh-openj9",
+                            "tags": "builder,java,openj9",
+                            "supports": "java:11,java",
+                            "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts",
+                            "sampleContextDir": "undertow-servlet",
+                            "version": "11"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
+                        },
+                        "from": {
+                            "kind": "DockerImage",
+                            "name": "registry.redhat.io/openj9/openj9-11-rhel7:latest"
                         }
                     },
                     {

--- a/templates/image-streams-ppc64le.json
+++ b/templates/image-streams-ppc64le.json
@@ -538,6 +538,26 @@
                         }
                     },
                     {
+                        "name": "openjdk-17-ubi8",
+                        "annotations": {
+                            "openshift.io/display-name": "Red Hat OpenJDK 17 (UBI 8)",
+                            "description": "Build and run Java applications using Maven and OpenJDK 17.",
+                            "iconClass": "icon-rh-openjdk",
+                            "tags": "builder,java,openjdk",
+                            "supports": "java:17,java",
+                            "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts",
+                            "sampleContextDir": "undertow-servlet",
+                            "version": "17"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
+                        },
+                        "from": {
+                            "kind": "DockerImage",
+                            "name": "registry.redhat.io/ubi8/openjdk-17:latest"
+                        }
+                    },
+                    {
                         "name": "latest",
                         "annotations": {
                             "openshift.io/display-name": "Java (Latest)",
@@ -554,7 +574,7 @@
                         },
                         "from": {
                             "kind": "ImageStreamTag",
-                            "name": "openjdk-11-ubi8"
+                            "name": "openjdk-17-ubi8"
                         }
                     }
                 ]

--- a/templates/image-streams-ppc64le.json
+++ b/templates/image-streams-ppc64le.json
@@ -11,7 +11,7 @@
     "items": [
         {
             "kind": "ImageStream",
-            "apiVersion": "v1",
+            "apiVersion": "image.openshift.io/v1",
             "metadata": {
                 "name": "redhat-openjdk18-openshift",
                 "annotations": {
@@ -130,7 +130,7 @@
         },
         {
             "kind": "ImageStream",
-            "apiVersion": "v1",
+            "apiVersion": "image.openshift.io/v1",
             "metadata": {
                 "name": "openjdk-11-rhel7",
                 "annotations": {
@@ -209,7 +209,7 @@
         },
         {
             "kind": "ImageStream",
-            "apiVersion": "v1",
+            "apiVersion": "image.openshift.io/v1",
             "metadata": {
                 "name": "ubi8-openjdk-8",
                 "annotations": {
@@ -266,7 +266,7 @@
         },
         {
             "kind": "ImageStream",
-            "apiVersion": "v1",
+            "apiVersion": "image.openshift.io/v1",
             "metadata": {
                 "name": "ubi8-openjdk-11",
                 "annotations": {
@@ -323,7 +323,7 @@
         },
         {
             "kind": "ImageStream",
-            "apiVersion": "v1",
+            "apiVersion": "image.openshift.io/v1",
             "metadata": {
                 "name": "java",
                 "annotations": {

--- a/templates/image-streams-s390x.json
+++ b/templates/image-streams-s390x.json
@@ -692,12 +692,32 @@
                         }
                     },
                     {
+                        "name": "openjdk-17-ubi8",
+                        "annotations": {
+                            "openshift.io/display-name": "Red Hat OpenJDK 17 (UBI 8)",
+                            "description": "Build and run Java applications using Maven and OpenJDK 17.",
+                            "iconClass": "icon-rh-openjdk",
+                            "tags": "builder,java,openjdk",
+                            "supports": "java:17,java",
+                            "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts",
+                            "sampleContextDir": "undertow-servlet",
+                            "version": "17"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
+                        },
+                        "from": {
+                            "kind": "DockerImage",
+                            "name": "registry.redhat.io/ubi8/openjdk-17:latest"
+                        }
+                    },
+                    {
                         "name": "latest",
                         "annotations": {
                             "openshift.io/display-name": "Java (Latest)",
                             "description": "Build and run Java applications using Maven.",
-                            "iconClass": "icon-rh-openj9",
-                            "tags": "builder,java,openj9",
+                            "iconClass": "icon-rh-openjdk",
+                            "tags": "builder,java,openjdk",
                             "supports": "java",
                             "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts",
                             "sampleContextDir": "undertow-servlet",
@@ -708,7 +728,7 @@
                         },
                         "from": {
                             "kind": "ImageStreamTag",
-                            "name": "openjdk-11-ubi8"
+                            "name": "openjdk-17-ubi8"
                         }
                     }
                 ]

--- a/templates/image-streams-s390x.json
+++ b/templates/image-streams-s390x.json
@@ -11,7 +11,7 @@
     "items": [
         {
             "kind": "ImageStream",
-            "apiVersion": "v1",
+            "apiVersion": "image.openshift.io/v1",
             "metadata": {
                 "name": "redhat-openjdk18-openshift",
                 "annotations": {
@@ -130,7 +130,7 @@
         },
         {
             "kind": "ImageStream",
-            "apiVersion": "v1",
+            "apiVersion": "image.openshift.io/v1",
             "metadata": {
                 "name": "openjdk-11-rhel7",
                 "annotations": {
@@ -209,7 +209,7 @@
         },
         {
             "kind": "ImageStream",
-            "apiVersion": "v1",
+            "apiVersion": "image.openshift.io/v1",
             "metadata": {
                 "name": "ubi8-openjdk-8",
                 "annotations": {
@@ -266,7 +266,7 @@
         },
         {
             "kind": "ImageStream",
-            "apiVersion": "v1",
+            "apiVersion": "image.openshift.io/v1",
             "metadata": {
                 "name": "ubi8-openjdk-11",
                 "annotations": {
@@ -323,7 +323,7 @@
         },
         {
             "kind": "ImageStream",
-            "apiVersion": "v1",
+            "apiVersion": "image.openshift.io/v1",
             "metadata": {
                 "name": "openj9-8-rhel7",
                 "annotations": {
@@ -362,7 +362,7 @@
         },
         {
             "kind": "ImageStream",
-            "apiVersion": "v1",
+            "apiVersion": "image.openshift.io/v1",
             "metadata": {
                 "name": "openj9-11-rhel7",
                 "annotations": {
@@ -401,7 +401,7 @@
         },
         {
             "kind": "ImageStream",
-            "apiVersion": "v1",
+            "apiVersion": "image.openshift.io/v1",
             "metadata": {
                 "name": "openj9-8-rhel8",
                 "annotations": {
@@ -439,7 +439,7 @@
         },
         {
             "kind": "ImageStream",
-            "apiVersion": "v1",
+            "apiVersion": "image.openshift.io/v1",
             "metadata": {
                 "name": "openj9-11-rhel8",
                 "annotations": {
@@ -477,7 +477,7 @@
         },
         {
             "kind": "ImageStream",
-            "apiVersion": "v1",
+            "apiVersion": "image.openshift.io/v1",
             "metadata": {
                 "name": "java",
                 "annotations": {

--- a/templates/image-streams.json
+++ b/templates/image-streams.json
@@ -11,7 +11,7 @@
     "items": [
         {
             "kind": "ImageStream",
-            "apiVersion": "v1",
+            "apiVersion": "image.openshift.io/v1",
             "metadata": {
                 "name": "redhat-openjdk18-openshift",
                 "annotations": {
@@ -230,7 +230,7 @@
         },
         {
             "kind": "ImageStream",
-            "apiVersion": "v1",
+            "apiVersion": "image.openshift.io/v1",
             "metadata": {
                 "name": "openjdk-11-rhel7",
                 "annotations": {
@@ -309,7 +309,7 @@
         },
         {
             "kind": "ImageStream",
-            "apiVersion": "v1",
+            "apiVersion": "image.openshift.io/v1",
             "metadata": {
                 "name": "ubi8-openjdk-8",
                 "annotations": {
@@ -366,7 +366,7 @@
         },
         {
             "kind": "ImageStream",
-            "apiVersion": "v1",
+            "apiVersion": "image.openshift.io/v1",
             "metadata": {
                 "name": "ubi8-openjdk-11",
                 "annotations": {
@@ -423,7 +423,7 @@
         },
         {
             "kind": "ImageStream",
-            "apiVersion": "v1",
+            "apiVersion": "image.openshift.io/v1",
             "metadata": {
                 "name": "openjdk-11-rhel8",
                 "annotations": {
@@ -461,7 +461,7 @@
         },
         {
             "kind": "ImageStream",
-            "apiVersion": "v1",
+            "apiVersion": "image.openshift.io/v1",
             "metadata": {
                 "name": "java",
                 "annotations": {

--- a/templates/image-streams.json
+++ b/templates/image-streams.json
@@ -596,6 +596,26 @@
                         }
                     },
                     {
+                        "name": "openjdk-17-ubi8",
+                        "annotations": {
+                            "openshift.io/display-name": "Red Hat OpenJDK 17 (UBI 8)",
+                            "description": "Build and run Java applications using Maven and OpenJDK 17.",
+                            "iconClass": "icon-rh-openjdk",
+                            "tags": "builder,java,openjdk",
+                            "supports": "java:17,java",
+                            "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts",
+                            "sampleContextDir": "undertow-servlet",
+                            "version": "17"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
+                        },
+                        "from": {
+                            "kind": "DockerImage",
+                            "name": "registry.redhat.io/ubi8/openjdk-17:latest"
+                        }
+                    },
+                    {
                         "name": "latest",
                         "annotations": {
                             "openshift.io/display-name": "Java (Latest)",
@@ -612,7 +632,7 @@
                         },
                         "from": {
                             "kind": "ImageStreamTag",
-                            "name": "openjdk-11-ubi8"
+                            "name": "openjdk-17-ubi8"
                         }
                     }
                 ]

--- a/templates/openjdk-web-basic-s2i.json
+++ b/templates/openjdk-web-basic-s2i.json
@@ -1,6 +1,6 @@
 {
     "kind": "Template",
-    "apiVersion": "v1",
+    "apiVersion": "template.openshift.io/v1",
     "metadata": {
         "annotations": {
             "iconClass": "icon-rh-openjdk",
@@ -114,7 +114,7 @@
         },
         {
             "kind": "Route",
-            "apiVersion": "v1",
+            "apiVersion": "route.openshift.io/v1",
             "id": "${APPLICATION_NAME}-http",
             "metadata": {
                 "name": "${APPLICATION_NAME}",
@@ -134,7 +134,7 @@
         },
         {
             "kind": "ImageStream",
-            "apiVersion": "v1",
+            "apiVersion": "image.openshift.io/v1",
             "metadata": {
                 "name": "${APPLICATION_NAME}",
                 "labels": {
@@ -144,7 +144,7 @@
         },
         {
             "kind": "BuildConfig",
-            "apiVersion": "v1",
+            "apiVersion": "build.openshift.io/v1",
             "metadata": {
                 "name": "${APPLICATION_NAME}",
                 "labels": {
@@ -202,7 +202,7 @@
         },
         {
             "kind": "DeploymentConfig",
-            "apiVersion": "v1",
+            "apiVersion": "apps.openshift.io/v1",
             "metadata": {
                 "name": "${APPLICATION_NAME}",
                 "labels": {

--- a/templates/runtime-image-streams.json
+++ b/templates/runtime-image-streams.json
@@ -110,6 +110,93 @@
                     }
                 ]
             }
+        },
+        {
+            "kind": "ImageStream",
+            "apiVersion": "image.openshift.io/v1",
+            "metadata": {
+                "name": "java-runtime",
+                "annotations": {
+                    "openshift.io/display-name": "Red Hat OpenJDK Runtime",
+                    "openshift.io/provider-display-name": "Red Hat, Inc."
+                }
+            },
+            "spec": {
+                "tags": [
+                    {
+                        "name": "openjdk-8-ubi8",
+                        "annotations": {
+                            "openshift.io/display-name": "Red Hat OpenJDK 1.8 Runtime (UBI8)",
+                            "description": "Run Java applications using OpenJDK 1.8 upon UBI8.",
+                            "iconClass": "icon-rh-openjdk",
+                            "tags": "java:8,openjdk,ubi8",
+                            "version": "8"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
+                        },
+                        "from": {
+                            "kind": "DockerImage",
+                            "name": "registry.access.redhat.com/ubi8/openjdk-8-runtime:latest"
+                        }
+                    },
+                    {
+                        "name": "openjdk-11-ubi8",
+                        "annotations": {
+                            "openshift.io/display-name": "Red Hat OpenJDK 11 Runtime (UBI8)",
+                            "description": "Run Java applications using OpenJDK 11 upon UBI8.",
+                            "iconClass": "icon-rh-openjdk",
+                            "tags": "java:11,openjdk,ubi8",
+                            "version": "11"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
+                        },
+                        "from": {
+                            "kind": "DockerImage",
+                            "name": "registry.access.redhat.com/ubi8/openjdk-11-runtime:latest"
+                        }
+                    },
+                    {
+                        "name": "openjdk-17-ubi8",
+                        "annotations": {
+                            "openshift.io/display-name": "Red Hat OpenJDK 17 Runtime (UBI8)",
+                            "description": "Run Java applications using OpenJDK 17 upon RHEL8.",
+                            "iconClass": "icon-rh-openjdk",
+                            "tags": "java:17,openjdk,ubi8",
+                            "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts",
+                            "sampleContextDir": "undertow-servlet",
+                            "version": "17"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
+                        },
+                        "from": {
+                            "kind": "DockerImage",
+                            "name": "registry.access.redhat.com/ubi8/openjdk-17-runtime:latest"
+                        }
+                    },
+                    {
+                        "name": "latest",
+                        "annotations": {
+                            "openshift.io/display-name": "Java Runtime (Latest)",
+                            "iconClass": "icon-rh-openjdk",
+                            "tags": "java,openjdk",
+                            "supports": "java",
+                            "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts",
+                            "sampleContextDir": "undertow-servlet",
+                            "version": "latest"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
+                        },
+                        "from": {
+                            "kind": "ImageStreamTag",
+                            "name": "openjdk-17-ubi8"
+                        }
+                    }
+                ]
+            }
         }
     ]
 }

--- a/templates/runtime-image-streams.json
+++ b/templates/runtime-image-streams.json
@@ -11,7 +11,7 @@
     "items": [
         {
             "kind": "ImageStream",
-            "apiVersion": "v1",
+            "apiVersion": "image.openshift.io/v1",
             "metadata": {
                 "name": "ubi8-openjdk-8-runtime",
                 "annotations": {
@@ -60,7 +60,7 @@
         },
         {
             "kind": "ImageStream",
-            "apiVersion": "v1",
+            "apiVersion": "image.openshift.io/v1",
             "metadata": {
                 "name": "ubi8-openjdk-11-runtime",
                 "annotations": {


### PR DESCRIPTION
Rebase of https://github.com/jboss-container-images/openjdk/pull/254 to release branch.

﻿- Use groupified apiVersion
- Add openj9 tags to ppc64le imagestreams
- Add openjdk-17-ubi8 tags to imagestreams
- Add java-runtime imagestream

- [ ] Pull Request title is properly formatted: `[CLOUD-XYA] Subject`
- [ ] Pull Request contains link to the JIRA issue
- [ ] Pull Request contains description of the issue
- [ ] Pull Request does not include fixes for issues other than the main ticket
- [x] Attached commits represent units of work and are properly formatted
- [x] You have read and agreed to the Developer Certificate of Origin (DCO) (see `CONTRIBUTING.md`)
- [x] Every commit contains `Signed-off-by: Your Name <yourname@example.com>` - use `git commit -s`

/cc @jmtd
