### PR TITLE
[OPENJDK-1813] fix hsperfdata owner check

### DIFF
--- a/tests/features/java/openjdk_s2i.feature
+++ b/tests/features/java/openjdk_s2i.feature
@@ -2,10 +2,10 @@
 @ubi9/openjdk-11
 @ubi9/openjdk-17
 Feature: Openshift OpenJDK-only S2I tests
-  Scenario: Check java perf dir owned by jboss (CLOUD-2070)
+  Scenario: Check java perf dir owned by default (CLOUD-2070, OPENJDK-91)
     Given s2i build https://github.com/jboss-openshift/openshift-quickstarts from undertow-servlet
     Then run jstat -gc 1 1000 1 in container and check its output for S0C
-    And run stat --printf="%U %G" /tmp/hsperfdata_jboss/ in container and check its output for jboss root
+    And run stat --printf="%U %G" /tmp/hsperfdata_default/ in container and check its output for default root
 
   Scenario: Ensure Quarkus CDS doesn't fail due to timestamp mismatch (OPENDJK-1673)
     Given s2i build https://github.com/jerboaa/quarkus-quickstarts from getting-started using quickstart-2.16-s2i-cds


### PR DESCRIPTION
The change in OPENJDK-91 (switch of username from "jboss" to "default") means this test, which encodes the username twice, was failing.

https://issues.redhat.com/browse/OPENJDK-1813