### PR TITLE
[OPENJDK-1812] correct jre module version for ubi9/openjdk-17-runtime

### DIFF
--- a/ubi9-openjdk-17-runtime.yaml
+++ b/ubi9-openjdk-17-runtime.yaml
@@ -41,7 +41,7 @@ modules:
   install:
   - name: jboss.container.util.pkg-update
   - name: jboss.container.openjdk.jre
-    version: "3.8.17"
+    version: "17"
   - name:  jboss.container.java.jre.run
 
 help:


### PR DESCRIPTION
https://issues.redhat.com/browse/OPENJDK-1812

I broke this image with the Maven 3.8 update PR. This should fix it.