### PR TITLE
[OPENJDK-1334] Move pkg-update to end of container build

### DIFF
--- a/ubi8-openjdk-11-runtime.yaml
+++ b/ubi8-openjdk-11-runtime.yaml
@@ -37,10 +37,10 @@ modules:
   repositories:
   - path: modules
   install:
-  - name: jboss.container.util.pkg-update
   - name: jboss.container.openjdk.jre
     version: "11"
   - name:  jboss.container.java.jre.run
+  - name: jboss.container.util.pkg-update
 
 help:
   add: true

--- a/ubi8-openjdk-11.yaml
+++ b/ubi8-openjdk-11.yaml
@@ -41,7 +41,6 @@ modules:
   repositories:
   - path: modules
   install:
-  - name: jboss.container.util.pkg-update
   - name: jboss.container.openjdk.jdk
     version: "11"
   - name: jboss.container.prometheus
@@ -50,6 +49,7 @@ modules:
   - name: jboss.container.maven
     version: "8.6.3.6.11"
   - name: jboss.container.java.s2i.bash
+  - name: jboss.container.util.pkg-update
   # required due to jolokia
   - name: jboss.container.java.singleton-jdk
 

--- a/ubi8-openjdk-17-runtime.yaml
+++ b/ubi8-openjdk-17-runtime.yaml
@@ -39,10 +39,10 @@ modules:
   repositories:
   - path: modules
   install:
-  - name: jboss.container.util.pkg-update
   - name: jboss.container.openjdk.jre
     version: "17"
   - name:  jboss.container.java.jre.run
+  - name: jboss.container.util.pkg-update
 
 help:
   add: true

--- a/ubi8-openjdk-17.yaml
+++ b/ubi8-openjdk-17.yaml
@@ -41,7 +41,6 @@ modules:
   repositories:
   - path: modules
   install:
-  - name: jboss.container.util.pkg-update
   - name: jboss.container.openjdk.jdk
     version: "17"
   - name: jboss.container.prometheus
@@ -49,6 +48,7 @@ modules:
   - name: jboss.container.maven
     version: "8.6.3.6.17"
   - name: jboss.container.java.s2i.bash
+  - name: jboss.container.util.pkg-update
   # needed for after Maven: https://bugzilla.redhat.com/show_bug.cgi?id=2080229
   - name: jboss.container.java.singleton-jdk
 

--- a/ubi8-openjdk-8-runtime.yaml
+++ b/ubi8-openjdk-8-runtime.yaml
@@ -37,10 +37,10 @@ modules:
   repositories:
   - path: modules
   install:
-  - name: jboss.container.util.pkg-update
   - name: jboss.container.openjdk.jre
     version: "8"
   - name:  jboss.container.java.jre.run
+  - name: jboss.container.util.pkg-update
 
 help:
   add: true

--- a/ubi8-openjdk-8.yaml
+++ b/ubi8-openjdk-8.yaml
@@ -41,7 +41,6 @@ modules:
   repositories:
   - path: modules
   install:
-  - name: jboss.container.util.pkg-update
   - name: jboss.container.openjdk.jdk
     version: "8"
   - name: jboss.container.prometheus
@@ -50,6 +49,7 @@ modules:
   - name: jboss.container.maven
     version: "8.2.3.6.8"
   - name: jboss.container.java.s2i.bash
+  - name: jboss.container.util.pkg-update
 
 help:
   add: true


### PR DESCRIPTION
This causes the "microdnf update" to take place after all the RPMs that are explicitly or implicitly installed by OpenJDK, Maven, etc have been installed.

This works around the issue described in RHELDST-15034.

https://issues.redhat.com/browse/OPENJDK-1334