### PR TITLE
Ensure Quarkus CDS test is not tagged for JDK8

### DIFF
--- a/tests/features/java/openjdk_s2i.feature
+++ b/tests/features/java/openjdk_s2i.feature
@@ -2,6 +2,7 @@
 @ubi8/openjdk-11
 @ubi8/openjdk-17
 Feature: Openshift OpenJDK-only S2I tests
+
   @ubi8/openjdk-8
   Scenario: Check java perf dir owned by jboss (CLOUD-2070)
     Given s2i build https://github.com/jboss-openshift/openshift-quickstarts from undertow-servlet


### PR DESCRIPTION
Fixes #356.