### PR TITLE
Adjust OpenJDK 17 OSBS package exception

### DIFF
--- a/redhat/ubi8-openjdk-17-runtime.yaml
+++ b/redhat/ubi8-openjdk-17-runtime.yaml
@@ -3,7 +3,8 @@ osbs:
     container:
       compose:
         pulp_repos: true
-        packages: []
+        packages:
+        - java-17-openjdk-headless
         signing_intent: release
   repository:
     name: containers/openjdk

--- a/redhat/ubi8-openjdk-17.yaml
+++ b/redhat/ubi8-openjdk-17.yaml
@@ -3,7 +3,10 @@ osbs:
     container:
       compose:
         pulp_repos: true
-        packages: []
+        packages:
+        - java-17-openjdk
+        - java-17-openjdk-devel
+        - java-17-openjdk-headless
         signing_intent: release
   repository:
     name: containers/openjdk


### PR DESCRIPTION
In line with the other images.

Without this, at present, Im seeing build failures due to the presence of some unsigned RPMs in the buildroot, which are totally unrelated to the containers (jigdo for example). This is a transient issue (those RPMs will likely go away or get signed) but this is an unnecessary sensitivity to the issue and a deviation from the other containers.

(JIRA forthcoming)