### PR TITLE
[OPENJDK-1464] Fix building ubi9/openjdk-17

### DIFF
--- a/ubi9-openjdk-17.yaml
+++ b/ubi9-openjdk-17.yaml
@@ -45,7 +45,7 @@ modules:
   - name: jboss.container.openjdk.jdk
     version: "17"
   - name: jboss.container.maven
-    version: "17"
+    version: "3.8.17"
   - name: jboss.container.java.s2i.bash
 
 help:


### PR DESCRIPTION
Oops, Changing the version scheme for the modules I missed this reference in the image descriptor.