### PR TITLE
[OPENJDK-1335] microdnf update weak deps

### DIFF
--- a/.github/workflows/ubi8-openjdk-11-runtime.yml
+++ b/.github/workflows/ubi8-openjdk-11-runtime.yml
@@ -2,7 +2,7 @@ name: OpenJDK 11 Runtime Image CI
 on: [push, pull_request]
 env:
   LANG: en_US.UTF-8
-  CEKIT_VERSION: 3.11.0
+  CEKIT_VERSION: 4.5.0
   S2I_URI: https://github.com/openshift/source-to-image/releases/download/v1.3.1/source-to-image-v1.3.1-a5a77147-linux-amd64.tar.gz
 jobs:
   openjdkci:

--- a/.github/workflows/ubi8-openjdk-11.yml
+++ b/.github/workflows/ubi8-openjdk-11.yml
@@ -2,7 +2,7 @@ name: OpenJDK 11 S2I Image CI
 on: [push, pull_request]
 env:
   LANG: en_US.UTF-8
-  CEKIT_VERSION: 3.6.0
+  CEKIT_VERSION: 4.5.0
   S2I_URI: https://github.com/openshift/source-to-image/releases/download/v1.3.1/source-to-image-v1.3.1-a5a77147-linux-amd64.tar.gz
 jobs:
   openjdkci:

--- a/.github/workflows/ubi8-openjdk-17-runtime.yml
+++ b/.github/workflows/ubi8-openjdk-17-runtime.yml
@@ -2,7 +2,7 @@ name: OpenJDK 17 Runtime Image CI
 on: [push, pull_request]
 env:
   LANG: en_US.UTF-8
-  CEKIT_VERSION: 3.11.0
+  CEKIT_VERSION: 4.5.0
   S2I_URI: https://github.com/openshift/source-to-image/releases/download/v1.3.1/source-to-image-v1.3.1-a5a77147-linux-amd64.tar.gz
 jobs:
   openjdkci:

--- a/.github/workflows/ubi8-openjdk-17.yml
+++ b/.github/workflows/ubi8-openjdk-17.yml
@@ -2,7 +2,7 @@ name: OpenJDK 17 S2I Image CI
 on: [push, pull_request]
 env:
   LANG: en_US.UTF-8
-  CEKIT_VERSION: 3.6.0
+  CEKIT_VERSION: 4.5.0
   S2I_URI: https://github.com/openshift/source-to-image/releases/download/v1.3.1/source-to-image-v1.3.1-a5a77147-linux-amd64.tar.gz
 jobs:
   openjdkci:

--- a/.github/workflows/ubi8-openjdk-8-runtime.yml
+++ b/.github/workflows/ubi8-openjdk-8-runtime.yml
@@ -2,7 +2,7 @@ name: OpenJDK 8 Runtime Image CI
 on: [push, pull_request]
 env:
   LANG: en_US.UTF-8
-  CEKIT_VERSION: 3.11.0
+  CEKIT_VERSION: 4.5.0
   S2I_URI: https://github.com/openshift/source-to-image/releases/download/v1.3.1/source-to-image-v1.3.1-a5a77147-linux-amd64.tar.gz
 jobs:
   openjdkci:

--- a/.github/workflows/ubi8-openjdk-8.yml
+++ b/.github/workflows/ubi8-openjdk-8.yml
@@ -2,7 +2,7 @@ name: OpenJDK 8 S2I Image CI
 on: [push, pull_request]
 env:
   LANG: en_US.UTF-8
-  CEKIT_VERSION: 3.6.0
+  CEKIT_VERSION: 4.5.0
   S2I_URI: https://github.com/openshift/source-to-image/releases/download/v1.3.1/source-to-image-v1.3.1-a5a77147-linux-amd64.tar.gz
 jobs:
   openjdkci:

--- a/modules/util/pkg-update/execute.sh
+++ b/modules/util/pkg-update/execute.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 for candidate in yum dnf microdnf; do
     if command -v "$candidate"; then
         mgr="$(command -v "$candidate")"
-        "$mgr" update -y
+        "$mgr" update --setopt=install_weak_deps=0 --setopt=tsflags=nodocs -y
         "$mgr" -y clean all
         exit
     fi

--- a/tests/features/java/openjdk.feature
+++ b/tests/features/java/openjdk.feature
@@ -80,6 +80,7 @@ Feature: Miscellaneous OpenJDK-related unit tests
     | command | bash -c "$JAVA_HOME/bin/java -XshowSettings:properties -version" |
     Then available container log should contain file.encoding = UTF-8
 
+  @wip
   @ubi8/openjdk-8
   @ubi8/openjdk-11
   @ubi8/openjdk-17
@@ -87,10 +88,10 @@ Feature: Miscellaneous OpenJDK-related unit tests
     When container is started with args
     | arg     | value   |
     | command | rpm -qa |
-    Then available container log should not contain procps-ng
-    Then available container log should not contain os-prober
-    Then available container log should not contain which
-    Then available container log should not contain systemd-pam
-    Then available container log should not contain libpwquality
-    Then available container log should not contain libxkbcommon
-    Then available container log should not contain kbd
+    Then container log should not contain procps-ng
+    Then container log should not contain os-prober
+    Then container log should not contain which
+    Then container log should not contain systemd-pam
+    Then container log should not contain libpwquality
+    Then container log should not contain libxkbcommon
+    Then container log should not contain kbd

--- a/tests/features/java/openjdk.feature
+++ b/tests/features/java/openjdk.feature
@@ -79,3 +79,18 @@ Feature: Miscellaneous OpenJDK-related unit tests
     | arg     | value                                  |
     | command | bash -c "$JAVA_HOME/bin/java -XshowSettings:properties -version" |
     Then available container log should contain file.encoding = UTF-8
+
+  @ubi8/openjdk-8
+  @ubi8/openjdk-11
+  @ubi8/openjdk-17
+  Scenario: Check that transitive weak dependencies are not installed (OPENJDK-1335)
+    When container is started with args
+    | arg     | value   |
+    | command | rpm -qa |
+    Then available container log should not contain procps-ng
+    Then available container log should not contain os-prober
+    Then available container log should not contain which
+    Then available container log should not contain systemd-pam
+    Then available container log should not contain libpwquality
+    Then available container log should not contain libxkbcommon
+    Then available container log should not contain kbd

--- a/tests/features/java/openjdk.feature
+++ b/tests/features/java/openjdk.feature
@@ -80,7 +80,6 @@ Feature: Miscellaneous OpenJDK-related unit tests
     | command | bash -c "$JAVA_HOME/bin/java -XshowSettings:properties -version" |
     Then available container log should contain file.encoding = UTF-8
 
-  @wip
   @ubi8/openjdk-8
   @ubi8/openjdk-11
   @ubi8/openjdk-17


### PR DESCRIPTION
Part 1 of a 2-commit PR: I want to see CI red lights for this commit before pushing the fix.

This commit adds a test for some RPMs that are installed as transitive weak dependencies via microdnf when it is not configured with install_weak_deps=0.

https://issues.redhat.com/browse/OPENJDK-1335?filter=12398815