### PR TITLE
README: links to ubi9 images, ubi8 branch

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -6,12 +6,17 @@ These are the OpenJDK Source to Image (S2I) images for Red Hat OpenShift.
 
 ### From https://access.redhat.com/containers/[Red Hat Container Catalog]
 
+ * link:https://catalog.redhat.com/software/containers/ubi9/openjdk-11/61ee7bafed74b2ffb22b07ab[ubi9/openjdk-11]
+ * link:https://catalog.redhat.com/software/containers/ubi9/openjdk-17/61ee7c26ed74b2ffb22b07f6[ubi9/openjdk-17]
+ * link:https://catalog.redhat.com/software/containers/ubi9/openjdk-11-runtime/61ee7d1c33f211c45407a91c[ubi9/openjdk-11-runtime]
+ * link:https://catalog.redhat.com/software/containers/ubi9/openjdk-17-runtime/61ee7d45384a3eb331996bee[ubi9/openjdk-17-runtime]
+
 The UBI9-based OpenJDK images are available under the terms of the
 link:https://www.redhat.com/en/about/red-hat-end-user-license-agreements#UBI[UBI EULA].
 
  * (GA catalog URIs go here)
 
-Older RHEL8 and RHEL7-based image sources are in the `develop` branch.
+Older RHEL7 and RHEL8-based image sources are in the `rhel7` and `ubi8` branches respectively.
 
 ## How to build the images
 


### PR DESCRIPTION
Update the README to add links to the ubi9 images in the Red Hat
Ecosystem Catalog.

Adjust the wording about deprecated images to correctly reference
the rhel7 and ubi8 branches.