### PR TITLE
[OPENJDK-1549] clean environment when invoking Maven

### DIFF
--- a/modules/maven/default/artifacts/opt/jboss/container/maven/default/maven.sh
+++ b/modules/maven/default/artifacts/opt/jboss/container/maven/default/maven.sh
@@ -69,16 +69,16 @@ function maven_build() {
   local goals=${2:-package}
   log_info "Performing Maven build in $build_dir"
 
-  pushd $build_dir &> /dev/null
+  # subshell so we can exec mvn with a clean environment (OPENJDK-1549)
+  (
+    cd $build_dir
 
-  log_info "Using MAVEN_OPTS ${MAVEN_OPTS}"
-  log_info "Using $(mvn $MAVEN_ARGS --version)"
-  log_info "Running 'mvn $MAVEN_ARGS $goals'"
-  # Execute the actual build
-  mvn $MAVEN_ARGS $goals
-  
-  popd &> /dev/null
-  
+    log_info "Using MAVEN_OPTS ${MAVEN_OPTS}"
+    log_info "Using $(mvn $MAVEN_ARGS --version)"
+    log_info "Running 'mvn $MAVEN_ARGS $goals'"
+
+    exec -c mvn $MAVEN_ARGS $goals
+  )
 }
 
 # post build cleanup.  deletes local repository after a build, if MAVEN_CLEAR_REPO is set

--- a/tests/OPENJDK-1549/README.md
+++ b/tests/OPENJDK-1549/README.md
@@ -1,0 +1,18 @@
+# Test for OPENJDK-1549
+
+<https://issues.redhat.com/browse/OPENJDK-1549>
+
+This is a minimal Maven project for which the `validate` target will fail
+if the environment variable `MAVEN_ARGS` is defined.
+
+This is achieved using the Enforcer plugin. We could not use the
+`requireEnvironmentVariable` built-in rule as it can only fail if a variable
+is undefined, rather than if it is. Instead we use `evaluateBeanshell` and
+a very short Beanshell expression.
+
+Maven expands strings of the form `${env.foo}` within the POM only if the
+variable is defined. That is, when `MAVEN_ARGS` is not defined in the
+environment, the string `${env.MAVEN_ARGS}` is passed through unaltered.
+If the variable is defined (including defined but empty), Maven will expand
+it. Some string concatenation trickery is needed to match against the
+un-expanded form.

--- a/tests/OPENJDK-1549/pom.xml
+++ b/tests/OPENJDK-1549/pom.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project>
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>org.acme</groupId>
+  <artifactId>getting-started</artifactId>
+  <version>1.0.0-SNAPSHOT</version>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-enforcer-plugin</artifactId>
+        <version>3.3.0</version>
+        <executions>
+
+          <!-- ensure the environment variable MAVEN_ARGS is unset -->
+          <execution>
+            <id>enforce-beanshell</id>
+            <goals>
+              <goal>enforce</goal>
+            </goals>
+            <configuration>
+              <rules>
+                <evaluateBeanshell>
+                  <condition>"${env.MAVEN_ARGS}".equals("${env."+"MAVEN_ARGS}")</condition>
+                </evaluateBeanshell>
+              </rules>
+              <fail>true</fail>
+            </configuration>
+          </execution>
+
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/tests/features/java/java_s2i.feature
+++ b/tests/features/java/java_s2i.feature
@@ -137,3 +137,8 @@ Feature: Openshift OpenJDK S2I tests
     Given s2i build https://github.com/jboss-openshift/openshift-examples from spring-boot-sample-simple/target
     Then s2i build log should not contain skipping directory .
     And  run find /deployments in container and check its output for spring-boot-sample-simple-1.5.0.BUILD-SNAPSHOT.jar
+
+  Scenario: Ensure the environment is cleaned when executing mvn (OPENJDK-1549)
+      Given s2i build https://github.com/jmtd/openjdk from tests/OPENJDK-1549 with env using OPENJDK-1549-MAVEN_ARGS
+       | variable           | value    |
+       | MAVEN_ARGS         | validate |


### PR DESCRIPTION
<https://issues.redhat.com/browse/OPENJDK-1549>

This is a proposed solution to the forthcoming issue that Maven (from
version 3.9) will start to honour the environment variable MAVEN_ARGS
(see #343).

The proposal is we clean the environment before launching Maven, such
that none of the variables we use for configuring the images leak out.

This would break a workflow whereby a user has deliberately defined a
variable for Maven to consume, within S2I.  I think this is unlikely,
but I am seeking feedback from the wider Middleware community.

Similarly (and not implemented in this PR) I think we should consider
the same approach when launching Java. That is, scrub the environment
in the run script prior to invoking /usr/bin/java. If a user defined
environment variables intended to reach their application, this would
break. I suspect this is more likely than in the Maven case, but I am
opening a discussion.

As an implementation note: I needed to define a Maven POM in order to
write a test for this, and I needed somewhere to store that. I didn't
think <https://github.com/jboss-openshift/openshift-quickstarts>  was
an appropriate place, since the test POM is not a quickstart, and now
we have archived that repository. So, I added it to this repository.
Due to the chicken-and-egg nature of needing to reference the POM by
URI prior to this being merged, the test references my fork instead.
This could be corrected in a follow-up PR.

Fixes: #343.
