### PR TITLE
[OPENJDK-1523] accept integers for JAVA_*_MEM_RATIO

### DIFF
--- a/modules/jvm/artifacts/opt/jboss/container/java/jvm/java-default-options
+++ b/modules/jvm/artifacts/opt/jboss/container/java/jvm/java-default-options
@@ -21,11 +21,18 @@ fi
 
 # Check for memory options and calculate a sane default if not given
 max_memory() {
-  # Check if explicitly disabled
-  if [ "x$JAVA_MAX_MEM_RATIO" = "x0" ]; then
-    return
-  fi
-  echo "-XX:MaxRAMPercentage=${JAVA_MAX_MEM_RATIO:-80.0}"
+  case "$JAVA_MAX_MEM_RATIO" in
+    "0") # explicitly disabled
+      return
+      ;;
+    "")
+      maxmem="80.0"
+      ;;
+    *)
+      maxmem="$(printf "%.0f.0" "$JAVA_MAX_MEM_RATIO")"
+      ;;
+  esac
+  echo "-XX:MaxRAMPercentage=$maxmem"
 }
 
 # Switch on diagnostics except when switched off

--- a/modules/jvm/module.yaml
+++ b/modules/jvm/module.yaml
@@ -25,7 +25,7 @@ envs:
     This variable has no effect if `JAVA_OPTS` has been defined.
   example:      "-Dsome.property=foo"
 - name: JAVA_MAX_MEM_RATIO
-  description:  Specify the maximum heap memory. Corresponds to the JVM argument `-XX:MaxRAMPercentage`. The default is `80.0` which means 80% of the available memory. You can disable this mechanism by setting the value to `0`.
+  description:  Specify the maximum heap memory. Corresponds to the JVM argument `-XX:MaxRAMPercentage`. The default is `80.0` which means 80% of the available memory. You can disable this mechanism by setting the value to `0`. The supplied value can be an integer or float, but only the whole number part is used.
   example: "90.0"
 - name:         JAVA_DIAGNOSTICS
   description:  "Set this to get some diagnostics information to standard output when things are happening. **Note: ** This option, if set to true, will set `-XX :+UnlockDiagnosticVMOptions`. **Disabled by default.**"

--- a/tests/features/java/memory.feature
+++ b/tests/features/java/memory.feature
@@ -6,11 +6,25 @@ Feature: OPENJDK-559 JVM Memory tests
     Then container log should contain -XX:MaxRAMPercentage=80.0
 
   @ubi9
-  Scenario: Check configured JVM max heap configuration
+  Scenario: Check configured JVM max heap configuration and ensure JAVA_MAX_MEM_RATIO accepts floats but only takes whole number part
     Given container is started with env
     | variable           | value  |
-    | JAVA_MAX_MEM_RATIO | 90.0   |
+    | JAVA_MAX_MEM_RATIO | 90.4   |
     Then container log should contain -XX:MaxRAMPercentage=90.0
+
+  @ubi9
+  Scenario: Ensure JAVA_MAX_MEM_RATIO accepts Integers
+    Given container is started with env
+    | variable           | value  |
+    | JAVA_MAX_MEM_RATIO | 90     |
+    Then container log should contain -XX:MaxRAMPercentage=90.0
+
+  @ubi9
+  Scenario: Ensure JAVA_MAX_MEM_RATIO=0 disables parameter
+    Given container is started with env
+    | variable           | value  |
+    | JAVA_MAX_MEM_RATIO | 0      |
+    Then container log should not contain -XX:MaxRAMPercentage
 
   @ubi9
   Scenario: Check default JVM initial heap configuration is unspecified


### PR DESCRIPTION
This is a cherry-pick-and-fixup of OPENJDK-1510 (06a5d27) on the ubi8 branch, to have consistency in the handling of JAVA_MAX_MEM_RATIO between the ubi8 and ubi9 images.

https://issues.redhat.com/browse/OPENJDK-1523