### PR TITLE
[OPENJDK-628] run: explicitly specify bash; simplify shell handling

### DIFF
--- a/modules/run/artifacts/opt/jboss/container/java/run/run-java.sh
+++ b/modules/run/artifacts/opt/jboss/container/java/run/run-java.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 # Fail on a single failed command
 set -eo pipefail
@@ -202,18 +202,8 @@ get_classpath() {
 
 # Set process name if possible
 get_exec_args() {
-  EXEC_ARGS=""
   if [ "x${JAVA_APP_NAME}" != x ]; then
-    # Not all shells support the 'exec -a newname' syntax..
-    `exec -a test true 2>/dev/null`
-    if [ "$?" = 0 ] ; then
-      echo "-a '${JAVA_APP_NAME}'"
-    else
-      # Lets switch to bash if you have it installed...
-      if [ -f "/bin/bash" ] ; then
-        exec "/bin/bash" $0 $@
-      fi
-    fi
+    echo "-a '${JAVA_APP_NAME}'"
   fi
 }
 


### PR DESCRIPTION
There was some code to work around non-bash shells that is not
necessary if we are using bash at all times. Clean it up and
explicitly require bash in the shebang line.

https://issues.redhat.com/projects/OPENJDK/issues/OPENJDK-628