### PR TITLE
Delete RHEL7/JDK8 Images version 1.2 and older

### DIFF
--- a/templates/image-streams.json
+++ b/templates/image-streams.json
@@ -26,66 +26,6 @@
             "spec": {
                 "tags": [
                     {
-                        "name": "1.0",
-                        "annotations": {
-                            "openshift.io/display-name": "Red Hat OpenJDK 8",
-                            "description": "Build and run Java applications using Maven and OpenJDK 8.",
-                            "iconClass": "icon-rh-openjdk",
-                            "tags": "builder,java,openjdk,hidden",
-                            "supports": "java:8",
-                            "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts",
-                            "sampleContextDir": "undertow-servlet",
-                            "version": "1.0"
-                        },
-                        "referencePolicy": {
-                            "type": "Local"
-                        },
-                        "from": {
-                            "kind": "DockerImage",
-                            "name": "registry.redhat.io/redhat-openjdk-18/openjdk18-openshift:1.0"
-                        }
-                    },
-                    {
-                        "name": "1.1",
-                        "annotations": {
-                            "openshift.io/display-name": "Red Hat OpenJDK 8",
-                            "description": "Build and run Java applications using Maven and OpenJDK 8.",
-                            "iconClass": "icon-rh-openjdk",
-                            "tags": "builder,java,openjdk,hidden",
-                            "supports": "java:8",
-                            "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts",
-                            "sampleContextDir": "undertow-servlet",
-                            "version": "1.1"
-                        },
-                        "referencePolicy": {
-                            "type": "Local"
-                        },
-                        "from": {
-                            "kind": "DockerImage",
-                            "name": "registry.redhat.io/redhat-openjdk-18/openjdk18-openshift:1.1"
-                        }
-                    },
-                    {
-                        "name": "1.2",
-                        "annotations": {
-                            "openshift.io/display-name": "Red Hat OpenJDK 8",
-                            "description": "Build and run Java applications using Maven and OpenJDK 8.",
-                            "iconClass": "icon-rh-openjdk",
-                            "tags": "builder,java,openjdk,hidden",
-                            "supports": "java:8",
-                            "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts",
-                            "sampleContextDir": "undertow-servlet",
-                            "version": "1.2"
-                        },
-                        "referencePolicy": {
-                            "type": "Local"
-                        },
-                        "from": {
-                            "kind": "DockerImage",
-                            "name": "registry.redhat.io/redhat-openjdk-18/openjdk18-openshift:1.2"
-                        }
-                    },
-                    {
                         "name": "1.3",
                         "annotations": {
                             "openshift.io/display-name": "Red Hat OpenJDK 8",


### PR DESCRIPTION
These old images (last updated five years ago) were build and use
Docker API schema version 1 which is deprecated and some systems
will shortly start throwing errors if they attempt to query these
images.

Remove them to avoid the errors clogging logs.

See <https://access.redhat.com/articles/6138332> for some context.