### PR TITLE
[OPENJDK-631] support quarkus fast-jar build layout out-of-the-box

### DIFF
--- a/modules/maven/s2i/module.yaml
+++ b/modules/maven/s2i/module.yaml
@@ -8,8 +8,10 @@ description: ^
 envs:
 - name: MAVEN_S2I_ARTIFACT_DIRS
   description: >
-    Relative paths of source directories to scan for build output, which will
-    be copied to $DEPLOY_DIR.  Defaults to **target**
+    Relative paths of source directories to scan for build output,
+    which will be copied to $S2I_TARGET_DEPLOYMENTS_DIR.
+    Paths should be delimited by a comma (,).
+    Defaults to **target**
   example: target
 
 - name: MAVEN_S2I_GOALS

--- a/modules/run/artifacts/opt/jboss/container/java/run/run-java.sh
+++ b/modules/run/artifacts/opt/jboss/container/java/run/run-java.sh
@@ -22,6 +22,17 @@ check_error() {
   fi
 }
 
+# detect Quarkus fast-jar package type (OPENJDK-631)
+is_quarkus_fast_jar() {
+  if test -f quarkus-app/quarkus-run.jar; then
+    log_info "quarkus fast-jar package type detected"
+    echo quarkus-app/quarkus-run.jar
+    return 0
+  else
+    return 1
+  fi
+}
+
 # Try hard to find a sane default jar-file
 auto_detect_jar_file() {
   local dir=$1
@@ -30,6 +41,12 @@ auto_detect_jar_file() {
   local old_dir=$(pwd)
   cd ${dir}
   if [ $? = 0 ]; then
+
+    if quarkus="$(is_quarkus_fast_jar)"; then
+      echo "$quarkus"
+      return
+    fi
+
     local nr_jars=`ls *.jar 2>/dev/null | grep -v '^original-' | wc -l | tr -d '[[:space:]]'`
     if [ ${nr_jars} = 1 ]; then
       ls *.jar | grep -v '^original-'

--- a/modules/s2i/bash/module.yaml
+++ b/modules/s2i/bash/module.yaml
@@ -6,8 +6,6 @@ description: Customization of common Maven S2I for Java S2I image.
 envs:
 - name: JBOSS_CONTAINER_JAVA_S2I_MODULE
   value: /opt/jboss/container/java/s2i
-- name: S2I_SOURCE_DEPLOYMENTS_FILTER
-  value: "*.jar"
 
 execute:
 - script: configure.sh

--- a/modules/s2i/core/module.yaml
+++ b/modules/s2i/core/module.yaml
@@ -78,8 +78,8 @@ envs:
 - name: S2I_SOURCE_DEPLOYMENTS_FILTER
   description: >
     Space separated list of filters to be applied when copying deployments.
-    Defaults to ** * **
-  value: "*"
+    Defaults to ** *.jar quarkus-app **
+  value: "*.jar quarkus-app"
   example: "*.jar *.war *.ear"
 
 - name: S2I_TARGET_DEPLOYMENTS_DIR

--- a/tests/features/java/openjdk_s2i.feature
+++ b/tests/features/java/openjdk_s2i.feature
@@ -10,3 +10,21 @@ Feature: Openshift OpenJDK-only S2I tests
   Scenario: Ensure Quarkus CDS doesn't fail due to timestamp mismatch (OPENDJK-1673)
     Given s2i build https://github.com/jerboaa/quarkus-quickstarts from getting-started using quickstart-2.16-s2i-cds
     Then container log should not contain A jar file is not the one used while building the shared archive file
+
+  Scenario: quarkus fast-jar layout works out-of-the-box (OPENJDK-631)
+    Given s2i build https://github.com/jmtd/openshift-quickstarts from quarkus-quickstarts/getting-started-3.0.1.Final-nos2i using OPENJDK-631-quarkus-fast-jar
+    Then container log should contain INFO quarkus fast-jar package type detected
+    And  container log should contain -jar /deployments/quarkus-app/quarkus-run.jar
+    And  container log should contain (main) getting-started 1.0.0-SNAPSHOT on JVM (powered by Quarkus
+    # these might occur if the wrong JAR is chosen as the main one
+    And  container log should not contain -jar /deployments/getting-started-1.0.0-SNAPSHOT.jar
+    And  container log should not contain no main manifest attribute
+
+  Scenario: quarkus uber-jar layout works out-of-the-box (OPENJDK-631)
+    Given s2i build https://github.com/jmtd/openshift-quickstarts from quarkus-quickstarts/getting-started-3.0.1.Final-nos2i with env using OPENJDK-631-quarkus-fast-jar
+       | variable             | value    |
+       | QUARKUS_PACKAGE_TYPE | uber-jar |
+    Then container log should not contain INFO quarkus fast-jar package type detected
+    And  container log should not contain -jar /deployments/quarkus-app/quarkus-run.jar
+    And  container log should contain -jar /deployments/getting-started-1.0.0-SNAPSHOT-runner.jar
+    And  container log should contain (main) getting-started 1.0.0-SNAPSHOT on JVM (powered by Quarkus


### PR DESCRIPTION
Also uber-jar layout.

A small tweak to one environment variable default, and adding auto-detection for the fast-jar JAR  to the run script, is all that's needed to get fast-jar working OOTB.

(I originally thought I'd have to change MAVEN_S2I_ARTIFACT_DIRS too, but I did not. A commit remains that fixes a documentation bug relating to it)