### PR TITLE
[OPENJDK-78] Re-work JAVA_OPTS to override script-calculated java options

### DIFF
--- a/modules/jvm/module.yaml
+++ b/modules/jvm/module.yaml
@@ -16,10 +16,13 @@ envs:
 - name:         JBOSS_CONTAINER_JAVA_JVM_MODULE
   value:        /opt/jboss/container/java/jvm
 - name:         JAVA_OPTS
-  description:  JVM options passed to the `java` command.
+  description:  If set, this prevents all default and generated options (such
+    as JVM and GC tuning, proxy settings, etc.) from being applied. Instead the
+    user should specify exactly the `java` options they want in this variable.
   example:      "-verbose:class"
 - name:         JAVA_OPTS_APPEND
-  description:  User specified Java options to be appended to generated options in JAVA_OPTS.
+  description:  User specified Java options to be appended to the generated options.
+    This variable has no effect if `JAVA_OPTS` has been defined.
   example:      "-Dsome.property=foo"
 - name: JAVA_MAX_MEM_RATIO
   description:  Specify the maximum heap memory. Corresponds to the JVM argument `-XX:MaxRAMPercentage`. The default is `80.0` which means 80% of the available memory. You can disable this mechanism by setting the value to `0`.

--- a/modules/run/artifacts/opt/jboss/container/java/run/run-java.sh
+++ b/modules/run/artifacts/opt/jboss/container/java/run/run-java.sh
@@ -103,18 +103,6 @@ load_env() {
   fi
 }
 
-# Check for standard /opt/run-java-options first, fallback to run-java-options in the path if not existing
-run_java_options() {
-  if [ -f "/opt/run-java-options" ]; then
-    echo `sh /opt/run-java-options`
-  else
-    type -p run-java-options >/dev/null 2>&1
-    if [ $? = 0 ]; then
-      echo `run-java-options`
-    fi
-  fi
-}
-
 # Combine all java options
 get_java_options() {
   local java_opts
@@ -130,7 +118,7 @@ get_java_options() {
     proxy_opts="$(proxy_options)"
   fi
   # Normalize spaces with awk (i.e. trim and elimate double spaces)
-  echo "${JAVA_OPTS} $(run_java_options) ${debug_opts} ${proxy_opts} ${java_opts} ${JAVA_OPTS_APPEND}" | awk '$1=$1'
+  echo "${JAVA_OPTS} ${debug_opts} ${proxy_opts} ${java_opts} ${JAVA_OPTS_APPEND}" | awk '$1=$1'
 }
 
 # Read in a classpath either from a file with a single line, colon separated

--- a/modules/run/artifacts/opt/jboss/container/java/run/run-java.sh
+++ b/modules/run/artifacts/opt/jboss/container/java/run/run-java.sh
@@ -105,10 +105,12 @@ load_env() {
 
 # Combine all java options
 get_java_options() {
-  local java_opts
+  local jvm_opts
   local debug_opts
+  local proxy_opts
+  local opts
   if [ -f "${JBOSS_CONTAINER_JAVA_JVM_MODULE}/java-default-options" ]; then
-    java_opts=$(${JBOSS_CONTAINER_JAVA_JVM_MODULE}/java-default-options)
+    jvm_opts=$(${JBOSS_CONTAINER_JAVA_JVM_MODULE}/java-default-options)
   fi
   if [ -f "${JBOSS_CONTAINER_JAVA_JVM_MODULE}/debug-options" ]; then
     debug_opts=$(${JBOSS_CONTAINER_JAVA_JVM_MODULE}/debug-options)
@@ -117,8 +119,10 @@ get_java_options() {
     source "${JBOSS_CONTAINER_JAVA_PROXY_MODULE}/proxy-options"
     proxy_opts="$(proxy_options)"
   fi
-  # Normalize spaces with awk (i.e. trim and elimate double spaces)
-  echo "${JAVA_OPTS} ${debug_opts} ${proxy_opts} ${java_opts} ${JAVA_OPTS_APPEND}" | awk '$1=$1'
+
+  opts=${JAVA_OPTS-${debug_opts} ${proxy_opts} ${jvm_opts} ${JAVA_OPTS_APPEND}}
+  # Normalize spaces with awk (i.e. trim and eliminate double spaces)
+  echo "${opts}" | awk '$1=$1'
 }
 
 # Read in a classpath either from a file with a single line, colon separated

--- a/tests/features/java/runtime.feature
+++ b/tests/features/java/runtime.feature
@@ -25,3 +25,13 @@ Feature: Openshift OpenJDK Runtime tests
     | variable  | value          |
     | JAVA_OPTS |                |
     Then container log should not contain -XX:MaxRAMPercentage
+
+  @ubi9
+  Scenario: Check JAVA_OPTS overrides JAVA_OPTS_APPEND
+    piv
+    Given container is started with env
+    | variable         | value          |
+    | JAVA_OPTS        | -verbose:gc    |
+    | JAVA_OPTS_APPEND | -Xint          |
+    Then container log should contain -verbose:gc
+     And container log should not contain -Xint

--- a/tests/features/java/runtime.feature
+++ b/tests/features/java/runtime.feature
@@ -11,3 +11,17 @@ Feature: Openshift OpenJDK Runtime tests
      And container log should contain -XX:NativeMemoryTracking=summary
      And file /usr/local/s2i/run should not contain JVM_ARGS
      And container log should not contain unique unique
+
+  @ubi9
+  Scenario: Check JAVA_OPTS overrides defaults
+    Given container is started with env
+    | variable  | value          |
+    | JAVA_OPTS | --show-version |
+    Then container log should not contain -XX:MaxRAMPercentage
+
+  @ubi9
+  Scenario: Check empty JAVA_OPTS overrides defaults
+    Given container is started with env
+    | variable  | value          |
+    | JAVA_OPTS |                |
+    Then container log should not contain -XX:MaxRAMPercentage


### PR DESCRIPTION
https://issues.redhat.com/browse/OPENJDK-78

This is a first attempt at a way of short-circuiting all Java options
generation.