### PR TITLE
[OPENJDK-344] Remove NSS Wrapper from ubi8 images

### DIFF
--- a/ubi8-openjdk-11.yaml
+++ b/ubi8-openjdk-11.yaml
@@ -49,7 +49,6 @@ modules:
   - name: jboss.container.jolokia
   - name: jboss.container.maven
     version: "8.6.3.6.11"
-  - name: jboss.container.util.nss-wrapper
   - name: jboss.container.java.s2i.bash
   # required due to jolokia
   - name: jboss.container.java.singleton-jdk

--- a/ubi8-openjdk-8.yaml
+++ b/ubi8-openjdk-8.yaml
@@ -49,7 +49,6 @@ modules:
   - name: jboss.container.jolokia
   - name: jboss.container.maven
     version: "8.2.3.6.8"
-  - name: jboss.container.util.nss-wrapper
   - name: jboss.container.java.s2i.bash
 
 help:


### PR DESCRIPTION
<https://issues.redhat.com/browse/OPENJDK-344>

We can't ship this until July onwards. I suggest we don't merge it
until then.

NSS wrapper is used to provide backwards compatibility for OCP 3.11.
OCP 3.11 is out of maintenance from July 2022.

Removing NSS wrapper also removes Perl from the images, reducing
their size.

I have only removed this from the UBI8 images, leaving the RHEL7 images
untouched. As a consequence, the code in the run script that creates 
and populates $HOME/passwd still exists, since this code is shared
between the RHEL7 and RHEL8 images, but is benign for RHEL8 in the 
absence of nss wrapper.