### PR TITLE
[Openjdk-1510] maxram floats

### DIFF
--- a/modules/jvm/api/module.yaml
+++ b/modules/jvm/api/module.yaml
@@ -14,14 +14,23 @@ envs:
   description: User specified Java options to be appended to generated options in JAVA_OPTS.
   example: "-Dsome.property=foo"
 - name: JAVA_MAX_MEM_RATIO
-  description:  Specify the maximum heap memory. Corresponds to the JVM argument `-XX:MaxRAMPercentage`. The default is `50.0` which means 50% of the available memory. You can disable this mechanism by setting the value to `0`.
+  description:
+    Specify the maximum heap memory. Corresponds to the JVM argument
+    `-XX:MaxRAMPercentage`. The default is `50.0` which means 50% of the
+    available memory. You can disable this mechanism by setting the value to
+    `0`.
+    The supplied value can be an integer or float, but only the whole
+    number part is used.
   example: "90.0"
 - name: JAVA_INITIAL_MEM_RATIO
   description:
     Specify the initial heap memory. Corresponds to the JVM argument
     `-XX:InitialRAMPercentage`. By default this is not specified.
-    **This is deprecated and will be removed in a future release. Users should
-    specify `-XX:InitialRAMPercentage` directly in JAVA_OPTS instead.**
+    The supplied value can be an integer or float, but only the whole
+    number part is used.
+    **JAVA_INITIAL_MEM_RATIO is deprecated and will be removed in a future
+    release. Users should specify `-XX:InitialRAMPercentage` directly in
+    JAVA_OPTS instead.**
   example: "25.0"
 - name: JAVA_MAX_INITIAL_MEM
   description:

--- a/modules/jvm/bash/artifacts/opt/jboss/container/java/jvm/java-default-options
+++ b/modules/jvm/bash/artifacts/opt/jboss/container/java/jvm/java-default-options
@@ -21,11 +21,18 @@ fi
 
 # Check for memory options and calculate a sane default if not given
 max_memory() {
-  # Check if explicitly disabled
-  if [ "x$JAVA_MAX_MEM_RATIO" = "x0" ]; then
-    return
-  fi
-  echo "-XX:MaxRAMPercentage=${JAVA_MAX_MEM_RATIO:-50.0}"
+  case "$JAVA_MAX_MEM_RATIO" in
+    "0") # explicitly disabled
+      return
+      ;;
+    "")
+      maxmem="50.0"
+      ;;
+    *)
+      maxmem="$(printf "%.0f.0" "$JAVA_MAX_MEM_RATIO")"
+      ;;
+  esac
+  echo "-XX:MaxRAMPercentage=$maxmem"
 }
 
 # Check for memory options and calculate a sane default if not given
@@ -36,8 +43,11 @@ initial_memory() {
   else
     # there's no point setting this if we are passing -Xms, since -Xms
     # overrides this
+    # JAVA_INITIAL_MEM_RATIO is deprecated and will be removed in a
+    # future release
     if [ -n "$JAVA_INITIAL_MEM_RATIO" ]; then
-      echo "-XX:InitialRAMPercentage=${JAVA_INITIAL_MEM_RATIO}"
+      initmem="$(printf "%.0f.0" "$JAVA_INITIAL_MEM_RATIO")"
+      echo "-XX:InitialRAMPercentage=${initmem}"
     fi
   fi
 }

--- a/tests/features/java/memory.feature
+++ b/tests/features/java/memory.feature
@@ -7,11 +7,32 @@ Feature: OPENJDK-559 JVM Memory tests
     And  container log should not contain -Xmx
 
   @ubi8
-  Scenario: Check configured JVM max heap configuration
+  Scenario: Check configured JVM max heap configuration and ensure JAVA_MAX_MEM_RATIO accepts floats but only takes whole number part
     Given container is started with env
     | variable           | value  |
-    | JAVA_MAX_MEM_RATIO | 90.0   |
+    | JAVA_MAX_MEM_RATIO | 90.4   |
     Then container log should contain -XX:MaxRAMPercentage=90.0
+
+  @ubi8
+  Scenario: Ensure JAVA_MAX_MEM_RATIO accepts Integers
+    Given container is started with env
+    | variable           | value  |
+    | JAVA_MAX_MEM_RATIO | 90     |
+    Then container log should contain -XX:MaxRAMPercentage=90.0
+
+  @ubi8
+  Scenario: Ensure JAVA_INITIAL_MEM_RATIO accepts Integers
+    Given container is started with env
+    | variable               | value  |
+    | JAVA_INITIAL_MEM_RATIO | 10     |
+    Then container log should contain -XX:InitialRAMPercentage=10.0
+
+  @ubi8
+  Scenario: Ensure JAVA_MAX_MEM_RATIO=0 disables parameter
+    Given container is started with env
+    | variable           | value  |
+    | JAVA_MAX_MEM_RATIO | 0     |
+    Then container log should not contain -XX:MaxRAMPercentage
 
   @ubi8
   Scenario: Check default JVM initial heap configuration is unspecified
@@ -20,10 +41,10 @@ Feature: OPENJDK-559 JVM Memory tests
     And  container log should not contain -Xms
 
   @ubi8
-  Scenario: Check configured JVM max heap configuration
+  Scenario: Check configured JVM max heap configuration and ensure JAVA_INITIAL_MEM_RATIO accepts floats but only takes whole number part
     Given container is started with env
     | variable               | value  |
-    | JAVA_INITIAL_MEM_RATIO | 25.0   |
+    | JAVA_INITIAL_MEM_RATIO | 25.2   |
     Then container log should contain -XX:InitialRAMPercentage=25.0
 
   @ubi8


### PR DESCRIPTION
https://issues.redhat.com/browse/OPENJDK-1510

JAVA_MAX_MEM_RATIO (and initial) used to accept integers, and therefore should do so. JDK8 requires floats with the '.X' suffix (.0 for no sub-1 value). We can't both accept integers and pass them through unaltered.

Some TODO notes in the commit message