### PR TITLE
[OPENJDK-1065] Add PNC Metadata to artifacts

### DIFF
--- a/.github/workflows/ubi8-openjdk-11-runtime.yml
+++ b/.github/workflows/ubi8-openjdk-11-runtime.yml
@@ -2,7 +2,7 @@ name: OpenJDK 11 Runtime Image CI
 on: [push, pull_request]
 env:
   LANG: en_US.UTF-8
-  CEKIT_VERSION: 3.11.0
+  CEKIT_VERSION: 4.3.0
   S2I_URI: https://github.com/openshift/source-to-image/releases/download/v1.3.1/source-to-image-v1.3.1-a5a77147-linux-amd64.tar.gz
 jobs:
   openjdkci:

--- a/.github/workflows/ubi8-openjdk-11.yml
+++ b/.github/workflows/ubi8-openjdk-11.yml
@@ -2,7 +2,7 @@ name: OpenJDK 11 S2I Image CI
 on: [push, pull_request]
 env:
   LANG: en_US.UTF-8
-  CEKIT_VERSION: 3.6.0
+  CEKIT_VERSION: 4.3.0
   S2I_URI: https://github.com/openshift/source-to-image/releases/download/v1.3.1/source-to-image-v1.3.1-a5a77147-linux-amd64.tar.gz
 jobs:
   openjdkci:

--- a/.github/workflows/ubi8-openjdk-17-runtime.yml
+++ b/.github/workflows/ubi8-openjdk-17-runtime.yml
@@ -2,7 +2,7 @@ name: OpenJDK 17 Runtime Image CI
 on: [push, pull_request]
 env:
   LANG: en_US.UTF-8
-  CEKIT_VERSION: 3.11.0
+  CEKIT_VERSION: 4.3.0
   S2I_URI: https://github.com/openshift/source-to-image/releases/download/v1.3.1/source-to-image-v1.3.1-a5a77147-linux-amd64.tar.gz
 jobs:
   openjdkci:

--- a/.github/workflows/ubi8-openjdk-17.yml
+++ b/.github/workflows/ubi8-openjdk-17.yml
@@ -2,7 +2,7 @@ name: OpenJDK 17 S2I Image CI
 on: [push, pull_request]
 env:
   LANG: en_US.UTF-8
-  CEKIT_VERSION: 3.6.0
+  CEKIT_VERSION: 4.3.0
   S2I_URI: https://github.com/openshift/source-to-image/releases/download/v1.3.1/source-to-image-v1.3.1-a5a77147-linux-amd64.tar.gz
 jobs:
   openjdkci:

--- a/.github/workflows/ubi8-openjdk-8-runtime.yml
+++ b/.github/workflows/ubi8-openjdk-8-runtime.yml
@@ -2,7 +2,7 @@ name: OpenJDK 8 Runtime Image CI
 on: [push, pull_request]
 env:
   LANG: en_US.UTF-8
-  CEKIT_VERSION: 3.11.0
+  CEKIT_VERSION: 4.3.0
   S2I_URI: https://github.com/openshift/source-to-image/releases/download/v1.3.1/source-to-image-v1.3.1-a5a77147-linux-amd64.tar.gz
 jobs:
   openjdkci:

--- a/.github/workflows/ubi8-openjdk-8.yml
+++ b/.github/workflows/ubi8-openjdk-8.yml
@@ -2,7 +2,7 @@ name: OpenJDK 8 S2I Image CI
 on: [push, pull_request]
 env:
   LANG: en_US.UTF-8
-  CEKIT_VERSION: 3.6.0
+  CEKIT_VERSION: 4.3.0
   S2I_URI: https://github.com/openshift/source-to-image/releases/download/v1.3.1/source-to-image-v1.3.1-a5a77147-linux-amd64.tar.gz
 jobs:
   openjdkci:

--- a/README.adoc
+++ b/README.adoc
@@ -21,7 +21,7 @@ The RHEL7-based OpenJDK images require a Red Hat subscription:
 
 You need to https://cekit.readthedocs.io/en/develop/installation.html[install Cekit] to build these images.
 
-These sources are prepared and tested for Cekit 3.6.0.
+These sources are prepared and tested for Cekit 4.3.0.
 
 For building within Red Hat, the instructions vary slightly, see link:redhat/README.adoc[].
 

--- a/modules/jolokia/7/module.yaml
+++ b/modules/jolokia/7/module.yaml
@@ -62,5 +62,6 @@ execute:
 
 artifacts:
 - name: jolokia-jvm
+  pnc_build_id: '24549'
+  pnc_artifact_id: '1684766'
   target: jolokia-jvm-1.6.2.redhat-00002-agent.jar
-  md5: 760f2fbaf6b142192f3cee2c99bfcbf8

--- a/modules/prometheus/7/module.yaml
+++ b/modules/prometheus/7/module.yaml
@@ -25,5 +25,6 @@ execute:
 
 artifacts:
 - name: jmx_prometheus_javaagent
+  pnc_build_id: '72393'
+  pnc_artifact_id: '5037842'
   target: jmx_prometheus_javaagent-0.3.2.redhat-00003.jar
-  md5: 8b3af39995b113baf35e53468bad7aae

--- a/tests/features/jolokia.feature
+++ b/tests/features/jolokia.feature
@@ -28,3 +28,11 @@ Feature: Openshift OpenJDK Jolokia tests
        | JAVA_DIAGNOSTICS | true                |
     Then container log should contain /deployments/undertow-servlet.jar Hello from CTF test
       And container log should contain Jolokia: Agent started
+
+  @redhat-openjdk-18
+  @openjdk
+  Scenario: Ensure the Jolokia Agent JAR has the expected checksum
+    When container is started with args
+    | arg     | value                                                        |
+    | command | bash -c "md5sum $JBOSS_CONTAINER_JOLOKIA_MODULE/jolokia.jar" |
+    Then available container log should contain 760f2fbaf6b142192f3cee2c99bfcbf8

--- a/tests/features/prometheus.feature
+++ b/tests/features/prometheus.feature
@@ -28,3 +28,11 @@ Feature: Prometheus agent tests
       | env_AB_PROMETHEUS_JMX_EXPORTER_CONFIG | /path/to/some/jmx-exporter-config.yaml |
       | arg_command                           | bash -c 'source $JBOSS_CONTAINER_PROMETHEUS_MODULE/prometheus-opts; get_prometheus_opts' |
     Then container log should contain -javaagent:/usr/share/java/prometheus-jmx-exporter/jmx_prometheus_javaagent.jar=8080:/path/to/some/jmx-exporter-config.yaml
+
+  @redhat-openjdk-18
+  @openjdk
+  Scenario: Ensure the Prometheus Agent JAR has the expected checksum
+    When container is started with args
+    | arg     | value                                                                            |
+    | command | bash -c "md5sum $JBOSS_CONTAINER_PROMETHEUS_MODULE/jmx_prometheus_javaagent.jar" |
+    Then available container log should contain 8b3af39995b113baf35e53468bad7aae


### PR DESCRIPTION
This causes OSBS-builds of these containers to consume the artifacts from an internal PNC instance.

The 'md5' key is not valid when the pnc keys are present. Remove it, but add two tests that check the md5 checksum of the JARs inside an image.

https://issues.redhat.com/browse/OPENJDK-1065