### PR TITLE
[OPENJDK-2033] OpenJDK runtime images cannot overwrite JAVA_APP_DIR

### DIFF
--- a/modules/run/artifacts/opt/jboss/container/java/run/run-env.sh
+++ b/modules/run/artifacts/opt/jboss/container/java/run/run-env.sh
@@ -1,4 +1,6 @@
 #!/bin/sh
 
-# Set the application dir to the S2I deployment dir
-JAVA_APP_DIR=/deployments
+# Default the application dir to the S2I deployment dir
+if [ -z "$JAVA_APP_DIR" ]
+then JAVA_APP_DIR=/deployments
+fi

--- a/modules/run/artifacts/opt/jboss/container/java/run/run-java.sh
+++ b/modules/run/artifacts/opt/jboss/container/java/run/run-java.sh
@@ -245,6 +245,7 @@ startup() {
   procname="${JAVA_APP_NAME-java}"
 
   log_info "exec -a \"${procname}\" java $(get_java_options) -cp \"$(get_classpath)\" ${args} $*"
+  log_info "running in $PWD"
   exec -a "${procname}" java $(get_java_options) -cp "$(get_classpath)" ${args} $*
 }
 

--- a/tests/features/java/runtime.feature
+++ b/tests/features/java/runtime.feature
@@ -67,3 +67,15 @@ Feature: Openshift OpenJDK Runtime tests
     | JAVA_OPTIONS | --show-version |
     Then container log should not contain -XX:MaxRAMPercentage
     And  container log should contain --show-version
+
+  @ubi8
+  Scenario: Check default JAVA_APP_DIR (OPENJDK-2033)
+  When container is ready
+  Then available container log should contain INFO running in /deployments
+
+  @ubi8
+  Scenario: Check custom JAVA_APP_DIR (OPENJDK-2033)
+    Given container is started with env
+    | variable     | value       |
+    | JAVA_APP_DIR | /home/jboss |
+  Then available container log should contain INFO running in /home/jboss

--- a/tests/features/java/runtime.feature
+++ b/tests/features/java/runtime.feature
@@ -79,3 +79,17 @@ Feature: Openshift OpenJDK Runtime tests
     | variable     | value       |
     | JAVA_APP_DIR | /home/jboss |
   Then available container log should contain INFO running in /home/jboss
+
+  @ubi8
+  Scenario: Check relative path JAVA_APP_DIR (OPENJDK-2033)
+    Given container is started with env
+    | variable     | value  |
+    | JAVA_APP_DIR | .      |
+  Then available container log should contain INFO running in /home/jboss
+
+  @ubi8
+  Scenario: Check non-existent path JAVA_APP_DIR (OPENJDK-2033)
+    Given container is started with env
+    | variable     | value  |
+    | JAVA_APP_DIR | /nope  |
+  Then available container log should contain ERROR No directory /nope found for auto detection


### PR DESCRIPTION
[OPENJDK-2033](https://issues.redhat.com/browse/OPENJDK-2033)

without this `run-java.sh` always overwrites the user-provided `JAVA_APP_DIR` with the one from `run-env.sh`.

Thanks for submitting your Pull Request!

Please make sure your PR meets the following requirements:

- [x] A JIRA issue must exist in the OPENJDK project at issues.redhat.com
- [x] Pull Request title should be prefixed with the JIRA issue: `[OPENJDK-XYZ] Subject`
- [x] Pull Request contains hyperlink to the JIRA issue
- [x] Pull Request contains description of the issue
- [x] Pull Request does not include fixes for issues other than the main ticket
- [x] Attached commits represent units of work and are properly formatted
- [x] You have read and agreed to the Developer Certificate of Origin (DCO) (see `CONTRIBUTING.md`)
- [x] Every commit contains `Signed-off-by: Your Name <yourname@example.com>` - use `git commit -s`
