### PR TITLE
[Openjdk-559] max ram percentage default

### DIFF
--- a/modules/jvm/api/module.yaml
+++ b/modules/jvm/api/module.yaml
@@ -14,7 +14,7 @@ envs:
   description: User specified Java options to be appended to generated options in JAVA_OPTS.
   example: "-Dsome.property=foo"
 - name: JAVA_MAX_MEM_RATIO
-  description:  Specify the maximum heap memory. Corresponds to the JVM argument `-XX:MaxRAMPercentage`. The default is `80.0` which means 80% of the available memory. You can disable this mechanism by setting the value to `0`.
+  description:  Specify the maximum heap memory. Corresponds to the JVM argument `-XX:MaxRAMPercentage`. The default is `50.0` which means 80% of the available memory. You can disable this mechanism by setting the value to `0`.
   example: "90.0"
 - name: JAVA_INITIAL_MEM_RATIO
   description:

--- a/modules/jvm/api/module.yaml
+++ b/modules/jvm/api/module.yaml
@@ -14,7 +14,7 @@ envs:
   description: User specified Java options to be appended to generated options in JAVA_OPTS.
   example: "-Dsome.property=foo"
 - name: JAVA_MAX_MEM_RATIO
-  description:  Specify the maximum heap memory. Corresponds to the JVM argument `-XX:MaxRAMPercentage`. The default is `50.0` which means 80% of the available memory. You can disable this mechanism by setting the value to `0`.
+  description:  Specify the maximum heap memory. Corresponds to the JVM argument `-XX:MaxRAMPercentage`. The default is `50.0` which means 50% of the available memory. You can disable this mechanism by setting the value to `0`.
   example: "90.0"
 - name: JAVA_INITIAL_MEM_RATIO
   description:

--- a/modules/jvm/bash/artifacts/opt/jboss/container/java/jvm/java-default-options
+++ b/modules/jvm/bash/artifacts/opt/jboss/container/java/jvm/java-default-options
@@ -25,7 +25,7 @@ max_memory() {
   if [ "x$JAVA_MAX_MEM_RATIO" = "x0" ]; then
     return
   fi
-  echo "-XX:MaxRAMPercentage=${JAVA_MAX_MEM_RATIO:-80.0}"
+  echo "-XX:MaxRAMPercentage=${JAVA_MAX_MEM_RATIO:-50.0}"
 }
 
 # Check for memory options and calculate a sane default if not given

--- a/tests/features/java/memory.feature
+++ b/tests/features/java/memory.feature
@@ -3,7 +3,8 @@ Feature: OPENJDK-559 JVM Memory tests
   @ubi8
   Scenario: Check default JVM max heap configuration
     Given container is started as uid 1000
-    Then container log should contain -XX:MaxRAMPercentage=80.0
+    Then container log should contain -XX:MaxRAMPercentage=50.0
+    And  container log should not contain -Xmx
 
   @ubi8
   Scenario: Check configured JVM max heap configuration


### PR DESCRIPTION
https://issues.redhat.com/browse/OPENJDK-559

Defer the change of max heap size to 80%, revert to previous default of 50%.