### PR TITLE
[OPENJDK-91] Rename jboss user to 'default'

### DIFF
--- a/modules/jdk/11/configure.sh
+++ b/modules/jdk/11/configure.sh
@@ -5,7 +5,7 @@ set -e
 SCRIPT_DIR=$(dirname $0)
 ARTIFACTS_DIR=${SCRIPT_DIR}/artifacts
 
-chown -R jboss:root $SCRIPT_DIR
+chown -R default:root $SCRIPT_DIR
 chmod -R ug+rwX $SCRIPT_DIR
 chmod ug+x ${ARTIFACTS_DIR}/opt/jboss/container/openjdk/jdk/*
 

--- a/modules/jdk/17/configure.sh
+++ b/modules/jdk/17/configure.sh
@@ -5,7 +5,7 @@ set -e
 SCRIPT_DIR=$(dirname $0)
 ARTIFACTS_DIR=${SCRIPT_DIR}/artifacts
 
-chown -R jboss:root $SCRIPT_DIR
+chown -R default:root $SCRIPT_DIR
 chmod -R ug+rwX $SCRIPT_DIR
 chmod ug+x ${ARTIFACTS_DIR}/opt/jboss/container/openjdk/jdk/*
 

--- a/modules/jdk/8/configure.sh
+++ b/modules/jdk/8/configure.sh
@@ -5,7 +5,7 @@ set -e
 SCRIPT_DIR=$(dirname $0)
 ARTIFACTS_DIR=${SCRIPT_DIR}/artifacts
 
-chown -R jboss:root $SCRIPT_DIR
+chown -R default:root $SCRIPT_DIR
 chmod -R ug+rwX $SCRIPT_DIR
 chmod ug+x ${ARTIFACTS_DIR}/opt/jboss/container/openjdk/jdk/*
 

--- a/modules/jre/11/configure.sh
+++ b/modules/jre/11/configure.sh
@@ -7,7 +7,7 @@ echo $SCRIPT_DIR
 ARTIFACTS_DIR=${SCRIPT_DIR}/artifacts
 echo $ARTIFACTS_DIR
 
-chown -R jboss:root $SCRIPT_DIR
+chown -R default:root $SCRIPT_DIR
 chmod -R ug+rwX $SCRIPT_DIR
 chmod ug+x ${ARTIFACTS_DIR}/opt/jboss/container/openjdk/jre/*
 

--- a/modules/jre/17/configure.sh
+++ b/modules/jre/17/configure.sh
@@ -7,7 +7,7 @@ echo $SCRIPT_DIR
 ARTIFACTS_DIR=${SCRIPT_DIR}/artifacts
 echo $ARTIFACTS_DIR
 
-chown -R jboss:root $SCRIPT_DIR
+chown -R default:root $SCRIPT_DIR
 chmod -R ug+rwX $SCRIPT_DIR
 chmod ug+x ${ARTIFACTS_DIR}/opt/jboss/container/openjdk/jre/*
 

--- a/modules/jre/8/configure.sh
+++ b/modules/jre/8/configure.sh
@@ -5,7 +5,7 @@ set -e
 SCRIPT_DIR=$(dirname $0)
 ARTIFACTS_DIR=${SCRIPT_DIR}/artifacts
 
-chown -R jboss:root $SCRIPT_DIR
+chown -R default:root $SCRIPT_DIR
 chmod -R ug+rwX $SCRIPT_DIR
 chmod ug+x ${ARTIFACTS_DIR}/opt/jboss/container/openjdk/jre/*
 

--- a/modules/jvm/configure.sh
+++ b/modules/jvm/configure.sh
@@ -5,7 +5,7 @@ set -e
 SCRIPT_DIR=$(dirname $0)
 ARTIFACTS_DIR=${SCRIPT_DIR}/artifacts
 
-chown -R jboss:root $SCRIPT_DIR
+chown -R default:root $SCRIPT_DIR
 chmod -R ug+rwX $SCRIPT_DIR
 chmod ug+x ${ARTIFACTS_DIR}/opt/jboss/container/java/jvm/*
 

--- a/modules/maven/7.0.3.6/configure.sh
+++ b/modules/maven/7.0.3.6/configure.sh
@@ -5,7 +5,7 @@ set -e
 SCRIPT_DIR=$(dirname $0)
 ARTIFACTS_DIR=${SCRIPT_DIR}/artifacts
 
-chown -R jboss:root $ARTIFACTS_DIR
+chown -R default:root $ARTIFACTS_DIR
 chmod -R ug+rwX $ARTIFACTS_DIR
 chmod ug+x ${ARTIFACTS_DIR}/opt/jboss/container/maven/36/scl-enable-maven
 

--- a/modules/maven/default/configure.sh
+++ b/modules/maven/default/configure.sh
@@ -6,7 +6,7 @@ SCRIPT_DIR=$(dirname $0)
 ARTIFACTS_DIR=${SCRIPT_DIR}/artifacts
 
 # configure artifact permissions
-chown -R jboss:root $ARTIFACTS_DIR
+chown -R default:root $ARTIFACTS_DIR
 chmod -R ug+rwX $ARTIFACTS_DIR
 chmod ug+x ${ARTIFACTS_DIR}/opt/jboss/container/maven/default/maven.sh
 
@@ -19,11 +19,11 @@ MAVEN_VERSION_SQUASHED=${MAVEN_VERSION/./}
 
 # pull in specific maven version to serve as default
 ln -s /opt/jboss/container/maven/${MAVEN_VERSION_SQUASHED}/* /opt/jboss/container/maven/default
-chown -h jboss:root /opt/jboss/container/maven/default/*
+chown -h default:root /opt/jboss/container/maven/default/*
 
 # install default settings.xml file in user home
 mkdir -p $HOME/.m2
 ln -s /opt/jboss/container/maven/default/jboss-settings.xml $HOME/.m2/settings.xml
 
-chown -R jboss:root $HOME/.m2
+chown -R default:root $HOME/.m2
 chmod -R ug+rwX $HOME/.m2

--- a/modules/maven/default/module.yaml
+++ b/modules/maven/default/module.yaml
@@ -46,10 +46,10 @@ envs:
   example: "http://10.0.0.1:8080/repository/internal"
 - name: MAVEN_SETTINGS_XML
   description: Location of custom Maven settings.xml file to use.
-  example: /home/jboss/.m2/settings.xml
+  example: /home/default/.m2/settings.xml
 - name: MAVEN_LOCAL_REPO
   description: Directory to use as the local Maven repository.
-  example: /home/jboss/.m2/repository
+  example: /home/default/.m2/repository
 - name: "MAVEN_REPOS"
   example: "dev-one,qe-two"
   description: "If set, multi-repo support is enabled, and other MAVEN_REPO_* variables will be prefixed. For example: DEV_ONE_MAVEN_REPO_URL and QE_TWO_MAVEN_REPO_URL"

--- a/modules/maven/s2i/configure.sh
+++ b/modules/maven/s2i/configure.sh
@@ -5,7 +5,7 @@ set -e
 SCRIPT_DIR=$(dirname $0)
 ARTIFACTS_DIR=${SCRIPT_DIR}/artifacts
 
-chown -R jboss:root $SCRIPT_DIR
+chown -R default:root $SCRIPT_DIR
 chmod -R ug+rwX $SCRIPT_DIR
 chmod ug+x ${ARTIFACTS_DIR}/opt/jboss/container/maven/s2i/*
 chmod ug+x ${ARTIFACTS_DIR}/usr/local/s2i/*

--- a/modules/proxy/configure.sh
+++ b/modules/proxy/configure.sh
@@ -5,7 +5,7 @@ set -e
 SCRIPT_DIR=$(dirname $0)
 ARTIFACTS_DIR=${SCRIPT_DIR}/artifacts
 
-chown -R jboss:root $SCRIPT_DIR
+chown -R default:root $SCRIPT_DIR
 chmod -R ug+rwX $SCRIPT_DIR
 chmod ug+x ${ARTIFACTS_DIR}/opt/jboss/container/java/proxy*
 

--- a/modules/run/configure.sh
+++ b/modules/run/configure.sh
@@ -5,7 +5,7 @@ set -e
 SCRIPT_DIR=$(dirname $0)
 ARTIFACTS_DIR=${SCRIPT_DIR}/artifacts
 
-chown -R jboss:root $SCRIPT_DIR
+chown -R default:root $SCRIPT_DIR
 chmod -R ug+rwX $SCRIPT_DIR
 chmod ug+x ${ARTIFACTS_DIR}/opt/jboss/container/java/run/*
 
@@ -15,7 +15,7 @@ popd
 
 mkdir -p /deployments/data \
  && chmod -R "ug+rwX" /deployments/data \
- && chown -R jboss:root /deployments/data
+ && chown -R default:root /deployments/data
 
 # OPENJDK-100: turn off negative DNS caching
 if [ -w ${JAVA_HOME}/jre/lib/security/java.security ]; then

--- a/modules/s2i/bash/configure.sh
+++ b/modules/s2i/bash/configure.sh
@@ -5,7 +5,7 @@ set -e
 SCRIPT_DIR=$(dirname $0)
 ARTIFACTS_DIR=${SCRIPT_DIR}/artifacts
 
-chown -R jboss:root $SCRIPT_DIR
+chown -R default:root $SCRIPT_DIR
 chmod -R ug+rwX $SCRIPT_DIR
 chmod ug+x ${ARTIFACTS_DIR}/opt/jboss/container/java/s2i/*
 chmod ug+x ${ARTIFACTS_DIR}/usr/local/s2i/*

--- a/modules/s2i/core/configure.sh
+++ b/modules/s2i/core/configure.sh
@@ -5,7 +5,7 @@ set -e
 SCRIPT_DIR=$(dirname $0)
 ARTIFACTS_DIR=${SCRIPT_DIR}/artifacts
 
-chown -R jboss:root $SCRIPT_DIR
+chown -R default:root $SCRIPT_DIR
 chmod -R ug+rwX $SCRIPT_DIR
 chmod ug+x ${ARTIFACTS_DIR}/opt/jboss/container/s2i/core/*
 
@@ -15,8 +15,8 @@ popd
 
 mkdir -p /usr/local/s2i \
  && chmod 775 /usr/local/s2i \
- && chown -R jboss:root /usr/local/s2i
+ && chown -R default:root /usr/local/s2i
 
 mkdir -p /deployments \
  && chmod -R "ug+rwX" /deployments \
- && chown -R jboss:root /deployments
+ && chown -R default:root /deployments

--- a/modules/user/configure.sh
+++ b/modules/user/configure.sh
@@ -5,7 +5,7 @@ set -e
 # We use the ID 185 for the group as well as for the user.
 # This ID is registered static ID for the JBoss EAP product
 # on RHEL which makes it safe to use.
-groupadd -r jboss -g 185 && useradd -u 185 -r -g root -G jboss -m -d /home/jboss -s /sbin/nologin -c "JBoss user" jboss
+groupadd -r default -g 185 && useradd -u 185 -r -g root -G default -m -d /home/default -s /sbin/nologin -c "Default user" default
 
 # OPENJDK-533, OPENJDK-556: correct permissions for OpenShift etc
-chmod 0770 /home/jboss
+chmod 0770 /home/default

--- a/modules/user/module.yaml
+++ b/modules/user/module.yaml
@@ -1,11 +1,11 @@
 schema_version: 1
 name: jboss.container.user
-version: '1.0'
-description: "Configures the jboss user and permissions.  This module should be included by all images."
+version: '2.0'
+description: "Configures the default user and permissions.  This module should be included by all images."
 
 envs:
 - name: "HOME"
-  value: "/home/jboss"
+  value: "/home/default"
 
 packages:
   install:
@@ -16,4 +16,4 @@ execute:
 
 run:
   user: 185
-  workdir: "/home/jboss"
+  workdir: "/home/default"

--- a/modules/util/logging/configure.sh
+++ b/modules/util/logging/configure.sh
@@ -5,7 +5,7 @@ set -e
 SCRIPT_DIR=$(dirname $0)
 ARTIFACTS_DIR=${SCRIPT_DIR}/artifacts
 
-chown -R jboss:root $SCRIPT_DIR
+chown -R default:root $SCRIPT_DIR
 chmod -R ug+rwX $SCRIPT_DIR
 chmod ug+x ${ARTIFACTS_DIR}/opt/jboss/container/util/logging/*
 

--- a/modules/util/nss-wrapper/configure.sh
+++ b/modules/util/nss-wrapper/configure.sh
@@ -2,5 +2,5 @@
 set -euo pipefail
 
 # set up a copy of the passwd file which nss_wrapper will use.
-cp /etc/passwd /home/jboss/passwd
-chmod ug+rwX /home/jboss/passwd
+cp /etc/passwd /home/default/passwd
+chmod ug+rwX /home/default/passwd

--- a/modules/util/nss-wrapper/module.yaml
+++ b/modules/util/nss-wrapper/module.yaml
@@ -9,7 +9,7 @@ envs:
 - name: LD_PRELOAD
   value: libnss_wrapper.so
 - name: NSS_WRAPPER_PASSWD
-  value: /home/jboss/passwd
+  value: /home/default/passwd
 - name: NSS_WRAPPER_GROUP
   value: /etc/group
 

--- a/tests/features/general.feature
+++ b/tests/features/general.feature
@@ -1,8 +1,8 @@
 Feature: Miscellaneous general settings unit tests
 
   @ubi9
-  Scenario: Check the attributes of /home/jboss using stat
+  Scenario: Check the attributes of /home/default using stat
     When container is started with args
-    | arg     | value            |
-    | command | stat /home/jboss |
+    | arg     | value              |
+    | command | stat /home/default |
     Then available container log should contain Access: (0770/drwxrwx---)


### PR DESCRIPTION
<https://issues.redhat.com/browse/OPENJDK-91>

The use of "jboss" for the runtime user is sometimes confusing for users
who are not using a JBoss product. Rename it to "default", in line with
some other UBI images. This also changes the $HOME path. We retain the
uid 185.

I'm not sure how disruptive this might be!