### PR TITLE
Bump GitHub CI Cekit version to 4.5.0

### DIFF
--- a/.github/workflows/ubi9-openjdk-11-runtime.yml
+++ b/.github/workflows/ubi9-openjdk-11-runtime.yml
@@ -2,7 +2,7 @@ name: UBI9 OpenJDK 11 Runtime S2I Image CI
 on: [push, pull_request]
 env:
   LANG: en_US.UTF-8
-  CEKIT_VERSION: 4.1.1
+  CEKIT_VERSION: 4.5.0
   S2I_URI: https://github.com/openshift/source-to-image/releases/download/v1.3.1/source-to-image-v1.3.1-a5a77147-linux-amd64.tar.gz
   IMAGE: ubi9-openjdk-11-runtime
 jobs:

--- a/.github/workflows/ubi9-openjdk-11.yml
+++ b/.github/workflows/ubi9-openjdk-11.yml
@@ -2,7 +2,7 @@ name: UBI9 OpenJDK 11 S2I Image CI
 on: [push, pull_request]
 env:
   LANG: en_US.UTF-8
-  CEKIT_VERSION: 4.1.1
+  CEKIT_VERSION: 4.5.0
   S2I_URI: https://github.com/openshift/source-to-image/releases/download/v1.3.1/source-to-image-v1.3.1-a5a77147-linux-amd64.tar.gz
   IMAGE: ubi9-openjdk-11
 jobs:

--- a/.github/workflows/ubi9-openjdk-17-runtime.yml
+++ b/.github/workflows/ubi9-openjdk-17-runtime.yml
@@ -2,7 +2,7 @@ name: UBI9 OpenJDK 17 Runtime S2I Image CI
 on: [push, pull_request]
 env:
   LANG: en_US.UTF-8
-  CEKIT_VERSION: 4.1.1
+  CEKIT_VERSION: 4.5.0
   S2I_URI: https://github.com/openshift/source-to-image/releases/download/v1.3.1/source-to-image-v1.3.1-a5a77147-linux-amd64.tar.gz
   IMAGE: ubi9-openjdk-17-runtime
 jobs:

--- a/.github/workflows/ubi9-openjdk-17.yml
+++ b/.github/workflows/ubi9-openjdk-17.yml
@@ -2,7 +2,7 @@ name: UBI9 OpenJDK 17 S2I Image CI
 on: [push, pull_request]
 env:
   LANG: en_US.UTF-8
-  CEKIT_VERSION: 4.1.1
+  CEKIT_VERSION: 4.5.0
   S2I_URI: https://github.com/openshift/source-to-image/releases/download/v1.3.1/source-to-image-v1.3.1-a5a77147-linux-amd64.tar.gz
   IMAGE: ubi9-openjdk-17
 jobs:


### PR DESCRIPTION
Bump GitHub CI Cekit version for UBI9 to match the (newly updated) UBI8 version (current latest)