### PR TITLE
[OPENJDK-986] Remove dejavu-sans-mono-fonts from test

### DIFF
--- a/tests/features/java/openjdk.feature
+++ b/tests/features/java/openjdk.feature
@@ -46,7 +46,6 @@ Feature: Miscellaneous OpenJDK-related unit tests
     | arg     | value   |
     | command | rpm -qa |
     Then available container log should not contain grub
-    Then available container log should not contain dejavu-sans-mono-fonts
     Then available container log should not contain os-prober
     Then available container log should not contain rpm-plugin-systemd-inhibit
 


### PR DESCRIPTION
This specific test is intended to catch packages that are not covered by
the UBI EULA leaking into built images. The package
dejavu-sans-mono-fonts has joined the UBI set since this test was
written.

https://issues.redhat.com/browse/OPENJDK-986