### PR TITLE
Correct comment about why singleton-jdk

### DIFF
--- a/ubi8-openjdk-17.yaml
+++ b/ubi8-openjdk-17.yaml
@@ -49,7 +49,7 @@ modules:
   - name: jboss.container.maven
     version: "8.6.3.6.17"
   - name: jboss.container.java.s2i.bash
-  # needed for after prometheus
+  # needed for after Maven: https://bugzilla.redhat.com/show_bug.cgi?id=2080229
   - name: jboss.container.java.singleton-jdk
 
 help:


### PR DESCRIPTION
Link to BZ for why we need singleton-jdk for ubi8/openjdk-17

trivial comment-only patch