### PR TITLE
[OPENJDK-1336] ensure microdnf update install_weak_deps=0

### DIFF
--- a/modules/util/pkg-update/execute.sh
+++ b/modules/util/pkg-update/execute.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 for candidate in yum dnf microdnf; do
     if command -v "$candidate"; then
         mgr="$(command -v "$candidate")"
-        "$mgr" update -y
+        "$mgr" update --setopt=install_weak_deps=0 --setopt=tsflags=nodocs -y
         "$mgr" -y clean all
         exit
     fi


### PR DESCRIPTION
https://issues.redhat.com/browse/OPENJDK-1336

This prevents microdnf from installing weak dependencies when upgrading a package.