### PR TITLE
Openjdk 1961, 1964: tests and docs for MAVEN_REPO_URL, MAVEN_REPOS, etc.

### DIFF
--- a/modules/maven/default/module.yaml
+++ b/modules/maven/default/module.yaml
@@ -50,6 +50,17 @@ envs:
 - name: MAVEN_LOCAL_REPO
   description: Directory to use as the local Maven repository.
   example: /home/default/.m2/repository
+- name: "MAVEN_REPO_URL"
+  example: "http://repo.example.com:8080/maven2/"
+  description: >
+    Specify a Maven repository by URL.
+    See MAVEN_REPOS for specifying multiple repositories.
+- name: "MAVEN_REPO_ID"
+  example: "myrepo"
+  description: >
+    Provide a static ID for the Maven repository specified by
+    MAVEN_REPO_URL. The default is to generate a random ID.
+    See MAVEN_REPOS for specifying multiple repositories.
 - name: "MAVEN_REPOS"
   example: "dev-one,qe-two"
   description: "If set, multi-repo support is enabled, and other MAVEN_REPO_* variables will be prefixed. For example: DEV_ONE_MAVEN_REPO_URL and QE_TWO_MAVEN_REPO_URL"

--- a/tests/features/java/java_s2i.feature
+++ b/tests/features/java/java_s2i.feature
@@ -138,6 +138,23 @@ Feature: Openshift OpenJDK S2I tests
     Then s2i build log should not contain skipping directory .
     And  run find /deployments in container and check its output for spring-boot-sample-simple-1.5.0.BUILD-SNAPSHOT.jar
 
+  # OPENJDK-1954 - MAVEN_REPOS
+  Scenario: run the s2i and check the maven mirror and proxy have been initialised in the default settings.xml, uses http_proxy
+    Given s2i build https://github.com/jboss-openshift/openshift-examples from spring-boot-sample-simple/target
+       | variable                | value                                |
+       | MAVEN_REPOS             | TESTREPO,ANOTHER                     |
+       | TESTREPO_MAVEN_REPO_URL | http://repo.example.com:8080/maven2/ |
+       | TESTREPO_MAVEN_REPO_ID  | myrepo                               |
+       | ANOTHER_MAVEN_REPO_URL  | https://repo.example.org:8888/       |
+       | ANOTHER_MAVEN_REPO_ID   | another                              |
+    And XML namespaces
+       | prefix | url                                    |
+       | ns     | http://maven.apache.org/SETTINGS/1.0.0 |
+    Then XML file /tmp/artifacts/configuration/settings.xml should have 1 elements on XPath //ns:server[ns:id='myrepo']
+    Then XML file /tmp/artifacts/configuration/settings.xml should have 1 elements on XPath //ns:profile[ns:id='myrepo-profile']/ns:repositories/ns:repository[ns:url='http://repo.example.com:8080/maven2/']
+    Then XML file /tmp/artifacts/configuration/settings.xml should have 1 elements on XPath //ns:server[ns:id='another']
+    Then XML file /tmp/artifacts/configuration/settings.xml should have 1 elements on XPath //ns:profile[ns:id='another-profile']/ns:repositories/ns:repository[ns:url='https://repo.example.org:8888/']
+
   # OPENJDK-1961: MAVEN_REPO_URL and MAVEN_REPO_ID
   Scenario: Check MAVEN_REPO_URL generates Maven settings and profile configuration
     Given s2i build https://github.com/jboss-openshift/openshift-examples from spring-boot-sample-simple/target

--- a/tests/features/java/java_s2i.feature
+++ b/tests/features/java/java_s2i.feature
@@ -137,3 +137,15 @@ Feature: Openshift OpenJDK S2I tests
     Given s2i build https://github.com/jboss-openshift/openshift-examples from spring-boot-sample-simple/target
     Then s2i build log should not contain skipping directory .
     And  run find /deployments in container and check its output for spring-boot-sample-simple-1.5.0.BUILD-SNAPSHOT.jar
+
+  # OPENJDK-1961: MAVEN_REPO_URL and MAVEN_REPO_ID
+  Scenario: Check MAVEN_REPO_URL generates Maven settings and profile configuration
+    Given s2i build https://github.com/jboss-openshift/openshift-examples from spring-boot-sample-simple/target
+       | variable       | value                                |
+       | MAVEN_REPO_URL | http://repo.example.com:8080/maven2/ |
+       | MAVEN_REPO_ID  | myrepo                               |
+    And XML namespaces
+       | prefix | url                                    |
+       | ns     | http://maven.apache.org/SETTINGS/1.0.0 |
+    Then XML file /tmp/artifacts/configuration/settings.xml should have 1 elements on XPath //ns:server[ns:id='myrepo']
+    Then XML file /tmp/artifacts/configuration/settings.xml should have 1 elements on XPath //ns:profile[ns:id='myrepo-profile']/ns:repositories/ns:repository[ns:url='http://repo.example.com:8080/maven2/']


### PR DESCRIPTION
https://issues.redhat.com/browse/OPENJDK-1954

document MAVEN_REPO_URL and MAVEN_REPO_ID. Add a test for them too.

Test for MAVEN_REPOS.