### PR TITLE
To address runtime images CMD pointing at new run script

### DIFF
--- a/modules/jre/run/artifacts/opt/jboss/container/java/run/run-env.sh
+++ b/modules/jre/run/artifacts/opt/jboss/container/java/run/run-env.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+# Set the application dir to the deployment dir
+JAVA_APP_DIR=/deployments

--- a/modules/jre/run/artifacts/opt/jboss/container/java/run/run-java.sh
+++ b/modules/jre/run/artifacts/opt/jboss/container/java/run/run-java.sh
@@ -1,0 +1,241 @@
+#!/bin/bash
+
+# Fail on a single failed command
+set -eo pipefail
+
+source "$JBOSS_CONTAINER_UTIL_LOGGING_MODULE/logging.sh"
+
+if [ "${SCRIPT_DEBUG}" = "true" ] ; then
+    set -x
+    log_info "Script debugging is enabled, allowing bash commands and their arguments to be printed as they are executed"
+fi
+
+# ==========================================================
+# Generic run script for running arbitrary Java applications
+#
+# Source and Documentation can be found
+# at https://github.com/fabric8io/run-java-sh
+#
+# ==========================================================
+
+# Error is indicated with a prefix in the return value
+check_error() {
+  local msg=$1
+  if echo ${msg} | grep -q "^ERROR:"; then
+    log_error ${msg}
+    exit 1
+  fi
+}
+
+# Try hard to find a sane default jar-file
+auto_detect_jar_file() {
+  local dir=$1
+
+  # Filter out temporary jars from the shade plugin which start with 'original-'
+  local old_dir=$(pwd)
+  cd ${dir}
+  if [ $? = 0 ]; then
+    local nr_jars=`ls *.jar 2>/dev/null | grep -v '^original-' | wc -l | tr -d '[[:space:]]'`
+    if [ ${nr_jars} = 1 ]; then
+      ls *.jar | grep -v '^original-'
+      exit 0
+    fi
+
+    log_error "Neither \$JAVA_MAIN_CLASS nor \$JAVA_APP_JAR is set and ${nr_jars} JARs found in ${dir} (1 expected)"
+    cd ${old_dir}
+  else
+    log_error "No directory ${dir} found for auto detection"
+  fi
+}
+
+# Check directories (arg 2...n) for a jar file (arg 1)
+get_jar_file() {
+  local jar=$1
+  shift;
+
+  if [ "${jar:0:1}" = "/" ]; then
+    if [ -f "${jar}" ]; then
+      echo "${jar}"
+    else
+      log_error "No such file ${jar}"
+    fi
+  else
+    for dir in $*; do
+      if [ -f "${dir}/$jar" ]; then
+        echo "${dir}/$jar"
+        return
+      fi
+    done
+    log_error "No ${jar} found in $*"
+  fi
+}
+
+load_env() {
+  # Configuration stuff is read from this file
+  local run_env_sh="run-env.sh"
+
+  # Load default default config
+  if [ -f "${JBOSS_CONTAINER_JAVA_RUN_MODULE}/${run_env_sh}" ]; then
+    source "${JBOSS_CONTAINER_JAVA_RUN_MODULE}/${run_env_sh}"
+  fi
+
+  # Check also $JAVA_APP_DIR. Overrides other defaults
+  # It's valid to set the app dir in the default script
+  if [ -z "${JAVA_APP_DIR}" ]; then
+    # XXX: is this correct?  This is defaulted above to /deployments.  Should we
+    # define a default to the old /opt/java-run?
+    JAVA_APP_DIR="${JBOSS_CONTAINER_JAVA_RUN_MODULE}"
+  else
+    if [ -f "${JAVA_APP_DIR}/${run_env_sh}" ]; then
+      source "${JAVA_APP_DIR}/${run_env_sh}"
+    fi
+  fi
+  export JAVA_APP_DIR
+
+  # Read in container limits and export the as environment variables
+  if [ -f "${JBOSS_CONTAINER_JAVA_JVM_MODULE}/container-limits" ]; then
+    source "${JBOSS_CONTAINER_JAVA_JVM_MODULE}/container-limits"
+  fi
+
+  # JAVA_LIB_DIR defaults to JAVA_APP_DIR
+  export JAVA_LIB_DIR="${JAVA_LIB_DIR:-${JAVA_APP_DIR}}"
+  if [ -z "${JAVA_MAIN_CLASS}" ] && [ -z "${JAVA_APP_JAR}" ]; then
+    JAVA_APP_JAR="$(auto_detect_jar_file ${JAVA_APP_DIR})"
+    check_error "${JAVA_APP_JAR}"
+  fi
+
+  if [ "x${JAVA_APP_JAR}" != x ]; then
+    local jar="$(get_jar_file ${JAVA_APP_JAR} ${JAVA_APP_DIR} ${JAVA_LIB_DIR})"
+    check_error "${jar}"
+    export JAVA_APP_JAR=${jar}
+  else
+    export JAVA_MAIN_CLASS
+  fi
+}
+
+# Check for standard /opt/run-java-options first, fallback to run-java-options in the path if not existing
+run_java_options() {
+  if [ -f "/opt/run-java-options" ]; then
+    echo `sh /opt/run-java-options`
+  else
+    type -p run-java-options >/dev/null 2>&1
+    if [ $? = 0 ]; then
+      echo `run-java-options`
+    fi
+  fi
+}
+
+# Combine all java options
+get_java_options() {
+  local java_opts
+  local debug_opts
+  if [ -f "${JBOSS_CONTAINER_JAVA_JVM_MODULE}/java-default-options" ]; then
+    java_opts=$(${JBOSS_CONTAINER_JAVA_JVM_MODULE}/java-default-options)
+  fi
+  if [ -f "${JBOSS_CONTAINER_JAVA_JVM_MODULE}/debug-options" ]; then
+    debug_opts=$(${JBOSS_CONTAINER_JAVA_JVM_MODULE}/debug-options)
+  fi
+  if [ -f "${JBOSS_CONTAINER_JAVA_PROXY_MODULE}/proxy-options" ]; then
+    source "${JBOSS_CONTAINER_JAVA_PROXY_MODULE}/proxy-options"
+    proxy_opts="$(proxy_options)"
+  fi
+  # Normalize spaces with awk (i.e. trim and elimate double spaces)
+  echo "${JAVA_OPTS} $(run_java_options) ${debug_opts} ${proxy_opts} ${java_opts} ${JAVA_OPTS_APPEND}" | awk '$1=$1'
+}
+
+# Read in a classpath either from a file with a single line, colon separated
+# or given line-by-line in separate lines
+# Arg 1: path to claspath (must exist), optional arg2: application jar, which is stripped from the classpath in
+# multi line arrangements
+format_classpath() {
+  local cp_file="$1"
+  local app_jar="$2"
+
+  local wc_out=`wc -l $1 2>&1`
+  if [ $? -ne 0 ]; then
+    log_error "Cannot read lines in ${cp_file}: $wc_out"
+    exit 1
+  fi
+
+  local nr_lines=`echo $wc_out | awk '{ print $1 }'`
+  if [ ${nr_lines} -gt 1 ]; then
+    local sep=""
+    local classpath=""
+    while read file; do
+      local full_path="${JAVA_LIB_DIR}/${file}"
+      # Don't include app jar if include in list
+      if [ x"${app_jar}" != x"${full_path}" ]; then
+        classpath="${classpath}${sep}${full_path}"
+      fi
+      sep=":"
+    done < "${cp_file}"
+    echo "${classpath}"
+  else
+    # Supposed to be a single line, colon separated classpath file
+    cat "${cp_file}"
+  fi
+}
+
+# Fetch classpath from env or from a local "run-classpath" file
+get_classpath() {
+  local cp_path="."
+  if [ "x${JAVA_LIB_DIR}" != "x${JAVA_APP_DIR}" ]; then
+    cp_path="${cp_path}:${JAVA_LIB_DIR}"
+  fi
+  if [ -z "${JAVA_CLASSPATH}" ] && [ "x${JAVA_MAIN_CLASS}" != x ]; then
+    if [ "x${JAVA_APP_JAR}" != x ]; then
+      cp_path="${cp_path}:${JAVA_APP_JAR}"
+    fi
+    if [ -f "${JAVA_LIB_DIR}/classpath" ]; then
+      # Classpath is pre-created and stored in a 'run-classpath' file
+      cp_path="${cp_path}:`format_classpath ${JAVA_LIB_DIR}/classpath ${JAVA_APP_JAR}`"
+    else
+      # No order implied
+      cp_path="${cp_path}:${JAVA_APP_DIR}/*"
+    fi
+  elif [ "x${JAVA_CLASSPATH}" != x ]; then
+    # Given from the outside
+    cp_path="${JAVA_CLASSPATH}"
+  fi
+  echo "${cp_path}"
+}
+
+# Set process name if possible
+get_exec_args() {
+  if [ "x${JAVA_APP_NAME}" != x ]; then
+    echo "-a '${JAVA_APP_NAME}'"
+  fi
+}
+
+# Ensure that the running UID has the "jboss" passwd metadata
+# XXX: Maybe we should make this an entrypoint for the image?
+function configure_passwd() {
+  # OPENJDK-533: this file is only writeable if the image uses the
+  # nss_wrapper module. ubi8/openjdk-17 does not.
+  if [ -w "$HOME/passwd" ]; then
+    sed "/^jboss/s/[^:]*/$(id -u)/3" /etc/passwd > "$HOME/passwd"
+  fi
+}
+
+# Start JVM
+startup() {
+  # Initialize environment
+  load_env
+
+  configure_passwd
+
+  local args
+  cd ${JAVA_APP_DIR}
+  if [ "x${JAVA_MAIN_CLASS}" != x ] ; then
+     args="${JAVA_MAIN_CLASS}"
+  else
+     args="-jar ${JAVA_APP_JAR}"
+  fi
+  log_info "exec $(get_exec_args) java $(get_java_options) -cp \"$(get_classpath)\" ${args} $*"
+  exec $(get_exec_args) java $(get_java_options) -cp "$(get_classpath)" ${args} $*
+}
+
+# =============================================================================
+
+# Fire up
+startup $*

--- a/modules/jre/run/configure.sh
+++ b/modules/jre/run/configure.sh
@@ -1,0 +1,31 @@
+#!/bin/sh
+# Configure module
+set -e
+
+SCRIPT_DIR=$(dirname $0)
+ARTIFACTS_DIR=${SCRIPT_DIR}/artifacts
+
+chown -R jboss:root $SCRIPT_DIR
+chmod -R ug+rwX $SCRIPT_DIR
+chmod ug+x ${ARTIFACTS_DIR}/opt/jboss/container/java/run/*
+
+pushd ${ARTIFACTS_DIR}
+cp -pr * /
+popd
+
+mkdir -p /deployments/data \
+ && chmod -R "ug+rwX" /deployments/data \
+ && chown -R jboss:root /deployments/data
+
+# OPENJDK-100: turn off negative DNS caching
+if [ -w ${JAVA_HOME}/jre/lib/security/java.security ]; then
+    # JDK8 location
+    javasecurity="${JAVA_HOME}/jre/lib/security/java.security"
+elif [ -w ${JAVA_HOME}/lib/security/java.security ]; then
+    # JDK8 JRE location
+    javasecurity="${JAVA_HOME}/lib/security/java.security"
+else
+    # JDK11 location
+    javasecurity="${JAVA_HOME}/conf/security/java.security"
+fi
+sed -i 's/\(networkaddress.cache.negative.ttl\)=[0-9]\+$/\1=0/' "$javasecurity"

--- a/modules/jre/run/module.yaml
+++ b/modules/jre/run/module.yaml
@@ -1,0 +1,64 @@
+schema_version: 1
+name: jboss.container.java.jre.run
+version: '1.0'
+description: ^
+  Provides support for running Java applications.  Basic usage is
+  $JBOSS_CONTAINER_JAVA_RUN_MODULE/run-java.sh.
+
+envs:
+- name: JBOSS_CONTAINER_JAVA_RUN_MODULE
+  value: /opt/jboss/container/java/run
+
+- name: JAVA_APP_DIR
+  description: ^
+    The directory where the application resides. All paths in your application
+    are relative to this directory.
+  example: "myapplication/"
+
+- name: JAVA_MAIN_CLASS
+  description: ^
+    A main class to use as argument for `java`. When this environment variable
+    is given, all jar files in **JAVA_APP_DIR** are added to the classpath as
+    well as **JAVA_LIB_DIR**.
+  example: "com.example.MainClass"
+
+- name: JAVA_LIB_DIR
+  description: ^
+    Directory holding the Java jar files as well an optional `classpath` file
+    which holds the classpath. Either as a single line classpath (colon
+    separated) or with jar files listed line-by-line. If not set
+    **JAVA_LIB_DIR** is the same as **JAVA_APP_DIR**.
+
+- name: JAVA_DATA_DIR
+  description: ^
+    The location of the directory which should be used by the application for
+    reading/writing application data.  Users should override the default if
+    their application should use a different directory, e.g. if a persistent
+    volume is used to persist data across restarts.
+  value: "/deployments/data"
+  example: "/var/cache/application"
+
+- name: JAVA_CLASSPATH
+  description: ^
+    The classpath to use. If not given, the startup script checks for a file
+    `**JAVA_APP_DIR/classpath**` and use its content literally as classpath. If
+    this file doesn't exists all jars in the app dir are added
+    (`classes:**JAVA_APP_DIR/***`).
+
+- name: JAVA_ARGS
+  description: Arguments passed to the `java` application.
+
+- name: JAVA_APP_NAME
+  description: To set the process or application name by the user.
+
+execute:
+- script: configure.sh
+
+modules:
+  install:
+  - name: jboss.container.java.jvm.bash
+  - name: jboss.container.util.logging.bash
+
+run:
+  cmd:
+  - "/opt/jboss/container/java/run/run-java.sh"

--- a/ubi8-openjdk-11-runtime.yaml
+++ b/ubi8-openjdk-11-runtime.yaml
@@ -40,7 +40,7 @@ modules:
   - name: jboss.container.util.pkg-update
   - name: jboss.container.openjdk.jre
     version: "11"
-  - name:  jboss.container.java.run
+  - name:  jboss.container.java.jre.run
 
 help:
   add: true

--- a/ubi8-openjdk-17-runtime.yaml
+++ b/ubi8-openjdk-17-runtime.yaml
@@ -42,7 +42,7 @@ modules:
   - name: jboss.container.util.pkg-update
   - name: jboss.container.openjdk.jre
     version: "17"
-  - name:  jboss.container.java.run
+  - name:  jboss.container.java.jre.run
 
 help:
   add: true

--- a/ubi8-openjdk-8-runtime.yaml
+++ b/ubi8-openjdk-8-runtime.yaml
@@ -40,7 +40,7 @@ modules:
   - name: jboss.container.util.pkg-update
   - name: jboss.container.openjdk.jre
     version: "8"
-  - name:  jboss.container.java.run
+  - name:  jboss.container.java.jre.run
 
 help:
   add: true


### PR DESCRIPTION
Could you please review the changes?
To address JIRA issue: [OPENJDK-681](https://issues.redhat.com/browse/OPENJDK-681)

Post this patch checked:
1. Image sizes and they are fine.
```
$ podman images --filter dangling=false
REPOSITORY                                                     TAG         IMAGE ID      CREATED         SIZE
localhost/ubi8/openjdk-17-runtime                              1.11        21bff1f8de4a  12 minutes ago  426 MB
localhost/ubi8/openjdk-17-runtime                              latest      21bff1f8de4a  12 minutes ago  426 MB
localhost/ubi8/openjdk-11-runtime                              1.11        c7aefdfaa7ab  13 minutes ago  425 MB
localhost/ubi8/openjdk-11-runtime                              latest      c7aefdfaa7ab  13 minutes ago  425 MB
localhost/ubi8/openjdk-8-runtime                               latest      582a93fff1cd  14 minutes ago  370 MB
localhost/ubi8/openjdk-8-runtime                               1.11        582a93fff1cd  14 minutes ago  370 MB

```
2. podman run --rm -ti ubi8/openjdk-{8,11,17}-runtime outputs
```
$ podman run --rm -ti ubi8/openjdk-8-runtime
ERROR Neither $JAVA_MAIN_CLASS nor $JAVA_APP_JAR is set and 0 JARs found in /deployments (1 expected)
INFO exec  java -XX:+UseParallelGC -XX:MinHeapFreeRatio=10 -XX:MaxHeapFreeRatio=20 -XX:GCTimeRatio=4 -XX:AdaptiveSizePolicyWeight=90 -XX:+ExitOnOutOfMemoryError -cp "." -jar  
Error: -jar requires jar file specification
Usage: java [-options] class [args...]
           (to execute a class)
   or  java [-options] -jar jarfile [args...]
           (to execute a jar file)
where options include:
    -d32	  use a 32-bit data model if available
    -d64	  use a 64-bit data model if available
    -server	  to select the "server" VM
                  The default VM is server,
                  because you are running on a server-class machine.


    -cp <class search path of directories and zip/jar files>
    -classpath <class search path of directories and zip/jar files>
                  A : separated list of directories, JAR archives,
                  and ZIP archives to search for class files.
    -D<name>=<value>
                  set a system property
    -verbose:[class|gc|jni]
                  enable verbose output
    -version      print product version and exit
    -version:<value>
                  Warning: this feature is deprecated and will be removed
                  in a future release.
                  require the specified version to run
    -showversion  print product version and continue
    -jre-restrict-search | -no-jre-restrict-search
                  Warning: this feature is deprecated and will be removed
                  in a future release.
                  include/exclude user private JREs in the version search
    -? -help      print this help message
    -X            print help on non-standard options
    -ea[:<packagename>...|:<classname>]
    -enableassertions[:<packagename>...|:<classname>]
                  enable assertions with specified granularity
    -da[:<packagename>...|:<classname>]
    -disableassertions[:<packagename>...|:<classname>]
                  disable assertions with specified granularity
    -esa | -enablesystemassertions
                  enable system assertions
    -dsa | -disablesystemassertions
                  disable system assertions
    -agentlib:<libname>[=<options>]
                  load native agent library <libname>, e.g. -agentlib:hprof
                  see also, -agentlib:jdwp=help and -agentlib:hprof=help
    -agentpath:<pathname>[=<options>]
                  load native agent library by full pathname
    -javaagent:<jarpath>[=<options>]
                  load Java programming language agent, see java.lang.instrument
    -splash:<imagepath>
                  show splash screen with specified image
See http://www.oracle.com/technetwork/java/javase/documentation/index.html for more details.
```
```
$ podman run --rm -ti ubi8/openjdk-11-runtime
ERROR Neither $JAVA_MAIN_CLASS nor $JAVA_APP_JAR is set and 0 JARs found in /deployments (1 expected)
INFO exec  java -XX:+UseParallelGC -XX:MinHeapFreeRatio=10 -XX:MaxHeapFreeRatio=20 -XX:GCTimeRatio=4 -XX:AdaptiveSizePolicyWeight=90 -XX:+ExitOnOutOfMemoryError -cp "." -jar  
Error: -jar requires jar file specification
Usage: java [options] <mainclass> [args...]
           (to execute a class)
   or  java [options] -jar <jarfile> [args...]
           (to execute a jar file)
   or  java [options] -m <module>[/<mainclass>] [args...]
       java [options] --module <module>[/<mainclass>] [args...]
           (to execute the main class in a module)
   or  java [options] <sourcefile> [args]
           (to execute a single source-file program)

 Arguments following the main class, source file, -jar <jarfile>,
 -m or --module <module>/<mainclass> are passed as the arguments to
 main class.

 where options include:

    -cp <class search path of directories and zip/jar files>
    -classpath <class search path of directories and zip/jar files>
    --class-path <class search path of directories and zip/jar files>
                  A : separated list of directories, JAR archives,
                  and ZIP archives to search for class files.
    -p <module path>
    --module-path <module path>...
                  A : separated list of directories, each directory
                  is a directory of modules.
    --upgrade-module-path <module path>...
                  A : separated list of directories, each directory
                  is a directory of modules that replace upgradeable
                  modules in the runtime image
    --add-modules <module name>[,<module name>...]
                  root modules to resolve in addition to the initial module.
                  <module name> can also be ALL-DEFAULT, ALL-SYSTEM,
                  ALL-MODULE-PATH.
    --list-modules
                  list observable modules and exit
    -d <module name>
    --describe-module <module name>
                  describe a module and exit
    --dry-run     create VM and load main class but do not execute main method.
                  The --dry-run option may be useful for validating the
                  command-line options such as the module system configuration.
    --validate-modules
                  validate all modules and exit
                  The --validate-modules option may be useful for finding
                  conflicts and other errors with modules on the module path.
    -D<name>=<value>
                  set a system property
    -verbose:[class|module|gc|jni]
                  enable verbose output
    -version      print product version to the error stream and exit
    --version     print product version to the output stream and exit
    -showversion  print product version to the error stream and continue
    --show-version
                  print product version to the output stream and continue
    --show-module-resolution
                  show module resolution output during startup
    -? -h -help
                  print this help message to the error stream
    --help        print this help message to the output stream
    -X            print help on extra options to the error stream
    --help-extra  print help on extra options to the output stream
    -ea[:<packagename>...|:<classname>]
    -enableassertions[:<packagename>...|:<classname>]
                  enable assertions with specified granularity
    -da[:<packagename>...|:<classname>]
    -disableassertions[:<packagename>...|:<classname>]
                  disable assertions with specified granularity
    -esa | -enablesystemassertions
                  enable system assertions
    -dsa | -disablesystemassertions
                  disable system assertions
    -agentlib:<libname>[=<options>]
                  load native agent library <libname>, e.g. -agentlib:jdwp
                  see also -agentlib:jdwp=help
    -agentpath:<pathname>[=<options>]
                  load native agent library by full pathname
    -javaagent:<jarpath>[=<options>]
                  load Java programming language agent, see java.lang.instrument
    -splash:<imagepath>
                  show splash screen with specified image
                  HiDPI scaled images are automatically supported and used
                  if available. The unscaled image filename, e.g. image.ext,
                  should always be passed as the argument to the -splash option.
                  The most appropriate scaled image provided will be picked up
                  automatically.
                  See the SplashScreen API documentation for more information
    @argument files
                  one or more argument files containing options
    -disable-@files
                  prevent further argument file expansion
    --enable-preview
                  allow classes to depend on preview features of this release
To specify an argument for a long option, you can use --<name>=<value> or
--<name> <value>.
```
```
$ podman run --rm -ti ubi8/openjdk-17-runtime
ERROR Neither $JAVA_MAIN_CLASS nor $JAVA_APP_JAR is set and 0 JARs found in /deployments (1 expected)
INFO exec  java -XX:+UseParallelGC -XX:MinHeapFreeRatio=10 -XX:MaxHeapFreeRatio=20 -XX:GCTimeRatio=4 -XX:AdaptiveSizePolicyWeight=90 -XX:+ExitOnOutOfMemoryError -cp "." -jar  
Error: -jar requires jar file specification
Usage: java [options] <mainclass> [args...]
           (to execute a class)
   or  java [options] -jar <jarfile> [args...]
           (to execute a jar file)
   or  java [options] -m <module>[/<mainclass>] [args...]
       java [options] --module <module>[/<mainclass>] [args...]
           (to execute the main class in a module)
   or  java [options] <sourcefile> [args]
           (to execute a single source-file program)

 Arguments following the main class, source file, -jar <jarfile>,
 -m or --module <module>/<mainclass> are passed as the arguments to
 main class.

 where options include:

    -cp <class search path of directories and zip/jar files>
    -classpath <class search path of directories and zip/jar files>
    --class-path <class search path of directories and zip/jar files>
                  A : separated list of directories, JAR archives,
                  and ZIP archives to search for class files.
    -p <module path>
    --module-path <module path>...
                  A : separated list of directories, each directory
                  is a directory of modules.
    --upgrade-module-path <module path>...
                  A : separated list of directories, each directory
                  is a directory of modules that replace upgradeable
                  modules in the runtime image
    --add-modules <module name>[,<module name>...]
                  root modules to resolve in addition to the initial module.
                  <module name> can also be ALL-DEFAULT, ALL-SYSTEM,
                  ALL-MODULE-PATH.
    --enable-native-access <module name>[,<module name>...]
                  modules that are permitted to perform restricted native operations.
                  <module name> can also be ALL-UNNAMED.
    --list-modules
                  list observable modules and exit
    -d <module name>
    --describe-module <module name>
                  describe a module and exit
    --dry-run     create VM and load main class but do not execute main method.
                  The --dry-run option may be useful for validating the
                  command-line options such as the module system configuration.
    --validate-modules
                  validate all modules and exit
                  The --validate-modules option may be useful for finding
                  conflicts and other errors with modules on the module path.
    -D<name>=<value>
                  set a system property
    -verbose:[class|module|gc|jni]
                  enable verbose output for the given subsystem
    -version      print product version to the error stream and exit
    --version     print product version to the output stream and exit
    -showversion  print product version to the error stream and continue
    --show-version
                  print product version to the output stream and continue
    --show-module-resolution
                  show module resolution output during startup
    -? -h -help
                  print this help message to the error stream
    --help        print this help message to the output stream
    -X            print help on extra options to the error stream
    --help-extra  print help on extra options to the output stream
    -ea[:<packagename>...|:<classname>]
    -enableassertions[:<packagename>...|:<classname>]
                  enable assertions with specified granularity
    -da[:<packagename>...|:<classname>]
    -disableassertions[:<packagename>...|:<classname>]
                  disable assertions with specified granularity
    -esa | -enablesystemassertions
                  enable system assertions
    -dsa | -disablesystemassertions
                  disable system assertions
    -agentlib:<libname>[=<options>]
                  load native agent library <libname>, e.g. -agentlib:jdwp
                  see also -agentlib:jdwp=help
    -agentpath:<pathname>[=<options>]
                  load native agent library by full pathname
    -javaagent:<jarpath>[=<options>]
                  load Java programming language agent, see java.lang.instrument
    -splash:<imagepath>
                  show splash screen with specified image
                  HiDPI scaled images are automatically supported and used
                  if available. The unscaled image filename, e.g. image.ext,
                  should always be passed as the argument to the -splash option.
                  The most appropriate scaled image provided will be picked up
                  automatically.
                  See the SplashScreen API documentation for more information
    @argument files
                  one or more argument files containing options
    -disable-@files
                  prevent further argument file expansion
    --enable-preview
                  allow classes to depend on preview features of this release
To specify an argument for a long option, you can use --<name>=<value> or
--<name> <value>.

```
3. runtime CMD value
```
$ podman inspect --format "{{.Config.Cmd}}" localhost/ubi8/openjdk-8-runtime:latest
[/opt/jboss/container/java/run/run-java.sh]
$ podman inspect --format "{{.Config.Cmd}}" localhost/ubi8/openjdk-11-runtime:latest
[/opt/jboss/container/java/run/run-java.sh]
$ podman inspect --format "{{.Config.Cmd}}" localhost/ubi8/openjdk-17-runtime:latest
[/opt/jboss/container/java/run/run-java.sh]
```