### PR TITLE
[Openjdk-1551] JAVA_APP_NAME quoting/interpolation issues

### DIFF
--- a/modules/run/artifacts/opt/jboss/container/java/run/run-java.sh
+++ b/modules/run/artifacts/opt/jboss/container/java/run/run-java.sh
@@ -182,13 +182,6 @@ get_classpath() {
   echo "${cp_path}"
 }
 
-# Set process name if possible
-get_exec_args() {
-  if [ "x${JAVA_APP_NAME}" != x ]; then
-    echo "-a '${JAVA_APP_NAME}'"
-  fi
-}
-
 # Start JVM
 startup() {
   # Initialize environment
@@ -201,8 +194,11 @@ startup() {
   else
      args="-jar ${JAVA_APP_JAR}"
   fi
-  log_info "exec $(get_exec_args) java $(get_java_options) -cp \"$(get_classpath)\" ${args} $*"
-  exec $(get_exec_args) java $(get_java_options) -cp "$(get_classpath)" ${args} $*
+
+  procname="${JAVA_APP_NAME-java}"
+
+  log_info "exec -a \"${procname}\" java $(get_java_options) -cp \"$(get_classpath)\" ${args} $*"
+  exec -a "${procname}" java $(get_java_options) -cp "$(get_classpath)" ${args} $*
 }
 
 # =============================================================================

--- a/tests/features/java/runtime.feature
+++ b/tests/features/java/runtime.feature
@@ -28,10 +28,16 @@ Feature: Openshift OpenJDK Runtime tests
 
   @ubi9
   Scenario: Check JAVA_OPTS overrides JAVA_OPTS_APPEND
-    piv
     Given container is started with env
     | variable         | value          |
     | JAVA_OPTS        | -verbose:gc    |
     | JAVA_OPTS_APPEND | -Xint          |
     Then container log should contain -verbose:gc
      And container log should not contain -Xint
+
+  @ubi9
+  Scenario: Check JAVA_APP_NAME can contain spaces (OPENJDK-1551)
+    Given container is started with env
+    | variable         | value   |
+    | JAVA_APP_NAME    | foo bar |
+  Then container log should not contain exec: bar': not found


### PR DESCRIPTION
https://issues.redhat.com/browse/OPENJDK-1551

The reporter specifically highlighted two issues

 *   JAVA_APP_NAME=foo means the process name will be 'foo' (with the single quotes included
 *   JAVA_APP_NAME=foo bar will cause the container to crash loop with exec: bar': not found

Both should now be addressed, and there's a test for the latter.

Remove a stray string from an earlier test (pebkac)