### PR TITLE
[OPENJDK-1673] use cp -p for s2i deployments

### DIFF
--- a/modules/s2i/core/artifacts/opt/jboss/container/s2i/core/s2i-core
+++ b/modules/s2i/core/artifacts/opt/jboss/container/s2i/core/s2i-core
@@ -92,7 +92,7 @@ function s2i_core_copy_deployments() {
       local relative_source=$(realpath --relative-to "${S2I_SOURCE_DIR}" "${1}/${S2I_SOURCE_DEPLOYMENTS_DIR}")
       log_info "Copying deployments from $relative_source to ${S2I_TARGET_DEPLOYMENTS_DIR}..."
       for filter in ${S2I_SOURCE_DEPLOYMENTS_FILTER:-*}; do
-        find "${S2I_SOURCE_DIR}/${relative_source}/" -maxdepth 1 -name "${filter}" | xargs -I '{}' -r cp -Lrv '{}' "${S2I_TARGET_DEPLOYMENTS_DIR}"
+        find "${S2I_SOURCE_DIR}/${relative_source}/" -maxdepth 1 -name "${filter}" | xargs -I '{}' -r cp -Lrpv '{}' "${S2I_TARGET_DEPLOYMENTS_DIR}"
       done
     fi
   fi 

--- a/tests/features/java/openjdk_s2i.feature
+++ b/tests/features/java/openjdk_s2i.feature
@@ -1,6 +1,12 @@
-# OpenJDK/hotspot only
+# builder only
+@ubi9/openjdk-11
+@ubi9/openjdk-17
 Feature: Openshift OpenJDK-only S2I tests
   Scenario: Check java perf dir owned by jboss (CLOUD-2070)
     Given s2i build https://github.com/jboss-openshift/openshift-quickstarts from undertow-servlet
     Then run jstat -gc 1 1000 1 in container and check its output for S0C
     And run stat --printf="%U %G" /tmp/hsperfdata_jboss/ in container and check its output for jboss root
+
+  Scenario: Ensure Quarkus CDS doesn't fail due to timestamp mismatch (OPENDJK-1673)
+    Given s2i build https://github.com/jerboaa/quarkus-quickstarts from getting-started using quickstart-2.16-s2i-cds
+    Then container log should not contain A jar file is not the one used while building the shared archive file


### PR DESCRIPTION
The test is preliminary, I guess it would be good to switch it to the quarkusio organisation rather than @jerboaa 's fork. I'm not sure if there's an appopriate ref in the mainline (in place of quickstart-2.16-s2i-cds); is any of the CDS stuff landed? Thanks

https://issues.redhat.com/browse/OPENJDK-1673