### PR TITLE
[RHEL8] JAVA_APP_NAME breaks if contains whitespace, incorrectly wraps with quotes

### DIFF
--- a/modules/run/artifacts/opt/jboss/container/java/run/run-java.sh
+++ b/modules/run/artifacts/opt/jboss/container/java/run/run-java.sh
@@ -195,13 +195,6 @@ get_classpath() {
   echo "${cp_path}"
 }
 
-# Set process name if possible
-get_exec_args() {
-  if [ "x${JAVA_APP_NAME}" != x ]; then
-    echo "-a '${JAVA_APP_NAME}'"
-  fi
-}
-
 # Ensure that the running UID has the "jboss" passwd metadata
 # XXX: Maybe we should make this an entrypoint for the image?
 function configure_passwd() {
@@ -226,8 +219,11 @@ startup() {
   else
      args="-jar ${JAVA_APP_JAR}"
   fi
-  log_info "exec $(get_exec_args) java $(get_java_options) -cp \"$(get_classpath)\" ${args} $*"
-  exec $(get_exec_args) java $(get_java_options) -cp "$(get_classpath)" ${args} $*
+
+  procname="${JAVA_APP_NAME-java}"
+
+  log_info "exec -a \"${procname}\" java $(get_java_options) -cp \"$(get_classpath)\" ${args} $*"
+  exec -a "${procname}" java $(get_java_options) -cp "$(get_classpath)" ${args} $*
 }
 
 # =============================================================================

--- a/tests/features/java/runtime.feature
+++ b/tests/features/java/runtime.feature
@@ -35,3 +35,10 @@ Feature: Openshift OpenJDK Runtime tests
     | variable  | value  |
     | JAVA_ARGS | unique |
   Then container log should not contain unique unique
+
+  @ubi8
+  Scenario: Check JAVA_APP_NAME can contain spaces (OPENJDK-104)
+    Given container is started with env
+    | variable         | value   |
+    | JAVA_APP_NAME    | foo bar |
+  Then container log should not contain exec: bar': not found


### PR DESCRIPTION
https://issues.redhat.com/browse/OPENJDK-104