### PR TITLE
[Openjdk-1984] maxram ubi8

### DIFF
--- a/modules/jvm/api/module.yaml
+++ b/modules/jvm/api/module.yaml
@@ -16,7 +16,7 @@ envs:
 - name: JAVA_MAX_MEM_RATIO
   description:
     Specify the maximum heap memory. Corresponds to the JVM argument
-    `-XX:MaxRAMPercentage`. The default is `50.0` which means 50% of the
+    `-XX:MaxRAMPercentage`. The default is `80.0` which means 80% of the
     available memory. You can disable this mechanism by setting the value to
     `0`.
     The supplied value can be an integer or float, but only the whole

--- a/modules/jvm/bash/artifacts/opt/jboss/container/java/jvm/java-default-options
+++ b/modules/jvm/bash/artifacts/opt/jboss/container/java/jvm/java-default-options
@@ -26,7 +26,7 @@ max_memory() {
       return
       ;;
     "")
-      maxmem="50.0"
+      maxmem="80.0"
       ;;
     *)
       maxmem="$(printf "%.0f.0" "$JAVA_MAX_MEM_RATIO")"

--- a/tests/features/java/memory.feature
+++ b/tests/features/java/memory.feature
@@ -3,7 +3,7 @@ Feature: OPENJDK-559 JVM Memory tests
   @ubi8
   Scenario: Check default JVM max heap configuration
     Given container is started as uid 1000
-    Then container log should contain -XX:MaxRAMPercentage=50.0
+    Then container log should contain -XX:MaxRAMPercentage=80.0
     And  container log should not contain -Xmx
 
   @ubi8


### PR DESCRIPTION
This is for https://issues.redhat.com/browse/OPENJDK-559 again - this time as https://issues.redhat.com/browse/OPENJDK-1984

set the default for JAVA_MAX_MEM_RATIO / MaxRAMPercentage to 80%.