### PR TITLE
[OPENJDK-779] Drop all openj9 imagestreams

### DIFF
--- a/templates/image-streams-ppc64le.json
+++ b/templates/image-streams-ppc64le.json
@@ -300,46 +300,6 @@
                         }
                     },
                     {
-                        "name": "openj9-8-el8",
-                        "annotations": {
-                            "openshift.io/display-name": "OpenJ9 1.8.0 (RHEL 8)",
-                            "description": "Build and run Java applications using Maven and OpenJ9 1.8.0.",
-                            "iconClass": "icon-rh-openj9",
-                            "tags": "builder,java,openj9",
-                            "supports": "java:8,java",
-                            "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts",
-                            "sampleContextDir": "undertow-servlet",
-                            "version": "8"
-                        },
-                        "referencePolicy": {
-                            "type": "Local"
-                        },
-                        "from": {
-                            "kind": "DockerImage",
-                            "name": "registry.redhat.io/openj9/openj9-8-rhel8:latest"
-                        }
-                    },
-                    {
-                        "name": "openj9-8-el7",
-                        "annotations": {
-                            "openshift.io/display-name": "OpenJ9 1.8.0 (RHEL 7)",
-                            "description": "Build and run Java applications using Maven and OpenJ9 1.8.0.",
-                            "iconClass": "icon-rh-openj9",
-                            "tags": "builder,java,openj9",
-                            "supports": "java:8,java",
-                            "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts",
-                            "sampleContextDir": "undertow-servlet",
-                            "version": "8"
-                        },
-                        "referencePolicy": {
-                            "type": "Local"
-                        },
-                        "from": {
-                            "kind": "DockerImage",
-                            "name": "registry.redhat.io/openj9/openj9-8-rhel7:latest"
-                        }
-                    },
-                    {
                         "name": "8",
                         "annotations": {
                             "openshift.io/display-name": "Red Hat OpenJDK 8",
@@ -397,46 +357,6 @@
                         "from": {
                             "kind": "DockerImage",
                             "name": "registry.redhat.io/openjdk/openjdk-11-rhel7:latest"
-                        }
-                    },
-                    {
-                        "name": "openj9-11-el8",
-                        "annotations": {
-                            "openshift.io/display-name": "Red Hat OpenJ9 11 (RHEL 8)",
-                            "description": "Build and run Java applications using Maven and OpenJ9 11.",
-                            "iconClass": "icon-rh-openj9",
-                            "tags": "builder,java,openj9",
-                            "supports": "java:11,java",
-                            "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts",
-                            "sampleContextDir": "undertow-servlet",
-                            "version": "11"
-                        },
-                        "referencePolicy": {
-                            "type": "Local"
-                        },
-                        "from": {
-                            "kind": "DockerImage",
-                            "name": "registry.redhat.io/openj9/openj9-11-rhel8:latest"
-                        }
-                    },
-                    {
-                        "name": "openj9-11-el7",
-                        "annotations": {
-                            "openshift.io/display-name": "Red Hat OpenJ9 11 (RHEL 7)",
-                            "description": "Build and run Java applications using Maven and OpenJ9 11.",
-                            "iconClass": "icon-rh-openj9",
-                            "tags": "builder,java,openj9",
-                            "supports": "java:11,java",
-                            "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts",
-                            "sampleContextDir": "undertow-servlet",
-                            "version": "11"
-                        },
-                        "referencePolicy": {
-                            "type": "Local"
-                        },
-                        "from": {
-                            "kind": "DockerImage",
-                            "name": "registry.redhat.io/openj9/openj9-11-rhel7:latest"
                         }
                     },
                     {

--- a/templates/image-streams-s390x.json
+++ b/templates/image-streams-s390x.json
@@ -4,7 +4,7 @@
     "metadata": {
         "name": "openjdk18-image-stream",
         "annotations": {
-            "description": "ImageStream definition for Red Hat OpenJDK and OpenJ9.",
+            "description": "ImageStream definition for Red Hat OpenJDK.",
             "openshift.io/provider-display-name": "Red Hat, Inc."
         }
     },
@@ -247,163 +247,9 @@
             "kind": "ImageStream",
             "apiVersion": "image.openshift.io/v1",
             "metadata": {
-                "name": "openj9-8-rhel7",
-                "annotations": {
-                    "openshift.io/display-name": "OpenJ9 1.8.0 (RHEL7)",
-                    "openshift.io/provider-display-name": "Red Hat, Inc.",
-                    "version": "1.4.17"
-                },
-                "labels": {
-                    "xpaas": "1.4.17"
-                }
-            },
-            "spec": {
-                "tags": [
-                    {
-                        "name": "1.1",
-                        "annotations": {
-                            "openshift.io/display-name": "OpenJ9 1.8.0 (RHEL7)",
-                            "description": "Build and run Java applications using Maven and OpenJ9 1.8.0.",
-                            "iconClass": "icon-rh-openj9",
-                            "tags": "builder,java,openj9,hidden",
-                            "supports": "java:8",
-                            "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts",
-                            "sampleContextDir": "undertow-servlet",
-                            "version": "1.1"
-                        },
-                        "referencePolicy": {
-                            "type": "Local"
-                        },
-                        "from": {
-                            "kind": "DockerImage",
-                            "name": "registry.redhat.io/openj9/openj9-8-rhel7:1.1"
-                        }
-                    }
-                ]
-            }
-        },
-        {
-            "kind": "ImageStream",
-            "apiVersion": "image.openshift.io/v1",
-            "metadata": {
-                "name": "openj9-11-rhel7",
-                "annotations": {
-                    "openshift.io/display-name": "OpenJ9 11 (RHEL7)",
-                    "openshift.io/provider-display-name": "Red Hat, Inc.",
-                    "version": "1.4.17"
-                },
-                "labels": {
-                    "xpaas": "1.4.17"
-                }
-            },
-            "spec": {
-                "tags": [
-                    {
-                        "name": "1.1",
-                        "annotations": {
-                            "openshift.io/display-name": "OpenJ9 11 (RHEL7)",
-                            "description": "Build and run Java applications using Maven and OpenJ9 11.",
-                            "iconClass": "icon-rh-openj9",
-                            "tags": "builder,java,openj9,hidden",
-                            "supports": "java:11",
-                            "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts",
-                            "sampleContextDir": "undertow-servlet",
-                            "version": "1.1"
-                        },
-                        "referencePolicy": {
-                            "type": "Local"
-                        },
-                        "from": {
-                            "kind": "DockerImage",
-                            "name": "registry.redhat.io/openj9/openj9-11-rhel7:1.1"
-                        }
-                    }
-                ]
-            }
-        },
-        {
-            "kind": "ImageStream",
-            "apiVersion": "image.openshift.io/v1",
-            "metadata": {
-                "name": "openj9-8-rhel8",
-                "annotations": {
-                    "openshift.io/display-name": "OpenJ9 1.8.0 (RHEL8)",
-                    "openshift.io/provider-display-name": "Red Hat, Inc.",
-                    "version": "1.4.17"
-                },
-                "labels": {
-                    "xpaas": "1.4.17"
-                }
-            },
-            "spec": {
-                "tags": [
-                    {
-                        "name": "1.1",
-                        "annotations": {
-                            "openshift.io/display-name": "OpenJ9 1.8.0 (RHEL8)",
-                            "description": "Build and run Java applications using Maven and OpenJ9 1.8.0 upon RHEL8.",
-                            "iconClass": "icon-rh-openj9",
-                            "tags": "builder,java,openj9,ubi8,hidden",
-                            "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts",
-                            "sampleContextDir": "undertow-servlet",
-                            "version": "1.1"
-                        },
-                        "referencePolicy": {
-                            "type": "Local"
-                        },
-                        "from": {
-                            "kind": "DockerImage",
-                            "name": "registry.redhat.io/openj9/openj9-8-rhel8:1.1"
-                        }
-                    }
-                ]
-            }
-        },
-        {
-            "kind": "ImageStream",
-            "apiVersion": "image.openshift.io/v1",
-            "metadata": {
-                "name": "openj9-11-rhel8",
-                "annotations": {
-                    "openshift.io/display-name": "Red Hat OpenJDK 11 (RHEL8)",
-                    "openshift.io/provider-display-name": "Red Hat, Inc.",
-                    "version": "1.4.17"
-                },
-                "labels": {
-                    "xpaas": "1.4.17"
-                }
-            },
-            "spec": {
-                "tags": [
-                    {
-                        "name": "1.1",
-                        "annotations": {
-                            "openshift.io/display-name": "OpenJ9 11 (RHEL8)",
-                            "description": "Build and run Java applications using Maven and OpenJ9 11 upon RHEL8.",
-                            "iconClass": "icon-rh-openj9",
-                            "tags": "builder,java,openj9,ubi8,hidden",
-                            "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts",
-                            "sampleContextDir": "undertow-servlet",
-                            "version": "1.1"
-                        },
-                        "referencePolicy": {
-                            "type": "Local"
-                        },
-                        "from": {
-                            "kind": "DockerImage",
-                            "name": "registry.redhat.io/openj9/openj9-11-rhel8:1.1"
-                        }
-                    }
-                ]
-            }
-        },
-        {
-            "kind": "ImageStream",
-            "apiVersion": "image.openshift.io/v1",
-            "metadata": {
                 "name": "java",
                 "annotations": {
-                    "openshift.io/display-name": "OpenJ9",
+                    "openshift.io/display-name": "Red Hat OpenJDK",
                     "openshift.io/provider-display-name": "Red Hat, Inc.",
                     "version": "1.4.17"
                 },
@@ -454,66 +300,6 @@
                         }
                     },
                     {
-                        "name": "openj9-8-el8",
-                        "annotations": {
-                            "openshift.io/display-name": "OpenJ9 1.8.0 (RHEL 8)",
-                            "description": "Build and run Java applications using Maven and OpenJ9 1.8.0.",
-                            "iconClass": "icon-rh-openj9",
-                            "tags": "builder,java,openj9",
-                            "supports": "java:8,java",
-                            "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts",
-                            "sampleContextDir": "undertow-servlet",
-                            "version": "8"
-                        },
-                        "referencePolicy": {
-                            "type": "Local"
-                        },
-                        "from": {
-                            "kind": "DockerImage",
-                            "name": "registry.redhat.io/openj9/openj9-8-rhel8:latest"
-                        }
-                    },
-                    {
-                        "name": "openj9-8-el7",
-                        "annotations": {
-                            "openshift.io/display-name": "OpenJ9 1.8.0 (RHEL 7)",
-                            "description": "Build and run Java applications using Maven and OpenJ9 1.8.0.",
-                            "iconClass": "icon-rh-openj9",
-                            "tags": "builder,java,openj9",
-                            "supports": "java:8,java",
-                            "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts",
-                            "sampleContextDir": "undertow-servlet",
-                            "version": "8"
-                        },
-                        "referencePolicy": {
-                            "type": "Local"
-                        },
-                        "from": {
-                            "kind": "DockerImage",
-                            "name": "registry.redhat.io/openj9/openj9-8-rhel7:latest"
-                        }
-                    },
-                    {
-                        "name": "8",
-                        "annotations": {
-                            "openshift.io/display-name": "OpenJ9 1.8.0",
-                            "description": "Build and run Java applications using Maven and OpenJ9 1.8.0.",
-                            "iconClass": "icon-rh-openj9",
-                            "tags": "builder,java,openj9,hidden",
-                            "supports": "java:8,java",
-                            "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts",
-                            "sampleContextDir": "undertow-servlet",
-                            "version": "8"
-                        },
-                        "referencePolicy": {
-                            "type": "Local"
-                        },
-                        "from": {
-                            "kind": "DockerImage",
-                            "name": "registry.redhat.io/openj9/openj9-8-rhel7:latest"
-                        }
-                    },
-                    {
                         "name": "openjdk-11-ubi8",
                         "annotations": {
                             "openshift.io/display-name": "Red Hat OpenJDK 11 (UBI 8)",
@@ -551,66 +337,6 @@
                         "from": {
                             "kind": "DockerImage",
                             "name": "registry.redhat.io/openjdk/openjdk-11-rhel7:latest"
-                        }
-                    },
-                    {
-                        "name": "openj9-11-el8",
-                        "annotations": {
-                            "openshift.io/display-name": "Red Hat OpenJ9 11 (RHEL 8)",
-                            "description": "Build and run Java applications using Maven and OpenJ9 11.",
-                            "iconClass": "icon-rh-openj9",
-                            "tags": "builder,java,openj9",
-                            "supports": "java:11,java",
-                            "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts",
-                            "sampleContextDir": "undertow-servlet",
-                            "version": "11"
-                        },
-                        "referencePolicy": {
-                            "type": "Local"
-                        },
-                        "from": {
-                            "kind": "DockerImage",
-                            "name": "registry.redhat.io/openj9/openj9-11-rhel8:latest"
-                        }
-                    },
-                    {
-                        "name": "openj9-11-el7",
-                        "annotations": {
-                            "openshift.io/display-name": "Red Hat OpenJ9 11 (RHEL 7)",
-                            "description": "Build and run Java applications using Maven and OpenJ9 11.",
-                            "iconClass": "icon-rh-openj9",
-                            "tags": "builder,java,openj9",
-                            "supports": "java:11,java",
-                            "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts",
-                            "sampleContextDir": "undertow-servlet",
-                            "version": "11"
-                        },
-                        "referencePolicy": {
-                            "type": "Local"
-                        },
-                        "from": {
-                            "kind": "DockerImage",
-                            "name": "registry.redhat.io/openj9/openj9-11-rhel7:latest"
-                        }
-                    },
-                    {
-                        "name": "11",
-                        "annotations": {
-                            "openshift.io/display-name": "Red Hat OpenJ9 11 (RHEL7)",
-                            "description": "Build and run Java applications using Maven and OpenJ9 11.",
-                            "iconClass": "icon-rh-openj9",
-                            "tags": "builder,java,openj9,hidden",
-                            "supports": "java:11,java",
-                            "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts",
-                            "sampleContextDir": "undertow-servlet",
-                            "version": "11"
-                        },
-                        "referencePolicy": {
-                            "type": "Local"
-                        },
-                        "from": {
-                            "kind": "DockerImage",
-                            "name": "registry.redhat.io/openj9/openj9-11-rhel7:latest"
                         }
                     },
                     {


### PR DESCRIPTION
With the deprecation of OpenJ9 images, all such references should be removed from the java imagestreams.

https://issues.redhat.com/browse/OPENJDK-779

Please make sure your PR meets the following requirements:

- [x] A JIRA issue must exist in the OPENJDK project at issues.redhat.com
- [x] Pull Request title should be prefixed with the JIRA issue: `[OPENJDK-XYZ] Subject`
- [x] Pull Request contains hyperlink to the JIRA issue
- [x] Pull Request contains description of the issue
- [x] Pull Request does not include fixes for issues other than the main ticket
- [x] Attached commits represent units of work and are properly formatted
- [x] You have read and agreed to the Developer Certificate of Origin (DCO) (see `CONTRIBUTING.md`)
- [x] Every commit contains `Signed-off-by: Your Name <yourname@example.com>` - use `git commit -s`
