### PR TITLE
[OPENJDK-574] Fix for Issue #262, java-default-options must check if maxMetaSpaceSize is defined

### DIFF
--- a/modules/jvm/bash/artifacts/opt/jboss/container/java/jvm/java-default-options
+++ b/modules/jvm/bash/artifacts/opt/jboss/container/java/jvm/java-default-options
@@ -144,9 +144,11 @@ gc_config() {
 
   if [ -n "${GC_METASPACE_SIZE}" ]; then
     metaspaceSize=${GC_METASPACE_SIZE}
-    # clamp the max size of metaspaceSize to be <= maxMetaspaceSize
-    if [ "${metaspaceSize}" -gt "${maxMetaspaceSize}" ]; then
-      metaspaceSize=${maxMetaspaceSize}
+    if [ -n "${maxMetaspaceSize}" ]; then
+      # clamp the max size of metaspaceSize to be <= maxMetaspaceSize
+      if [ "${metaspaceSize}" -gt "${maxMetaspaceSize}" ]; then
+        metaspaceSize=${maxMetaspaceSize}
+      fi
     fi
   fi
 

--- a/tests/features/java/gc.feature
+++ b/tests/features/java/gc.feature
@@ -53,3 +53,20 @@ Feature: Openshift OpenJDK GC tests
     Then s2i build log should contain Using MAVEN_OPTS -XX:+UseG1GC
     And container log should contain -XX:+UseG1GC
     And container log should not contain -XX:+UseParallelGC
+
+  Scenario: Check GC_METASPACE_SIZE GC configuration
+    Given s2i build https://github.com/jboss-openshift/openshift-quickstarts from undertow-servlet
+       | variable                 | value  |
+       | GC_METASPACE_SIZE    | 120    |
+    Then s2i build log should contain -XX:MetaspaceSize=120m
+    And container log should contain -XX:MetaspaceSize=120m
+    And container log should not contain integer expression expected
+
+  Scenario: Check GC_METASPACE_SIZE constrained by GC_MAX_METASPACE_SIZE GC configuration
+    Given s2i build https://github.com/jboss-openshift/openshift-quickstarts from undertow-servlet
+       | variable                 | value  |
+       | GC_METASPACE_SIZE    | 120    |
+       | GC_MAX_METASPACE_SIZE    | 90    |
+    Then s2i build log should contain -XX:MaxMetaspaceSize=90m -XX:MetaspaceSize=90m
+    And container log should contain -XX:MaxMetaspaceSize=90m -XX:MetaspaceSize=90m
+


### PR DESCRIPTION
Fix for Issue #262 , add a check for maxMetaSpaceSize