### PR TITLE
[OPENJDK-556] use explicit 770 in $HOME mode set

### DIFF
--- a/modules/user/configure.sh
+++ b/modules/user/configure.sh
@@ -6,8 +6,6 @@ set -e
 # This ID is registered static ID for the JBoss EAP product
 # on RHEL which makes it safe to use.
 groupadd -r jboss -g 185 && useradd -u 185 -r -g root -G jboss -m -d /home/jboss -s /sbin/nologin -c "JBoss user" jboss
-chmod ug+rwX /home/jboss
 
-# OPENJDK-533: Some container runtimes (Docker) will fail to start if
-# the running UID cannot chdir to $HOME
-chmod og+x /home/jboss
+# OPENJDK-533, OPENJDK-556: correct permissions for OpenShift etc
+chmod 0770 /home/jboss

--- a/tests/features/general.feature
+++ b/tests/features/general.feature
@@ -7,4 +7,4 @@ Feature: Miscellaneous general settings unit tests
     When container is started with args
     | arg     | value            |
     | command | stat /home/jboss |
-    Then available container log should contain Access: (0771/drwxrwx--x)
+    Then available container log should contain Access: (0770/drwxrwx---)


### PR DESCRIPTION
Scott caught that the previous change (0d1ce6e) changed the
permissions to be wider than necessary (771) on all the images.