### PR TITLE
[OPENJDK-2048] imagestream scripts and updated imagestreams

### DIFF
--- a/.github/workflows/verifyTemplates.yml
+++ b/.github/workflows/verifyTemplates.yml
@@ -1,0 +1,26 @@
+name: Validate ImageStream templates
+
+on:
+  push:
+    branches:
+      - release
+  pull_request:
+    branches:
+      - release
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        template: 
+          - community-image-streams.json
+          - image-streams.json
+          - image-streams-aarch64.json
+          - image-streams-ppc64le.json
+          - image-streams-s390x.json
+          - runtime-image-streams.json
+    steps:
+    - uses: actions/checkout@v2
+    - name: run jq
+      run: jq < templates/${{ matrix.template }}

--- a/templates/community-image-streams.json
+++ b/templates/community-image-streams.json
@@ -96,6 +96,82 @@
                             "kind": "DockerImage",
                             "name": "registry.access.redhat.com/ubi8/openjdk-8:1.12"
                         }
+                    },
+                    {
+                        "name": "1.13",
+                        "annotations": {
+                            "openshift.io/display-name": "Red Hat OpenJDK 8 (UBI8)",
+                            "description": "Build and run Java applications using Maven and OpenJDK 8 upon UBI8.",
+                            "iconClass": "icon-rh-openjdk",
+                            "tags": "builder,java,openjdk,ubi8",
+                            "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts",
+                            "sampleContextDir": "undertow-servlet",
+                            "version": "1.13"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
+                        },
+                        "from": {
+                            "kind": "DockerImage",
+                            "name": "registry.access.redhat.com/ubi8/openjdk-8:1.13"
+                        }
+                    },
+                    {
+                        "name": "1.14",
+                        "annotations": {
+                            "openshift.io/display-name": "Red Hat OpenJDK 8 (UBI8)",
+                            "description": "Build and run Java applications using Maven and OpenJDK 8 upon UBI8.",
+                            "iconClass": "icon-rh-openjdk",
+                            "tags": "builder,java,openjdk,ubi8",
+                            "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts",
+                            "sampleContextDir": "undertow-servlet",
+                            "version": "1.14"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
+                        },
+                        "from": {
+                            "kind": "DockerImage",
+                            "name": "registry.access.redhat.com/ubi8/openjdk-8:1.14"
+                        }
+                    },
+                    {
+                        "name": "1.15",
+                        "annotations": {
+                            "openshift.io/display-name": "Red Hat OpenJDK 8 (UBI8)",
+                            "description": "Build and run Java applications using Maven and OpenJDK 8 upon UBI8.",
+                            "iconClass": "icon-rh-openjdk",
+                            "tags": "builder,java,openjdk,ubi8",
+                            "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts",
+                            "sampleContextDir": "undertow-servlet",
+                            "version": "1.15"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
+                        },
+                        "from": {
+                            "kind": "DockerImage",
+                            "name": "registry.access.redhat.com/ubi8/openjdk-8:1.15"
+                        }
+                    },
+                    {
+                        "name": "1.16",
+                        "annotations": {
+                            "openshift.io/display-name": "Red Hat OpenJDK 8 (UBI8)",
+                            "description": "Build and run Java applications using Maven and OpenJDK 8 upon UBI8.",
+                            "iconClass": "icon-rh-openjdk",
+                            "tags": "builder,java,openjdk,ubi8",
+                            "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts",
+                            "sampleContextDir": "undertow-servlet",
+                            "version": "1.16"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
+                        },
+                        "from": {
+                            "kind": "DockerImage",
+                            "name": "registry.access.redhat.com/ubi8/openjdk-8:1.16"
+                        }
                     }
                 ]
             }
@@ -187,6 +263,82 @@
                             "kind": "DockerImage",
                             "name": "registry.access.redhat.com/ubi8/openjdk-11:1.12"
                         }
+                    },
+                    {
+                        "name": "1.13",
+                        "annotations": {
+                            "openshift.io/display-name": "Red Hat OpenJDK 11 (UBI8)",
+                            "description": "Build and run Java applications using Maven and OpenJDK 11 upon UBI8.",
+                            "iconClass": "icon-rh-openjdk",
+                            "tags": "builder,java,openjdk,ubi8",
+                            "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts",
+                            "sampleContextDir": "undertow-servlet",
+                            "version": "1.13"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
+                        },
+                        "from": {
+                            "kind": "DockerImage",
+                            "name": "registry.access.redhat.com/ubi8/openjdk-11:1.13"
+                        }
+                    },
+                    {
+                        "name": "1.14",
+                        "annotations": {
+                            "openshift.io/display-name": "Red Hat OpenJDK 11 (UBI8)",
+                            "description": "Build and run Java applications using Maven and OpenJDK 11 upon UBI8.",
+                            "iconClass": "icon-rh-openjdk",
+                            "tags": "builder,java,openjdk,ubi8",
+                            "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts",
+                            "sampleContextDir": "undertow-servlet",
+                            "version": "1.14"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
+                        },
+                        "from": {
+                            "kind": "DockerImage",
+                            "name": "registry.access.redhat.com/ubi8/openjdk-11:1.14"
+                        }
+                    },
+                    {
+                        "name": "1.15",
+                        "annotations": {
+                            "openshift.io/display-name": "Red Hat OpenJDK 11 (UBI8)",
+                            "description": "Build and run Java applications using Maven and OpenJDK 11 upon UBI8.",
+                            "iconClass": "icon-rh-openjdk",
+                            "tags": "builder,java,openjdk,ubi8",
+                            "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts",
+                            "sampleContextDir": "undertow-servlet",
+                            "version": "1.15"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
+                        },
+                        "from": {
+                            "kind": "DockerImage",
+                            "name": "registry.access.redhat.com/ubi8/openjdk-11:1.15"
+                        }
+                    },
+                    {
+                        "name": "1.16",
+                        "annotations": {
+                            "openshift.io/display-name": "Red Hat OpenJDK 11 (UBI8)",
+                            "description": "Build and run Java applications using Maven and OpenJDK 11 upon UBI8.",
+                            "iconClass": "icon-rh-openjdk",
+                            "tags": "builder,java,openjdk,ubi8",
+                            "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts",
+                            "sampleContextDir": "undertow-servlet",
+                            "version": "1.16"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
+                        },
+                        "from": {
+                            "kind": "DockerImage",
+                            "name": "registry.access.redhat.com/ubi8/openjdk-11:1.16"
+                        }
                     }
                 ]
             }
@@ -239,6 +391,82 @@
                         "from": {
                             "kind": "DockerImage",
                             "name": "registry.access.redhat.com/ubi8/openjdk-17:1.12"
+                        }
+                    },
+                    {
+                        "name": "1.13",
+                        "annotations": {
+                            "openshift.io/display-name": "Red Hat OpenJDK 17 (UBI8)",
+                            "description": "Build and run Java applications using Maven and OpenJDK 17 upon UBI8.",
+                            "iconClass": "icon-rh-openjdk",
+                            "tags": "builder,java,openjdk,ubi8",
+                            "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts",
+                            "sampleContextDir": "undertow-servlet",
+                            "version": "1.13"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
+                        },
+                        "from": {
+                            "kind": "DockerImage",
+                            "name": "registry.access.redhat.com/ubi8/openjdk-17:1.13"
+                        }
+                    },
+                    {
+                        "name": "1.14",
+                        "annotations": {
+                            "openshift.io/display-name": "Red Hat OpenJDK 17 (UBI8)",
+                            "description": "Build and run Java applications using Maven and OpenJDK 17 upon UBI8.",
+                            "iconClass": "icon-rh-openjdk",
+                            "tags": "builder,java,openjdk,ubi8",
+                            "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts",
+                            "sampleContextDir": "undertow-servlet",
+                            "version": "1.14"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
+                        },
+                        "from": {
+                            "kind": "DockerImage",
+                            "name": "registry.access.redhat.com/ubi8/openjdk-17:1.14"
+                        }
+                    },
+                    {
+                        "name": "1.15",
+                        "annotations": {
+                            "openshift.io/display-name": "Red Hat OpenJDK 17 (UBI8)",
+                            "description": "Build and run Java applications using Maven and OpenJDK 17 upon UBI8.",
+                            "iconClass": "icon-rh-openjdk",
+                            "tags": "builder,java,openjdk,ubi8",
+                            "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts",
+                            "sampleContextDir": "undertow-servlet",
+                            "version": "1.15"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
+                        },
+                        "from": {
+                            "kind": "DockerImage",
+                            "name": "registry.access.redhat.com/ubi8/openjdk-17:1.15"
+                        }
+                    },
+                    {
+                        "name": "1.16",
+                        "annotations": {
+                            "openshift.io/display-name": "Red Hat OpenJDK 17 (UBI8)",
+                            "description": "Build and run Java applications using Maven and OpenJDK 17 upon UBI8.",
+                            "iconClass": "icon-rh-openjdk",
+                            "tags": "builder,java,openjdk,ubi8",
+                            "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts",
+                            "sampleContextDir": "undertow-servlet",
+                            "version": "1.16"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
+                        },
+                        "from": {
+                            "kind": "DockerImage",
+                            "name": "registry.access.redhat.com/ubi8/openjdk-17:1.16"
                         }
                     }
                 ]

--- a/templates/community-image-streams.json
+++ b/templates/community-image-streams.json
@@ -15,17 +15,17 @@
             "metadata": {
                 "name": "ubi8-openjdk-8",
                 "annotations": {
-                    "openshift.io/display-name": "Red Hat OpenJDK 1.8 (UBI8)",
+                    "openshift.io/display-name": "Red Hat OpenJDK 8 (UBI8)",
                     "openshift.io/provider-display-name": "Red Hat, Inc."
                 }
             },
             "spec": {
                 "tags": [
-                    {
+                                        {
                         "name": "1.3",
                         "annotations": {
-                            "openshift.io/display-name": "Red Hat OpenJDK 1.8 (UBI8)",
-                            "description": "Build and run Java applications using Maven and OpenJDK 1.8 upon UBI8.",
+                            "openshift.io/display-name": "Red Hat OpenJDK 8 (UBI8)",
+                            "description": "Build and run Java applications using Maven and OpenJDK 8 upon UBI8.",
                             "iconClass": "icon-rh-openjdk",
                             "tags": "builder,java,openjdk,ubi8",
                             "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts",
@@ -43,8 +43,8 @@
                     {
                         "name": "1.10",
                         "annotations": {
-                            "openshift.io/display-name": "Red Hat OpenJDK 1.8 (UBI8)",
-                            "description": "Build and run Java applications using Maven and OpenJDK 1.8 upon UBI8.",
+                            "openshift.io/display-name": "Red Hat OpenJDK 8 (UBI8)",
+                            "description": "Build and run Java applications using Maven and OpenJDK 8 upon UBI8.",
                             "iconClass": "icon-rh-openjdk",
                             "tags": "builder,java,openjdk,ubi8",
                             "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts",
@@ -62,8 +62,8 @@
                     {
                         "name": "1.11",
                         "annotations": {
-                            "openshift.io/display-name": "Red Hat OpenJDK 1.8 (UBI8)",
-                            "description": "Build and run Java applications using Maven and OpenJDK 1.8 upon UBI8.",
+                            "openshift.io/display-name": "Red Hat OpenJDK 8 (UBI8)",
+                            "description": "Build and run Java applications using Maven and OpenJDK 8 upon UBI8.",
                             "iconClass": "icon-rh-openjdk",
                             "tags": "builder,java,openjdk,ubi8",
                             "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts",
@@ -81,8 +81,8 @@
                     {
                         "name": "1.12",
                         "annotations": {
-                            "openshift.io/display-name": "Red Hat OpenJDK 1.8 (UBI8)",
-                            "description": "Build and run Java applications using Maven and OpenJDK 1.8 upon UBI8.",
+                            "openshift.io/display-name": "Red Hat OpenJDK 8 (UBI8)",
+                            "description": "Build and run Java applications using Maven and OpenJDK 8 upon UBI8.",
                             "iconClass": "icon-rh-openjdk",
                             "tags": "builder,java,openjdk,ubi8",
                             "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts",
@@ -100,7 +100,7 @@
                 ]
             }
         },
-        {
+{
             "kind": "ImageStream",
             "apiVersion": "image.openshift.io/v1",
             "metadata": {
@@ -112,11 +112,11 @@
             },
             "spec": {
                 "tags": [
-                    {
+                                        {
                         "name": "1.3",
                         "annotations": {
                             "openshift.io/display-name": "Red Hat OpenJDK 11 (UBI8)",
-                            "description": "Build and run Java applications using Maven and OpenJDK 11 upon RHEL8.",
+                            "description": "Build and run Java applications using Maven and OpenJDK 11 upon UBI8.",
                             "iconClass": "icon-rh-openjdk",
                             "tags": "builder,java,openjdk,ubi8",
                             "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts",
@@ -135,7 +135,7 @@
                         "name": "1.10",
                         "annotations": {
                             "openshift.io/display-name": "Red Hat OpenJDK 11 (UBI8)",
-                            "description": "Build and run Java applications using Maven and OpenJDK 11 upon RHEL8.",
+                            "description": "Build and run Java applications using Maven and OpenJDK 11 upon UBI8.",
                             "iconClass": "icon-rh-openjdk",
                             "tags": "builder,java,openjdk,ubi8",
                             "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts",
@@ -154,7 +154,7 @@
                         "name": "1.11",
                         "annotations": {
                             "openshift.io/display-name": "Red Hat OpenJDK 11 (UBI8)",
-                            "description": "Build and run Java applications using Maven and OpenJDK 11 upon RHEL8.",
+                            "description": "Build and run Java applications using Maven and OpenJDK 11 upon UBI8.",
                             "iconClass": "icon-rh-openjdk",
                             "tags": "builder,java,openjdk,ubi8",
                             "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts",
@@ -173,7 +173,7 @@
                         "name": "1.12",
                         "annotations": {
                             "openshift.io/display-name": "Red Hat OpenJDK 11 (UBI8)",
-                            "description": "Build and run Java applications using Maven and OpenJDK 11 upon RHEL8.",
+                            "description": "Build and run Java applications using Maven and OpenJDK 11 upon UBI8.",
                             "iconClass": "icon-rh-openjdk",
                             "tags": "builder,java,openjdk,ubi8",
                             "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts",
@@ -191,7 +191,7 @@
                 ]
             }
         },
-        {
+{
             "kind": "ImageStream",
             "apiVersion": "image.openshift.io/v1",
             "metadata": {
@@ -203,11 +203,11 @@
             },
             "spec": {
                 "tags": [
-                    {
+                                        {
                         "name": "1.11",
                         "annotations": {
                             "openshift.io/display-name": "Red Hat OpenJDK 17 (UBI8)",
-                            "description": "Build and run Java applications using Maven and OpenJDK 17 upon RHEL8.",
+                            "description": "Build and run Java applications using Maven and OpenJDK 17 upon UBI8.",
                             "iconClass": "icon-rh-openjdk",
                             "tags": "builder,java,openjdk,ubi8",
                             "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts",
@@ -226,7 +226,7 @@
                         "name": "1.12",
                         "annotations": {
                             "openshift.io/display-name": "Red Hat OpenJDK 17 (UBI8)",
-                            "description": "Build and run Java applications using Maven and OpenJDK 17 upon RHEL8.",
+                            "description": "Build and run Java applications using Maven and OpenJDK 17 upon UBI8.",
                             "iconClass": "icon-rh-openjdk",
                             "tags": "builder,java,openjdk,ubi8",
                             "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts",
@@ -243,8 +243,7 @@
                     }
                 ]
             }
-        },
-        {
+        },        {
             "kind": "ImageStream",
             "apiVersion": "image.openshift.io/v1",
             "metadata": {

--- a/templates/data.yaml
+++ b/templates/data.yaml
@@ -1,0 +1,54 @@
+# ImageStream template generator parameters
+# this data describes the version ranges for each container image and the various
+# exceptional circumstances, i.e., when a particular image version didn't ship, or
+# an image's name doesn't follow the naming convention, or an architecture
+# started shipping from a later version, etc.
+
+rhel7:
+  # for the rhel7 images, the default range of versions is 1.0-1.12
+  # (these keys are numeric as the script uses them as inputs for range())
+  from: 0
+  to: 12
+  builder:
+    8:
+      name: "redhat-openjdk-18/openjdk18-openshift"
+      from: 3 # we stopped including the metadata for 1.0-1.2
+      not: [ 9, 13 ] # and never shipped 1.9 or 1.13
+      # architecture special-cases
+      ppc64le:
+        from: 5
+      s390x:
+        from: 5
+    11:
+      name: "openjdk/openjdk-11-rhel7"
+      not: [ 2, 3, 4, 5, 6, 7, 8, 9, 13 ]
+ubi8:
+  from: 3
+  to: 12
+  not: [ 4, 5, 6, 7, 8, 9 ]
+  builder: # "ubi8/openjdk-X"
+    8:  {}
+    11: {}
+    17:
+      from: 11 # 1.11
+  runtime: # "ubi8/openjdk-X-runtime"
+    from: 9
+    to: 12
+    not: []
+    8:
+      name: "ubi8/openjdk-8-runtime"
+    11:
+      name: "ubi8/openjdk-11-runtime"
+    17:
+      name: "ubi8/openjdk-17-runtime"
+      from: 11
+ubi9:
+  from: 13
+  builder:
+    11: {}
+    17: {}
+  runtime:
+    11:
+      name: "ubi9/openjdk-11-runtime"
+    17:
+      name: "ubi9/openjdk-17-runtime"

--- a/templates/data.yaml
+++ b/templates/data.yaml
@@ -8,7 +8,7 @@ rhel7:
   # for the rhel7 images, the default range of versions is 1.0-1.12
   # (these keys are numeric as the script uses them as inputs for range())
   from: 0
-  to: 12
+  to: 15
   builder:
     8:
       name: "redhat-openjdk-18/openjdk18-openshift"
@@ -24,16 +24,15 @@ rhel7:
       not: [ 2, 3, 4, 5, 6, 7, 8, 9, 13 ]
 ubi8:
   from: 3
-  to: 12
+  to: 16
   not: [ 4, 5, 6, 7, 8, 9 ]
   builder: # "ubi8/openjdk-X"
     8:  {}
     11: {}
     17:
-      from: 11 # 1.11
-  runtime: # "ubi8/openjdk-X-runtime"
+      from: 11
+  runtime:
     from: 9
-    to: 12
     not: []
     8:
       name: "ubi8/openjdk-8-runtime"

--- a/templates/generateImageStreamTemplates.py
+++ b/templates/generateImageStreamTemplates.py
@@ -1,0 +1,219 @@
+#!/usr/bin/python3
+
+# generate ImageStream metadata
+
+# inputs:
+#   data.yaml: data on versions and exceptions
+#   templates/*: Jinja-format template snippets
+
+from jinja2 import Environment, FileSystemLoader, select_autoescape
+import yaml
+
+# fetch a key from a nested dict
+def fetch(obj, path, k):
+    # traverse the dicts to find the one nested at path
+    o = obj
+    for i in range(0, len(path)):
+        o = o[path[i]]
+
+    # if they key isn't present at this level, try the parent
+    if not k in o.keys() and path:
+        return fetch(obj, path[:-1], k)
+    return o.get(k)
+
+def renderTags(os,
+               jdkVersion,
+               data,
+               variant='builder', # or runtime
+               imageTags=False,
+               supports=False,
+               arch=False,
+               sampleRepo=True,
+               description=False,
+               displayName=False,
+              ):
+
+    path = [os, variant, jdkVersion]
+    if fetch(data, path, arch):
+        path.append(arch)
+
+    name = fetch(data, path, 'name') or "{}/openjdk-{}".format(os, jdkVersion)
+    from_= fetch(data, path, 'from')
+    to_  = fetch(data, path, 'to')
+    not_ = fetch(data, path, 'not') or []
+
+    return ",\n".join([ tag.render(
+        version="1.{}".format(v),
+        tag="1.{}".format(v),
+        rhel=os,
+        openjdk=jdkVersion,
+        containerName=name,
+        tags=imageTags,
+        supports=supports,
+        sampleRepo=sampleRepo,
+        description=description,
+        displayName=displayName,
+        )
+        for v in range(from_, to_+1)
+        if v not in not_
+    ])
+
+def renderImageStream(os,
+                      nameFn=lambda os,v: "{}-openjdk-{}".format(os,v),
+                      variant='builder',
+                      displayNameFn=lambda v: False,
+
+                      # the following flags are passed through to renderTags
+                      imageTags=False,
+                      sampleRepo=True,
+                      descriptionFn=lambda v: False,
+                     ):
+    return ",\n".join([ imagestream.render(
+        rhel=os,
+        name=nameFn(os,v),
+        openjdk=v,
+        displayName=displayNameFn(v),
+        tags=renderTags(
+             os,
+             v,
+             data,
+             variant=variant,
+             imageTags=imageTags,
+             sampleRepo=sampleRepo,
+             displayName=displayNameFn(v),
+             description=descriptionFn(v),
+        ))
+        for v in [8,11,17]
+   ])
+
+##############################################################################
+
+env = Environment(
+    loader = FileSystemLoader("templates"),
+    autoescape=select_autoescape()
+)
+
+template    = env.get_template("template.jinja")
+imagestream = env.get_template("imagestream.jinja")
+tag         = env.get_template("tag.jinja")
+
+data  = yaml.safe_load(open("data.yaml"))
+ubi8  = data['ubi8']
+rhel7 = data['rhel7']
+
+with open("community-image-streams.json","w") as fh:
+    fh.write(template.render(
+        rhel="ubi8",
+        items=renderImageStream("ubi8")+","+
+            env.get_template("community-javaImageStream.jinja").render()
+    ))
+
+with open("image-streams.json","w") as fh:
+    fh.write(template.render(
+        rhel="",
+        description="ImageStream definition for Red Hat OpenJDK.",
+        name="openjdk18-image-stream",
+        items=",".join([
+            imagestream.render(
+                rhel="rhel7",
+                name="redhat-openjdk18-openshift",
+                openjdk="8",
+                tags=renderTags("rhel7", 8, data,
+                imageTags="builder,java,openjdk,hidden",
+                supports="java:8",),
+            ),
+            imagestream.render(
+                rhel="rhel7",
+                name="openjdk-11-rhel7",
+                openjdk="11",
+                tags=renderTags("rhel7", 11, data,
+                    imageTags="builder,java,openjdk,hidden",
+                    supports="java:11",),
+            ),
+            renderImageStream("ubi8", imageTags="builder,java,openjdk,ubi8,hidden"),
+            env.get_template("javaImageStream.jinja").render()
+        ])
+    ))
+
+with open("image-streams-aarch64.json", "w") as fh:
+    fh.write(template.render(
+        rhel="ubi8",
+        name="openjdk18-image-stream",
+        items=",".join([
+            renderImageStream("ubi8", imageTags="builder,java,openjdk,ubi8,hidden"),
+            env.get_template("community-javaImageStream.jinja").render()
+        ])
+    ))
+
+with open("image-streams-ppc64le.json", "w") as fh:
+    fh.write(template.render(
+        rhel="",
+        description="ImageStream definition for Red Hat OpenJDK.",
+        name="openjdk18-image-stream",
+        items=",".join([
+            imagestream.render(
+                rhel="rhel7",
+                name="redhat-openjdk18-openshift",
+                openjdk="8",
+                tags=renderTags("rhel7", 8, data,
+                imageTags="builder,java,openjdk,hidden",
+                supports="java:8", arch="ppc64le"),
+            ),
+            imagestream.render(
+                rhel="rhel7",
+                name="openjdk-11-rhel7",
+                openjdk="11",
+                tags=renderTags("rhel7", 11, data,
+                    imageTags="builder,java,openjdk,hidden",
+                    supports="java:11",),
+            ),
+            renderImageStream("ubi8", imageTags="builder,java,openjdk,ubi8,hidden"),
+            env.get_template("javaImageStream.jinja").render()
+        ])
+    ))
+
+with open("image-streams-s390x.json", "w") as fh:
+    fh.write(template.render(
+        rhel="",
+        description="ImageStream definition for Red Hat OpenJDK.",
+        name="openjdk18-image-stream",
+        items=",".join([
+            imagestream.render(
+                rhel="rhel7",
+                name="redhat-openjdk18-openshift",
+                openjdk="8",
+                tags=renderTags("rhel7", 8, data,
+                imageTags="builder,java,openjdk,hidden",
+                supports="java:8", arch="s390x"),
+            ),
+            imagestream.render(
+                rhel="rhel7",
+                name="openjdk-11-rhel7",
+                openjdk="11",
+                tags=renderTags("rhel7", 11, data,
+                    imageTags="builder,java,openjdk,hidden",
+                    supports="java:11",),
+            ),
+            renderImageStream("ubi8", imageTags="builder,java,openjdk,ubi8,hidden"),
+            env.get_template("javaImageStream.jinja").render()
+        ])
+    ))
+
+with open("runtime-image-streams.json", "w") as fh:
+    fh.write(template.render(
+        rhel="ubi8",
+        name="ubi8-openjdk-runtime-image-stream",
+        description="ImageStream definition for Red Hat UBI8 OpenJDK Runtimes.",
+        items=",".join([
+            renderImageStream(
+                "ubi8",
+                variant="runtime",
+                nameFn=lambda o,v: "{}-openjdk-{}-runtime".format(o,v),
+                displayNameFn=lambda v: "Red Hat OpenJDK {} Runtime (UBI8)".format(v),
+                imageTags="java,openjdk,ubi8",
+                sampleRepo=False,
+                descriptionFn=lambda v: "Run Java applications using OpenJDK {} upon UBI8.".format(v),
+            ),
+            env.get_template("java-runtimeImageStream.jinja").render()
+        ])
+    ))

--- a/templates/image-streams-aarch64.json
+++ b/templates/image-streams-aarch64.json
@@ -4,7 +4,7 @@
     "metadata": {
         "name": "openjdk18-image-stream",
         "annotations": {
-            "description": "ImageStream definition for Red Hat OpenJDK.",
+            "description": "ImageStream definition for Red Hat UBI8 OpenJDK.",
             "openshift.io/provider-display-name": "Red Hat, Inc."
         }
     },
@@ -15,21 +15,17 @@
             "metadata": {
                 "name": "ubi8-openjdk-8",
                 "annotations": {
-                    "openshift.io/display-name": "Red Hat OpenJDK 1.8 (UBI8)",
-                    "openshift.io/provider-display-name": "Red Hat, Inc.",
-                    "version": "1.4.17"
-                },
-                "labels": {
-                    "xpaas": "1.4.17"
+                    "openshift.io/display-name": "Red Hat OpenJDK 8 (UBI8)",
+                    "openshift.io/provider-display-name": "Red Hat, Inc."
                 }
             },
             "spec": {
                 "tags": [
-                    {
+                                        {
                         "name": "1.3",
                         "annotations": {
-                            "openshift.io/display-name": "Red Hat OpenJDK 1.8 (UBI8)",
-                            "description": "Build and run Java applications using Maven and OpenJDK 1.8 upon UBI8.",
+                            "openshift.io/display-name": "Red Hat OpenJDK 8 (UBI8)",
+                            "description": "Build and run Java applications using Maven and OpenJDK 8 upon UBI8.",
                             "iconClass": "icon-rh-openjdk",
                             "tags": "builder,java,openjdk,ubi8,hidden",
                             "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts",
@@ -47,8 +43,8 @@
                     {
                         "name": "1.10",
                         "annotations": {
-                            "openshift.io/display-name": "Red Hat OpenJDK 1.8 (UBI8)",
-                            "description": "Build and run Java applications using Maven and OpenJDK 1.8 upon UBI8.",
+                            "openshift.io/display-name": "Red Hat OpenJDK 8 (UBI8)",
+                            "description": "Build and run Java applications using Maven and OpenJDK 8 upon UBI8.",
                             "iconClass": "icon-rh-openjdk",
                             "tags": "builder,java,openjdk,ubi8,hidden",
                             "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts",
@@ -66,8 +62,8 @@
                     {
                         "name": "1.11",
                         "annotations": {
-                            "openshift.io/display-name": "Red Hat OpenJDK 1.8 (UBI8)",
-                            "description": "Build and run Java applications using Maven and OpenJDK 1.8 upon UBI8.",
+                            "openshift.io/display-name": "Red Hat OpenJDK 8 (UBI8)",
+                            "description": "Build and run Java applications using Maven and OpenJDK 8 upon UBI8.",
                             "iconClass": "icon-rh-openjdk",
                             "tags": "builder,java,openjdk,ubi8,hidden",
                             "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts",
@@ -85,8 +81,8 @@
                     {
                         "name": "1.12",
                         "annotations": {
-                            "openshift.io/display-name": "Red Hat OpenJDK 1.8 (UBI8)",
-                            "description": "Build and run Java applications using Maven and OpenJDK 1.8 upon UBI8.",
+                            "openshift.io/display-name": "Red Hat OpenJDK 8 (UBI8)",
+                            "description": "Build and run Java applications using Maven and OpenJDK 8 upon UBI8.",
                             "iconClass": "icon-rh-openjdk",
                             "tags": "builder,java,openjdk,ubi8,hidden",
                             "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts",
@@ -104,23 +100,19 @@
                 ]
             }
         },
-        {
+{
             "kind": "ImageStream",
             "apiVersion": "image.openshift.io/v1",
             "metadata": {
                 "name": "ubi8-openjdk-11",
                 "annotations": {
                     "openshift.io/display-name": "Red Hat OpenJDK 11 (UBI8)",
-                    "openshift.io/provider-display-name": "Red Hat, Inc.",
-                    "version": "1.4.17"
-                },
-                "labels": {
-                    "xpaas": "1.4.17"
+                    "openshift.io/provider-display-name": "Red Hat, Inc."
                 }
             },
             "spec": {
                 "tags": [
-                    {
+                                        {
                         "name": "1.3",
                         "annotations": {
                             "openshift.io/display-name": "Red Hat OpenJDK 11 (UBI8)",
@@ -199,23 +191,19 @@
                 ]
             }
         },
-        {
+{
             "kind": "ImageStream",
             "apiVersion": "image.openshift.io/v1",
             "metadata": {
                 "name": "ubi8-openjdk-17",
                 "annotations": {
                     "openshift.io/display-name": "Red Hat OpenJDK 17 (UBI8)",
-                    "openshift.io/provider-display-name": "Red Hat, Inc.",
-                    "version": "1.4.17"
-                },
-                "labels": {
-                    "xpaas": "1.4.17"
+                    "openshift.io/provider-display-name": "Red Hat, Inc."
                 }
             },
             "spec": {
                 "tags": [
-                    {
+                                        {
                         "name": "1.11",
                         "annotations": {
                             "openshift.io/display-name": "Red Hat OpenJDK 17 (UBI8)",
@@ -255,19 +243,14 @@
                     }
                 ]
             }
-        },
-        {
+        },        {
             "kind": "ImageStream",
             "apiVersion": "image.openshift.io/v1",
             "metadata": {
                 "name": "java",
                 "annotations": {
                     "openshift.io/display-name": "Red Hat OpenJDK",
-                    "openshift.io/provider-display-name": "Red Hat, Inc.",
-                    "version": "1.4.17"
-                },
-                "labels": {
-                    "xpaas": "1.4.17"
+                    "openshift.io/provider-display-name": "Red Hat, Inc."
                 }
             },
             "spec": {
@@ -276,7 +259,7 @@
                         "name": "openjdk-8-ubi8",
                         "annotations": {
                             "openshift.io/display-name": "Red Hat OpenJDK 8 (UBI 8)",
-                            "description": "Build and run Java applications using Maven and OpenJDK 8.",
+                            "description": "Build and run Java applications using Maven and OpenJDK 1.8 upon UBI8.",
                             "iconClass": "icon-rh-openjdk",
                             "tags": "builder,java,openjdk",
                             "supports": "java:8,java",
@@ -289,14 +272,34 @@
                         },
                         "from": {
                             "kind": "DockerImage",
-                            "name": "registry.redhat.io/ubi8/openjdk-8:latest"
+                            "name": "registry.access.redhat.com/ubi8/openjdk-8:latest"
+                        }
+                    },
+                    {
+                        "name": "8",
+                        "annotations": {
+                            "openshift.io/display-name": "Red Hat OpenJDK 8",
+                            "description": "Build and run Java applications using Maven and OpenJDK 1.8 upon UBI8.",
+                            "iconClass": "icon-rh-openjdk",
+                            "tags": "builder,java,openjdk,hidden",
+                            "supports": "java:8,java",
+                            "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts",
+                            "sampleContextDir": "undertow-servlet",
+                            "version": "8"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
+                        },
+                        "from": {
+                            "kind": "DockerImage",
+                            "name": "registry.access.redhat.com/ubi8/openjdk-8:latest"
                         }
                     },
                     {
                         "name": "openjdk-11-ubi8",
                         "annotations": {
                             "openshift.io/display-name": "Red Hat OpenJDK 11 (UBI 8)",
-                            "description": "Build and run Java applications using Maven and OpenJDK 11.",
+                            "description": "Build and run Java applications using Maven and OpenJDK 11 upon UBI8.",
                             "iconClass": "icon-rh-openjdk",
                             "tags": "builder,java,openjdk",
                             "supports": "java:11,java",
@@ -309,14 +312,34 @@
                         },
                         "from": {
                             "kind": "DockerImage",
-                            "name": "registry.redhat.io/ubi8/openjdk-11:latest"
+                            "name": "registry.access.redhat.com/ubi8/openjdk-11:latest"
+                        }
+                    },
+                    {
+                        "name": "11",
+                        "annotations": {
+                            "openshift.io/display-name": "Red Hat OpenJDK 11",
+                            "description": "Build and run Java applications using Maven and OpenJDK 11 upon UBI8.",
+                            "iconClass": "icon-rh-openjdk",
+                            "tags": "builder,java,openjdk,hidden",
+                            "supports": "java:11,java",
+                            "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts",
+                            "sampleContextDir": "undertow-servlet",
+                            "version": "11"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
+                        },
+                        "from": {
+                            "kind": "DockerImage",
+                            "name": "registry.access.redhat.com/ubi8/openjdk-11:latest"
                         }
                     },
                     {
                         "name": "openjdk-17-ubi8",
                         "annotations": {
                             "openshift.io/display-name": "Red Hat OpenJDK 17 (UBI 8)",
-                            "description": "Build and run Java applications using Maven and OpenJDK 17.",
+                            "description": "Build and run Java applications using Maven and OpenJDK 17 upon UBI8.",
                             "iconClass": "icon-rh-openjdk",
                             "tags": "builder,java,openjdk",
                             "supports": "java:17,java",
@@ -329,7 +352,7 @@
                         },
                         "from": {
                             "kind": "DockerImage",
-                            "name": "registry.redhat.io/ubi8/openjdk-17:latest"
+                            "name": "registry.access.redhat.com/ubi8/openjdk-17:latest"
                         }
                     },
                     {

--- a/templates/image-streams-aarch64.json
+++ b/templates/image-streams-aarch64.json
@@ -96,6 +96,82 @@
                             "kind": "DockerImage",
                             "name": "registry.access.redhat.com/ubi8/openjdk-8:1.12"
                         }
+                    },
+                    {
+                        "name": "1.13",
+                        "annotations": {
+                            "openshift.io/display-name": "Red Hat OpenJDK 8 (UBI8)",
+                            "description": "Build and run Java applications using Maven and OpenJDK 8 upon UBI8.",
+                            "iconClass": "icon-rh-openjdk",
+                            "tags": "builder,java,openjdk,ubi8,hidden",
+                            "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts",
+                            "sampleContextDir": "undertow-servlet",
+                            "version": "1.13"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
+                        },
+                        "from": {
+                            "kind": "DockerImage",
+                            "name": "registry.access.redhat.com/ubi8/openjdk-8:1.13"
+                        }
+                    },
+                    {
+                        "name": "1.14",
+                        "annotations": {
+                            "openshift.io/display-name": "Red Hat OpenJDK 8 (UBI8)",
+                            "description": "Build and run Java applications using Maven and OpenJDK 8 upon UBI8.",
+                            "iconClass": "icon-rh-openjdk",
+                            "tags": "builder,java,openjdk,ubi8,hidden",
+                            "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts",
+                            "sampleContextDir": "undertow-servlet",
+                            "version": "1.14"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
+                        },
+                        "from": {
+                            "kind": "DockerImage",
+                            "name": "registry.access.redhat.com/ubi8/openjdk-8:1.14"
+                        }
+                    },
+                    {
+                        "name": "1.15",
+                        "annotations": {
+                            "openshift.io/display-name": "Red Hat OpenJDK 8 (UBI8)",
+                            "description": "Build and run Java applications using Maven and OpenJDK 8 upon UBI8.",
+                            "iconClass": "icon-rh-openjdk",
+                            "tags": "builder,java,openjdk,ubi8,hidden",
+                            "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts",
+                            "sampleContextDir": "undertow-servlet",
+                            "version": "1.15"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
+                        },
+                        "from": {
+                            "kind": "DockerImage",
+                            "name": "registry.access.redhat.com/ubi8/openjdk-8:1.15"
+                        }
+                    },
+                    {
+                        "name": "1.16",
+                        "annotations": {
+                            "openshift.io/display-name": "Red Hat OpenJDK 8 (UBI8)",
+                            "description": "Build and run Java applications using Maven and OpenJDK 8 upon UBI8.",
+                            "iconClass": "icon-rh-openjdk",
+                            "tags": "builder,java,openjdk,ubi8,hidden",
+                            "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts",
+                            "sampleContextDir": "undertow-servlet",
+                            "version": "1.16"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
+                        },
+                        "from": {
+                            "kind": "DockerImage",
+                            "name": "registry.access.redhat.com/ubi8/openjdk-8:1.16"
+                        }
                     }
                 ]
             }
@@ -187,6 +263,82 @@
                             "kind": "DockerImage",
                             "name": "registry.access.redhat.com/ubi8/openjdk-11:1.12"
                         }
+                    },
+                    {
+                        "name": "1.13",
+                        "annotations": {
+                            "openshift.io/display-name": "Red Hat OpenJDK 11 (UBI8)",
+                            "description": "Build and run Java applications using Maven and OpenJDK 11 upon UBI8.",
+                            "iconClass": "icon-rh-openjdk",
+                            "tags": "builder,java,openjdk,ubi8,hidden",
+                            "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts",
+                            "sampleContextDir": "undertow-servlet",
+                            "version": "1.13"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
+                        },
+                        "from": {
+                            "kind": "DockerImage",
+                            "name": "registry.access.redhat.com/ubi8/openjdk-11:1.13"
+                        }
+                    },
+                    {
+                        "name": "1.14",
+                        "annotations": {
+                            "openshift.io/display-name": "Red Hat OpenJDK 11 (UBI8)",
+                            "description": "Build and run Java applications using Maven and OpenJDK 11 upon UBI8.",
+                            "iconClass": "icon-rh-openjdk",
+                            "tags": "builder,java,openjdk,ubi8,hidden",
+                            "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts",
+                            "sampleContextDir": "undertow-servlet",
+                            "version": "1.14"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
+                        },
+                        "from": {
+                            "kind": "DockerImage",
+                            "name": "registry.access.redhat.com/ubi8/openjdk-11:1.14"
+                        }
+                    },
+                    {
+                        "name": "1.15",
+                        "annotations": {
+                            "openshift.io/display-name": "Red Hat OpenJDK 11 (UBI8)",
+                            "description": "Build and run Java applications using Maven and OpenJDK 11 upon UBI8.",
+                            "iconClass": "icon-rh-openjdk",
+                            "tags": "builder,java,openjdk,ubi8,hidden",
+                            "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts",
+                            "sampleContextDir": "undertow-servlet",
+                            "version": "1.15"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
+                        },
+                        "from": {
+                            "kind": "DockerImage",
+                            "name": "registry.access.redhat.com/ubi8/openjdk-11:1.15"
+                        }
+                    },
+                    {
+                        "name": "1.16",
+                        "annotations": {
+                            "openshift.io/display-name": "Red Hat OpenJDK 11 (UBI8)",
+                            "description": "Build and run Java applications using Maven and OpenJDK 11 upon UBI8.",
+                            "iconClass": "icon-rh-openjdk",
+                            "tags": "builder,java,openjdk,ubi8,hidden",
+                            "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts",
+                            "sampleContextDir": "undertow-servlet",
+                            "version": "1.16"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
+                        },
+                        "from": {
+                            "kind": "DockerImage",
+                            "name": "registry.access.redhat.com/ubi8/openjdk-11:1.16"
+                        }
                     }
                 ]
             }
@@ -239,6 +391,82 @@
                         "from": {
                             "kind": "DockerImage",
                             "name": "registry.access.redhat.com/ubi8/openjdk-17:1.12"
+                        }
+                    },
+                    {
+                        "name": "1.13",
+                        "annotations": {
+                            "openshift.io/display-name": "Red Hat OpenJDK 17 (UBI8)",
+                            "description": "Build and run Java applications using Maven and OpenJDK 17 upon UBI8.",
+                            "iconClass": "icon-rh-openjdk",
+                            "tags": "builder,java,openjdk,ubi8,hidden",
+                            "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts",
+                            "sampleContextDir": "undertow-servlet",
+                            "version": "1.13"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
+                        },
+                        "from": {
+                            "kind": "DockerImage",
+                            "name": "registry.access.redhat.com/ubi8/openjdk-17:1.13"
+                        }
+                    },
+                    {
+                        "name": "1.14",
+                        "annotations": {
+                            "openshift.io/display-name": "Red Hat OpenJDK 17 (UBI8)",
+                            "description": "Build and run Java applications using Maven and OpenJDK 17 upon UBI8.",
+                            "iconClass": "icon-rh-openjdk",
+                            "tags": "builder,java,openjdk,ubi8,hidden",
+                            "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts",
+                            "sampleContextDir": "undertow-servlet",
+                            "version": "1.14"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
+                        },
+                        "from": {
+                            "kind": "DockerImage",
+                            "name": "registry.access.redhat.com/ubi8/openjdk-17:1.14"
+                        }
+                    },
+                    {
+                        "name": "1.15",
+                        "annotations": {
+                            "openshift.io/display-name": "Red Hat OpenJDK 17 (UBI8)",
+                            "description": "Build and run Java applications using Maven and OpenJDK 17 upon UBI8.",
+                            "iconClass": "icon-rh-openjdk",
+                            "tags": "builder,java,openjdk,ubi8,hidden",
+                            "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts",
+                            "sampleContextDir": "undertow-servlet",
+                            "version": "1.15"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
+                        },
+                        "from": {
+                            "kind": "DockerImage",
+                            "name": "registry.access.redhat.com/ubi8/openjdk-17:1.15"
+                        }
+                    },
+                    {
+                        "name": "1.16",
+                        "annotations": {
+                            "openshift.io/display-name": "Red Hat OpenJDK 17 (UBI8)",
+                            "description": "Build and run Java applications using Maven and OpenJDK 17 upon UBI8.",
+                            "iconClass": "icon-rh-openjdk",
+                            "tags": "builder,java,openjdk,ubi8,hidden",
+                            "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts",
+                            "sampleContextDir": "undertow-servlet",
+                            "version": "1.16"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
+                        },
+                        "from": {
+                            "kind": "DockerImage",
+                            "name": "registry.access.redhat.com/ubi8/openjdk-17:1.16"
                         }
                     }
                 ]

--- a/templates/image-streams-ppc64le.json
+++ b/templates/image-streams-ppc64le.json
@@ -15,21 +15,17 @@
             "metadata": {
                 "name": "redhat-openjdk18-openshift",
                 "annotations": {
-                    "openshift.io/display-name": "Red Hat OpenJDK 8",
-                    "openshift.io/provider-display-name": "Red Hat, Inc.",
-                    "version": "1.4.17"
-                },
-                "labels": {
-                    "xpaas": "1.4.17"
+                    "openshift.io/display-name": "Red Hat OpenJDK 8 (RHEL7)",
+                    "openshift.io/provider-display-name": "Red Hat, Inc."
                 }
             },
             "spec": {
                 "tags": [
-                    {
+                                        {
                         "name": "1.5",
                         "annotations": {
-                            "openshift.io/display-name": "Red Hat OpenJDK 8",
-                            "description": "Build and run Java applications using Maven and OpenJDK 8.",
+                            "openshift.io/display-name": "Red Hat OpenJDK 8 (RHEL7)",
+                            "description": "Build and run Java applications using Maven and OpenJDK 8 upon RHEL7.",
                             "iconClass": "icon-rh-openjdk",
                             "tags": "builder,java,openjdk,hidden",
                             "supports": "java:8",
@@ -42,14 +38,14 @@
                         },
                         "from": {
                             "kind": "DockerImage",
-                            "name": "registry.redhat.io/redhat-openjdk-18/openjdk18-openshift:1.5"
+                            "name": "registry.access.redhat.com/redhat-openjdk-18/openjdk18-openshift:1.5"
                         }
                     },
                     {
                         "name": "1.6",
                         "annotations": {
-                            "openshift.io/display-name": "Red Hat OpenJDK 8",
-                            "description": "Build and run Java applications using Maven and OpenJDK 8.",
+                            "openshift.io/display-name": "Red Hat OpenJDK 8 (RHEL7)",
+                            "description": "Build and run Java applications using Maven and OpenJDK 8 upon RHEL7.",
                             "iconClass": "icon-rh-openjdk",
                             "tags": "builder,java,openjdk,hidden",
                             "supports": "java:8",
@@ -62,14 +58,14 @@
                         },
                         "from": {
                             "kind": "DockerImage",
-                            "name": "registry.redhat.io/redhat-openjdk-18/openjdk18-openshift:1.6"
+                            "name": "registry.access.redhat.com/redhat-openjdk-18/openjdk18-openshift:1.6"
                         }
                     },
                     {
                         "name": "1.7",
                         "annotations": {
-                            "openshift.io/display-name": "Red Hat OpenJDK 8",
-                            "description": "Build and run Java applications using Maven and OpenJDK 8.",
+                            "openshift.io/display-name": "Red Hat OpenJDK 8 (RHEL7)",
+                            "description": "Build and run Java applications using Maven and OpenJDK 8 upon RHEL7.",
                             "iconClass": "icon-rh-openjdk",
                             "tags": "builder,java,openjdk,hidden",
                             "supports": "java:8",
@@ -82,14 +78,14 @@
                         },
                         "from": {
                             "kind": "DockerImage",
-                            "name": "registry.redhat.io/redhat-openjdk-18/openjdk18-openshift:1.7"
+                            "name": "registry.access.redhat.com/redhat-openjdk-18/openjdk18-openshift:1.7"
                         }
                     },
                     {
                         "name": "1.8",
                         "annotations": {
-                            "openshift.io/display-name": "Red Hat OpenJDK 8",
-                            "description": "Build and run Java applications using Maven and OpenJDK 8.",
+                            "openshift.io/display-name": "Red Hat OpenJDK 8 (RHEL7)",
+                            "description": "Build and run Java applications using Maven and OpenJDK 8 upon RHEL7.",
                             "iconClass": "icon-rh-openjdk",
                             "tags": "builder,java,openjdk,hidden",
                             "supports": "java:8",
@@ -102,14 +98,14 @@
                         },
                         "from": {
                             "kind": "DockerImage",
-                            "name": "registry.redhat.io/redhat-openjdk-18/openjdk18-openshift:1.8"
+                            "name": "registry.access.redhat.com/redhat-openjdk-18/openjdk18-openshift:1.8"
                         }
                     },
                     {
                         "name": "1.10",
                         "annotations": {
-                            "openshift.io/display-name": "Red Hat OpenJDK 8",
-                            "description": "Build and run Java applications using Maven and OpenJDK 8.",
+                            "openshift.io/display-name": "Red Hat OpenJDK 8 (RHEL7)",
+                            "description": "Build and run Java applications using Maven and OpenJDK 8 upon RHEL7.",
                             "iconClass": "icon-rh-openjdk",
                             "tags": "builder,java,openjdk,hidden",
                             "supports": "java:8",
@@ -122,14 +118,14 @@
                         },
                         "from": {
                             "kind": "DockerImage",
-                            "name": "registry.redhat.io/redhat-openjdk-18/openjdk18-openshift:1.10"
+                            "name": "registry.access.redhat.com/redhat-openjdk-18/openjdk18-openshift:1.10"
                         }
                     },
                     {
                         "name": "1.11",
                         "annotations": {
-                            "openshift.io/display-name": "Red Hat OpenJDK 8",
-                            "description": "Build and run Java applications using Maven and OpenJDK 8.",
+                            "openshift.io/display-name": "Red Hat OpenJDK 8 (RHEL7)",
+                            "description": "Build and run Java applications using Maven and OpenJDK 8 upon RHEL7.",
                             "iconClass": "icon-rh-openjdk",
                             "tags": "builder,java,openjdk,hidden",
                             "supports": "java:8",
@@ -142,14 +138,14 @@
                         },
                         "from": {
                             "kind": "DockerImage",
-                            "name": "registry.redhat.io/redhat-openjdk-18/openjdk18-openshift:1.11"
+                            "name": "registry.access.redhat.com/redhat-openjdk-18/openjdk18-openshift:1.11"
                         }
                     },
                     {
                         "name": "1.12",
                         "annotations": {
-                            "openshift.io/display-name": "Red Hat OpenJDK 8",
-                            "description": "Build and run Java applications using Maven and OpenJDK 8.",
+                            "openshift.io/display-name": "Red Hat OpenJDK 8 (RHEL7)",
+                            "description": "Build and run Java applications using Maven and OpenJDK 8 upon RHEL7.",
                             "iconClass": "icon-rh-openjdk",
                             "tags": "builder,java,openjdk,hidden",
                             "supports": "java:8",
@@ -162,33 +158,28 @@
                         },
                         "from": {
                             "kind": "DockerImage",
-                            "name": "registry.redhat.io/redhat-openjdk-18/openjdk18-openshift:1.12"
+                            "name": "registry.access.redhat.com/redhat-openjdk-18/openjdk18-openshift:1.12"
                         }
                     }
                 ]
             }
-        },
-        {
+        },{
             "kind": "ImageStream",
             "apiVersion": "image.openshift.io/v1",
             "metadata": {
                 "name": "openjdk-11-rhel7",
                 "annotations": {
-                    "openshift.io/display-name": "Red Hat OpenJDK 11",
-                    "openshift.io/provider-display-name": "Red Hat, Inc.",
-                    "version": "1.4.17"
-                },
-                "labels": {
-                    "xpaas": "1.4.17"
+                    "openshift.io/display-name": "Red Hat OpenJDK 11 (RHEL7)",
+                    "openshift.io/provider-display-name": "Red Hat, Inc."
                 }
             },
             "spec": {
                 "tags": [
-                    {
+                                        {
                         "name": "1.0",
                         "annotations": {
-                            "openshift.io/display-name": "Red Hat OpenJDK 11",
-                            "description": "Build and run Java applications using Maven and OpenJDK 11.",
+                            "openshift.io/display-name": "Red Hat OpenJDK 11 (RHEL7)",
+                            "description": "Build and run Java applications using Maven and OpenJDK 11 upon RHEL7.",
                             "iconClass": "icon-rh-openjdk",
                             "tags": "builder,java,openjdk,hidden",
                             "supports": "java:11",
@@ -201,14 +192,14 @@
                         },
                         "from": {
                             "kind": "DockerImage",
-                            "name": "registry.redhat.io/openjdk/openjdk-11-rhel7:1.0"
+                            "name": "registry.access.redhat.com/openjdk/openjdk-11-rhel7:1.0"
                         }
                     },
                     {
                         "name": "1.1",
                         "annotations": {
-                            "openshift.io/display-name": "Red Hat OpenJDK 11",
-                            "description": "Build and run Java applications using Maven and OpenJDK 11.",
+                            "openshift.io/display-name": "Red Hat OpenJDK 11 (RHEL7)",
+                            "description": "Build and run Java applications using Maven and OpenJDK 11 upon RHEL7.",
                             "iconClass": "icon-rh-openjdk",
                             "tags": "builder,java,openjdk,hidden",
                             "supports": "java:11",
@@ -221,14 +212,14 @@
                         },
                         "from": {
                             "kind": "DockerImage",
-                            "name": "registry.redhat.io/openjdk/openjdk-11-rhel7:1.1"
+                            "name": "registry.access.redhat.com/openjdk/openjdk-11-rhel7:1.1"
                         }
                     },
                     {
                         "name": "1.10",
                         "annotations": {
-                            "openshift.io/display-name": "Red Hat OpenJDK 11",
-                            "description": "Build and run Java applications using Maven and OpenJDK 11.",
+                            "openshift.io/display-name": "Red Hat OpenJDK 11 (RHEL7)",
+                            "description": "Build and run Java applications using Maven and OpenJDK 11 upon RHEL7.",
                             "iconClass": "icon-rh-openjdk",
                             "tags": "builder,java,openjdk,hidden",
                             "supports": "java:11",
@@ -241,14 +232,14 @@
                         },
                         "from": {
                             "kind": "DockerImage",
-                            "name": "registry.redhat.io/openjdk/openjdk-11-rhel7:1.10"
+                            "name": "registry.access.redhat.com/openjdk/openjdk-11-rhel7:1.10"
                         }
                     },
                     {
                         "name": "1.11",
                         "annotations": {
-                            "openshift.io/display-name": "Red Hat OpenJDK 11",
-                            "description": "Build and run Java applications using Maven and OpenJDK 11.",
+                            "openshift.io/display-name": "Red Hat OpenJDK 11 (RHEL7)",
+                            "description": "Build and run Java applications using Maven and OpenJDK 11 upon RHEL7.",
                             "iconClass": "icon-rh-openjdk",
                             "tags": "builder,java,openjdk,hidden",
                             "supports": "java:11",
@@ -261,14 +252,14 @@
                         },
                         "from": {
                             "kind": "DockerImage",
-                            "name": "registry.redhat.io/openjdk/openjdk-11-rhel7:1.11"
+                            "name": "registry.access.redhat.com/openjdk/openjdk-11-rhel7:1.11"
                         }
                     },
                     {
                         "name": "1.12",
                         "annotations": {
-                            "openshift.io/display-name": "Red Hat OpenJDK 11",
-                            "description": "Build and run Java applications using Maven and OpenJDK 11.",
+                            "openshift.io/display-name": "Red Hat OpenJDK 11 (RHEL7)",
+                            "description": "Build and run Java applications using Maven and OpenJDK 11 upon RHEL7.",
                             "iconClass": "icon-rh-openjdk",
                             "tags": "builder,java,openjdk,hidden",
                             "supports": "java:11",
@@ -281,33 +272,28 @@
                         },
                         "from": {
                             "kind": "DockerImage",
-                            "name": "registry.redhat.io/openjdk/openjdk-11-rhel7:1.12"
+                            "name": "registry.access.redhat.com/openjdk/openjdk-11-rhel7:1.12"
                         }
                     }
                 ]
             }
-        },
-        {
+        },{
             "kind": "ImageStream",
             "apiVersion": "image.openshift.io/v1",
             "metadata": {
                 "name": "ubi8-openjdk-8",
                 "annotations": {
-                    "openshift.io/display-name": "Red Hat OpenJDK 1.8 (UBI8)",
-                    "openshift.io/provider-display-name": "Red Hat, Inc.",
-                    "version": "1.4.17"
-                },
-                "labels": {
-                    "xpaas": "1.4.17"
+                    "openshift.io/display-name": "Red Hat OpenJDK 8 (UBI8)",
+                    "openshift.io/provider-display-name": "Red Hat, Inc."
                 }
             },
             "spec": {
                 "tags": [
-                    {
+                                        {
                         "name": "1.3",
                         "annotations": {
-                            "openshift.io/display-name": "Red Hat OpenJDK 1.8 (UBI8)",
-                            "description": "Build and run Java applications using Maven and OpenJDK 1.8 upon UBI8.",
+                            "openshift.io/display-name": "Red Hat OpenJDK 8 (UBI8)",
+                            "description": "Build and run Java applications using Maven and OpenJDK 8 upon UBI8.",
                             "iconClass": "icon-rh-openjdk",
                             "tags": "builder,java,openjdk,ubi8,hidden",
                             "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts",
@@ -325,8 +311,8 @@
                     {
                         "name": "1.10",
                         "annotations": {
-                            "openshift.io/display-name": "Red Hat OpenJDK 1.8 (UBI8)",
-                            "description": "Build and run Java applications using Maven and OpenJDK 1.8 upon UBI8.",
+                            "openshift.io/display-name": "Red Hat OpenJDK 8 (UBI8)",
+                            "description": "Build and run Java applications using Maven and OpenJDK 8 upon UBI8.",
                             "iconClass": "icon-rh-openjdk",
                             "tags": "builder,java,openjdk,ubi8,hidden",
                             "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts",
@@ -344,8 +330,8 @@
                     {
                         "name": "1.11",
                         "annotations": {
-                            "openshift.io/display-name": "Red Hat OpenJDK 1.8 (UBI8)",
-                            "description": "Build and run Java applications using Maven and OpenJDK 1.8 upon UBI8.",
+                            "openshift.io/display-name": "Red Hat OpenJDK 8 (UBI8)",
+                            "description": "Build and run Java applications using Maven and OpenJDK 8 upon UBI8.",
                             "iconClass": "icon-rh-openjdk",
                             "tags": "builder,java,openjdk,ubi8,hidden",
                             "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts",
@@ -363,8 +349,8 @@
                     {
                         "name": "1.12",
                         "annotations": {
-                            "openshift.io/display-name": "Red Hat OpenJDK 1.8 (UBI8)",
-                            "description": "Build and run Java applications using Maven and OpenJDK 1.8 upon UBI8.",
+                            "openshift.io/display-name": "Red Hat OpenJDK 8 (UBI8)",
+                            "description": "Build and run Java applications using Maven and OpenJDK 8 upon UBI8.",
                             "iconClass": "icon-rh-openjdk",
                             "tags": "builder,java,openjdk,ubi8,hidden",
                             "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts",
@@ -382,23 +368,19 @@
                 ]
             }
         },
-        {
+{
             "kind": "ImageStream",
             "apiVersion": "image.openshift.io/v1",
             "metadata": {
                 "name": "ubi8-openjdk-11",
                 "annotations": {
                     "openshift.io/display-name": "Red Hat OpenJDK 11 (UBI8)",
-                    "openshift.io/provider-display-name": "Red Hat, Inc.",
-                    "version": "1.4.17"
-                },
-                "labels": {
-                    "xpaas": "1.4.17"
+                    "openshift.io/provider-display-name": "Red Hat, Inc."
                 }
             },
             "spec": {
                 "tags": [
-                    {
+                                        {
                         "name": "1.3",
                         "annotations": {
                             "openshift.io/display-name": "Red Hat OpenJDK 11 (UBI8)",
@@ -477,23 +459,19 @@
                 ]
             }
         },
-        {
+{
             "kind": "ImageStream",
             "apiVersion": "image.openshift.io/v1",
             "metadata": {
                 "name": "ubi8-openjdk-17",
                 "annotations": {
                     "openshift.io/display-name": "Red Hat OpenJDK 17 (UBI8)",
-                    "openshift.io/provider-display-name": "Red Hat, Inc.",
-                    "version": "1.4.17"
-                },
-                "labels": {
-                    "xpaas": "1.4.17"
+                    "openshift.io/provider-display-name": "Red Hat, Inc."
                 }
             },
             "spec": {
                 "tags": [
-                    {
+                                        {
                         "name": "1.11",
                         "annotations": {
                             "openshift.io/display-name": "Red Hat OpenJDK 17 (UBI8)",
@@ -533,8 +511,7 @@
                     }
                 ]
             }
-        },
-        {
+        },{
             "kind": "ImageStream",
             "apiVersion": "image.openshift.io/v1",
             "metadata": {

--- a/templates/image-streams-ppc64le.json
+++ b/templates/image-streams-ppc64le.json
@@ -160,6 +160,46 @@
                             "kind": "DockerImage",
                             "name": "registry.access.redhat.com/redhat-openjdk-18/openjdk18-openshift:1.12"
                         }
+                    },
+                    {
+                        "name": "1.14",
+                        "annotations": {
+                            "openshift.io/display-name": "Red Hat OpenJDK 8 (RHEL7)",
+                            "description": "Build and run Java applications using Maven and OpenJDK 8 upon RHEL7.",
+                            "iconClass": "icon-rh-openjdk",
+                            "tags": "builder,java,openjdk,hidden",
+                            "supports": "java:8",
+                            "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts",
+                            "sampleContextDir": "undertow-servlet",
+                            "version": "1.14"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
+                        },
+                        "from": {
+                            "kind": "DockerImage",
+                            "name": "registry.access.redhat.com/redhat-openjdk-18/openjdk18-openshift:1.14"
+                        }
+                    },
+                    {
+                        "name": "1.15",
+                        "annotations": {
+                            "openshift.io/display-name": "Red Hat OpenJDK 8 (RHEL7)",
+                            "description": "Build and run Java applications using Maven and OpenJDK 8 upon RHEL7.",
+                            "iconClass": "icon-rh-openjdk",
+                            "tags": "builder,java,openjdk,hidden",
+                            "supports": "java:8",
+                            "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts",
+                            "sampleContextDir": "undertow-servlet",
+                            "version": "1.15"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
+                        },
+                        "from": {
+                            "kind": "DockerImage",
+                            "name": "registry.access.redhat.com/redhat-openjdk-18/openjdk18-openshift:1.15"
+                        }
                     }
                 ]
             }
@@ -274,6 +314,46 @@
                             "kind": "DockerImage",
                             "name": "registry.access.redhat.com/openjdk/openjdk-11-rhel7:1.12"
                         }
+                    },
+                    {
+                        "name": "1.14",
+                        "annotations": {
+                            "openshift.io/display-name": "Red Hat OpenJDK 11 (RHEL7)",
+                            "description": "Build and run Java applications using Maven and OpenJDK 11 upon RHEL7.",
+                            "iconClass": "icon-rh-openjdk",
+                            "tags": "builder,java,openjdk,hidden",
+                            "supports": "java:11",
+                            "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts",
+                            "sampleContextDir": "undertow-servlet",
+                            "version": "1.14"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
+                        },
+                        "from": {
+                            "kind": "DockerImage",
+                            "name": "registry.access.redhat.com/openjdk/openjdk-11-rhel7:1.14"
+                        }
+                    },
+                    {
+                        "name": "1.15",
+                        "annotations": {
+                            "openshift.io/display-name": "Red Hat OpenJDK 11 (RHEL7)",
+                            "description": "Build and run Java applications using Maven and OpenJDK 11 upon RHEL7.",
+                            "iconClass": "icon-rh-openjdk",
+                            "tags": "builder,java,openjdk,hidden",
+                            "supports": "java:11",
+                            "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts",
+                            "sampleContextDir": "undertow-servlet",
+                            "version": "1.15"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
+                        },
+                        "from": {
+                            "kind": "DockerImage",
+                            "name": "registry.access.redhat.com/openjdk/openjdk-11-rhel7:1.15"
+                        }
                     }
                 ]
             }
@@ -363,6 +443,82 @@
                         "from": {
                             "kind": "DockerImage",
                             "name": "registry.access.redhat.com/ubi8/openjdk-8:1.12"
+                        }
+                    },
+                    {
+                        "name": "1.13",
+                        "annotations": {
+                            "openshift.io/display-name": "Red Hat OpenJDK 8 (UBI8)",
+                            "description": "Build and run Java applications using Maven and OpenJDK 8 upon UBI8.",
+                            "iconClass": "icon-rh-openjdk",
+                            "tags": "builder,java,openjdk,ubi8,hidden",
+                            "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts",
+                            "sampleContextDir": "undertow-servlet",
+                            "version": "1.13"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
+                        },
+                        "from": {
+                            "kind": "DockerImage",
+                            "name": "registry.access.redhat.com/ubi8/openjdk-8:1.13"
+                        }
+                    },
+                    {
+                        "name": "1.14",
+                        "annotations": {
+                            "openshift.io/display-name": "Red Hat OpenJDK 8 (UBI8)",
+                            "description": "Build and run Java applications using Maven and OpenJDK 8 upon UBI8.",
+                            "iconClass": "icon-rh-openjdk",
+                            "tags": "builder,java,openjdk,ubi8,hidden",
+                            "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts",
+                            "sampleContextDir": "undertow-servlet",
+                            "version": "1.14"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
+                        },
+                        "from": {
+                            "kind": "DockerImage",
+                            "name": "registry.access.redhat.com/ubi8/openjdk-8:1.14"
+                        }
+                    },
+                    {
+                        "name": "1.15",
+                        "annotations": {
+                            "openshift.io/display-name": "Red Hat OpenJDK 8 (UBI8)",
+                            "description": "Build and run Java applications using Maven and OpenJDK 8 upon UBI8.",
+                            "iconClass": "icon-rh-openjdk",
+                            "tags": "builder,java,openjdk,ubi8,hidden",
+                            "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts",
+                            "sampleContextDir": "undertow-servlet",
+                            "version": "1.15"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
+                        },
+                        "from": {
+                            "kind": "DockerImage",
+                            "name": "registry.access.redhat.com/ubi8/openjdk-8:1.15"
+                        }
+                    },
+                    {
+                        "name": "1.16",
+                        "annotations": {
+                            "openshift.io/display-name": "Red Hat OpenJDK 8 (UBI8)",
+                            "description": "Build and run Java applications using Maven and OpenJDK 8 upon UBI8.",
+                            "iconClass": "icon-rh-openjdk",
+                            "tags": "builder,java,openjdk,ubi8,hidden",
+                            "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts",
+                            "sampleContextDir": "undertow-servlet",
+                            "version": "1.16"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
+                        },
+                        "from": {
+                            "kind": "DockerImage",
+                            "name": "registry.access.redhat.com/ubi8/openjdk-8:1.16"
                         }
                     }
                 ]
@@ -455,6 +611,82 @@
                             "kind": "DockerImage",
                             "name": "registry.access.redhat.com/ubi8/openjdk-11:1.12"
                         }
+                    },
+                    {
+                        "name": "1.13",
+                        "annotations": {
+                            "openshift.io/display-name": "Red Hat OpenJDK 11 (UBI8)",
+                            "description": "Build and run Java applications using Maven and OpenJDK 11 upon UBI8.",
+                            "iconClass": "icon-rh-openjdk",
+                            "tags": "builder,java,openjdk,ubi8,hidden",
+                            "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts",
+                            "sampleContextDir": "undertow-servlet",
+                            "version": "1.13"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
+                        },
+                        "from": {
+                            "kind": "DockerImage",
+                            "name": "registry.access.redhat.com/ubi8/openjdk-11:1.13"
+                        }
+                    },
+                    {
+                        "name": "1.14",
+                        "annotations": {
+                            "openshift.io/display-name": "Red Hat OpenJDK 11 (UBI8)",
+                            "description": "Build and run Java applications using Maven and OpenJDK 11 upon UBI8.",
+                            "iconClass": "icon-rh-openjdk",
+                            "tags": "builder,java,openjdk,ubi8,hidden",
+                            "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts",
+                            "sampleContextDir": "undertow-servlet",
+                            "version": "1.14"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
+                        },
+                        "from": {
+                            "kind": "DockerImage",
+                            "name": "registry.access.redhat.com/ubi8/openjdk-11:1.14"
+                        }
+                    },
+                    {
+                        "name": "1.15",
+                        "annotations": {
+                            "openshift.io/display-name": "Red Hat OpenJDK 11 (UBI8)",
+                            "description": "Build and run Java applications using Maven and OpenJDK 11 upon UBI8.",
+                            "iconClass": "icon-rh-openjdk",
+                            "tags": "builder,java,openjdk,ubi8,hidden",
+                            "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts",
+                            "sampleContextDir": "undertow-servlet",
+                            "version": "1.15"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
+                        },
+                        "from": {
+                            "kind": "DockerImage",
+                            "name": "registry.access.redhat.com/ubi8/openjdk-11:1.15"
+                        }
+                    },
+                    {
+                        "name": "1.16",
+                        "annotations": {
+                            "openshift.io/display-name": "Red Hat OpenJDK 11 (UBI8)",
+                            "description": "Build and run Java applications using Maven and OpenJDK 11 upon UBI8.",
+                            "iconClass": "icon-rh-openjdk",
+                            "tags": "builder,java,openjdk,ubi8,hidden",
+                            "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts",
+                            "sampleContextDir": "undertow-servlet",
+                            "version": "1.16"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
+                        },
+                        "from": {
+                            "kind": "DockerImage",
+                            "name": "registry.access.redhat.com/ubi8/openjdk-11:1.16"
+                        }
                     }
                 ]
             }
@@ -507,6 +739,82 @@
                         "from": {
                             "kind": "DockerImage",
                             "name": "registry.access.redhat.com/ubi8/openjdk-17:1.12"
+                        }
+                    },
+                    {
+                        "name": "1.13",
+                        "annotations": {
+                            "openshift.io/display-name": "Red Hat OpenJDK 17 (UBI8)",
+                            "description": "Build and run Java applications using Maven and OpenJDK 17 upon UBI8.",
+                            "iconClass": "icon-rh-openjdk",
+                            "tags": "builder,java,openjdk,ubi8,hidden",
+                            "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts",
+                            "sampleContextDir": "undertow-servlet",
+                            "version": "1.13"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
+                        },
+                        "from": {
+                            "kind": "DockerImage",
+                            "name": "registry.access.redhat.com/ubi8/openjdk-17:1.13"
+                        }
+                    },
+                    {
+                        "name": "1.14",
+                        "annotations": {
+                            "openshift.io/display-name": "Red Hat OpenJDK 17 (UBI8)",
+                            "description": "Build and run Java applications using Maven and OpenJDK 17 upon UBI8.",
+                            "iconClass": "icon-rh-openjdk",
+                            "tags": "builder,java,openjdk,ubi8,hidden",
+                            "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts",
+                            "sampleContextDir": "undertow-servlet",
+                            "version": "1.14"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
+                        },
+                        "from": {
+                            "kind": "DockerImage",
+                            "name": "registry.access.redhat.com/ubi8/openjdk-17:1.14"
+                        }
+                    },
+                    {
+                        "name": "1.15",
+                        "annotations": {
+                            "openshift.io/display-name": "Red Hat OpenJDK 17 (UBI8)",
+                            "description": "Build and run Java applications using Maven and OpenJDK 17 upon UBI8.",
+                            "iconClass": "icon-rh-openjdk",
+                            "tags": "builder,java,openjdk,ubi8,hidden",
+                            "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts",
+                            "sampleContextDir": "undertow-servlet",
+                            "version": "1.15"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
+                        },
+                        "from": {
+                            "kind": "DockerImage",
+                            "name": "registry.access.redhat.com/ubi8/openjdk-17:1.15"
+                        }
+                    },
+                    {
+                        "name": "1.16",
+                        "annotations": {
+                            "openshift.io/display-name": "Red Hat OpenJDK 17 (UBI8)",
+                            "description": "Build and run Java applications using Maven and OpenJDK 17 upon UBI8.",
+                            "iconClass": "icon-rh-openjdk",
+                            "tags": "builder,java,openjdk,ubi8,hidden",
+                            "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts",
+                            "sampleContextDir": "undertow-servlet",
+                            "version": "1.16"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
+                        },
+                        "from": {
+                            "kind": "DockerImage",
+                            "name": "registry.access.redhat.com/ubi8/openjdk-17:1.16"
                         }
                     }
                 ]

--- a/templates/image-streams-s390x.json
+++ b/templates/image-streams-s390x.json
@@ -15,21 +15,17 @@
             "metadata": {
                 "name": "redhat-openjdk18-openshift",
                 "annotations": {
-                    "openshift.io/display-name": "Red Hat OpenJDK 8",
-                    "openshift.io/provider-display-name": "Red Hat, Inc.",
-                    "version": "1.4.17"
-                },
-                "labels": {
-                    "xpaas": "1.4.17"
+                    "openshift.io/display-name": "Red Hat OpenJDK 8 (RHEL7)",
+                    "openshift.io/provider-display-name": "Red Hat, Inc."
                 }
             },
             "spec": {
                 "tags": [
-                    {
+                                        {
                         "name": "1.5",
                         "annotations": {
-                            "openshift.io/display-name": "Red Hat OpenJDK 8",
-                            "description": "Build and run Java applications using Maven and OpenJDK 8.",
+                            "openshift.io/display-name": "Red Hat OpenJDK 8 (RHEL7)",
+                            "description": "Build and run Java applications using Maven and OpenJDK 8 upon RHEL7.",
                             "iconClass": "icon-rh-openjdk",
                             "tags": "builder,java,openjdk,hidden",
                             "supports": "java:8",
@@ -42,14 +38,14 @@
                         },
                         "from": {
                             "kind": "DockerImage",
-                            "name": "registry.redhat.io/redhat-openjdk-18/openjdk18-openshift:1.5"
+                            "name": "registry.access.redhat.com/redhat-openjdk-18/openjdk18-openshift:1.5"
                         }
                     },
                     {
                         "name": "1.6",
                         "annotations": {
-                            "openshift.io/display-name": "Red Hat OpenJDK 8",
-                            "description": "Build and run Java applications using Maven and OpenJDK 8.",
+                            "openshift.io/display-name": "Red Hat OpenJDK 8 (RHEL7)",
+                            "description": "Build and run Java applications using Maven and OpenJDK 8 upon RHEL7.",
                             "iconClass": "icon-rh-openjdk",
                             "tags": "builder,java,openjdk,hidden",
                             "supports": "java:8",
@@ -62,14 +58,14 @@
                         },
                         "from": {
                             "kind": "DockerImage",
-                            "name": "registry.redhat.io/redhat-openjdk-18/openjdk18-openshift:1.6"
+                            "name": "registry.access.redhat.com/redhat-openjdk-18/openjdk18-openshift:1.6"
                         }
                     },
                     {
                         "name": "1.7",
                         "annotations": {
-                            "openshift.io/display-name": "Red Hat OpenJDK 8",
-                            "description": "Build and run Java applications using Maven and OpenJDK 8.",
+                            "openshift.io/display-name": "Red Hat OpenJDK 8 (RHEL7)",
+                            "description": "Build and run Java applications using Maven and OpenJDK 8 upon RHEL7.",
                             "iconClass": "icon-rh-openjdk",
                             "tags": "builder,java,openjdk,hidden",
                             "supports": "java:8",
@@ -82,14 +78,14 @@
                         },
                         "from": {
                             "kind": "DockerImage",
-                            "name": "registry.redhat.io/redhat-openjdk-18/openjdk18-openshift:1.7"
+                            "name": "registry.access.redhat.com/redhat-openjdk-18/openjdk18-openshift:1.7"
                         }
                     },
                     {
                         "name": "1.8",
                         "annotations": {
-                            "openshift.io/display-name": "Red Hat OpenJDK 8",
-                            "description": "Build and run Java applications using Maven and OpenJDK 8.",
+                            "openshift.io/display-name": "Red Hat OpenJDK 8 (RHEL7)",
+                            "description": "Build and run Java applications using Maven and OpenJDK 8 upon RHEL7.",
                             "iconClass": "icon-rh-openjdk",
                             "tags": "builder,java,openjdk,hidden",
                             "supports": "java:8",
@@ -102,14 +98,14 @@
                         },
                         "from": {
                             "kind": "DockerImage",
-                            "name": "registry.redhat.io/redhat-openjdk-18/openjdk18-openshift:1.8"
+                            "name": "registry.access.redhat.com/redhat-openjdk-18/openjdk18-openshift:1.8"
                         }
                     },
                     {
                         "name": "1.10",
                         "annotations": {
-                            "openshift.io/display-name": "Red Hat OpenJDK 8",
-                            "description": "Build and run Java applications using Maven and OpenJDK 8.",
+                            "openshift.io/display-name": "Red Hat OpenJDK 8 (RHEL7)",
+                            "description": "Build and run Java applications using Maven and OpenJDK 8 upon RHEL7.",
                             "iconClass": "icon-rh-openjdk",
                             "tags": "builder,java,openjdk,hidden",
                             "supports": "java:8",
@@ -122,14 +118,14 @@
                         },
                         "from": {
                             "kind": "DockerImage",
-                            "name": "registry.redhat.io/redhat-openjdk-18/openjdk18-openshift:1.10"
+                            "name": "registry.access.redhat.com/redhat-openjdk-18/openjdk18-openshift:1.10"
                         }
                     },
                     {
                         "name": "1.11",
                         "annotations": {
-                            "openshift.io/display-name": "Red Hat OpenJDK 8",
-                            "description": "Build and run Java applications using Maven and OpenJDK 8.",
+                            "openshift.io/display-name": "Red Hat OpenJDK 8 (RHEL7)",
+                            "description": "Build and run Java applications using Maven and OpenJDK 8 upon RHEL7.",
                             "iconClass": "icon-rh-openjdk",
                             "tags": "builder,java,openjdk,hidden",
                             "supports": "java:8",
@@ -142,14 +138,14 @@
                         },
                         "from": {
                             "kind": "DockerImage",
-                            "name": "registry.redhat.io/redhat-openjdk-18/openjdk18-openshift:1.11"
+                            "name": "registry.access.redhat.com/redhat-openjdk-18/openjdk18-openshift:1.11"
                         }
                     },
                     {
                         "name": "1.12",
                         "annotations": {
-                            "openshift.io/display-name": "Red Hat OpenJDK 8",
-                            "description": "Build and run Java applications using Maven and OpenJDK 8.",
+                            "openshift.io/display-name": "Red Hat OpenJDK 8 (RHEL7)",
+                            "description": "Build and run Java applications using Maven and OpenJDK 8 upon RHEL7.",
                             "iconClass": "icon-rh-openjdk",
                             "tags": "builder,java,openjdk,hidden",
                             "supports": "java:8",
@@ -162,33 +158,28 @@
                         },
                         "from": {
                             "kind": "DockerImage",
-                            "name": "registry.redhat.io/redhat-openjdk-18/openjdk18-openshift:1.12"
+                            "name": "registry.access.redhat.com/redhat-openjdk-18/openjdk18-openshift:1.12"
                         }
                     }
                 ]
             }
-        },
-        {
+        },{
             "kind": "ImageStream",
             "apiVersion": "image.openshift.io/v1",
             "metadata": {
                 "name": "openjdk-11-rhel7",
                 "annotations": {
-                    "openshift.io/display-name": "Red Hat OpenJDK 11",
-                    "openshift.io/provider-display-name": "Red Hat, Inc.",
-                    "version": "1.4.17"
-                },
-                "labels": {
-                    "xpaas": "1.4.17"
+                    "openshift.io/display-name": "Red Hat OpenJDK 11 (RHEL7)",
+                    "openshift.io/provider-display-name": "Red Hat, Inc."
                 }
             },
             "spec": {
                 "tags": [
-                    {
+                                        {
                         "name": "1.0",
                         "annotations": {
-                            "openshift.io/display-name": "Red Hat OpenJDK 11",
-                            "description": "Build and run Java applications using Maven and OpenJDK 11.",
+                            "openshift.io/display-name": "Red Hat OpenJDK 11 (RHEL7)",
+                            "description": "Build and run Java applications using Maven and OpenJDK 11 upon RHEL7.",
                             "iconClass": "icon-rh-openjdk",
                             "tags": "builder,java,openjdk,hidden",
                             "supports": "java:11",
@@ -201,14 +192,14 @@
                         },
                         "from": {
                             "kind": "DockerImage",
-                            "name": "registry.redhat.io/openjdk/openjdk-11-rhel7:1.0"
+                            "name": "registry.access.redhat.com/openjdk/openjdk-11-rhel7:1.0"
                         }
                     },
                     {
                         "name": "1.1",
                         "annotations": {
-                            "openshift.io/display-name": "Red Hat OpenJDK 11",
-                            "description": "Build and run Java applications using Maven and OpenJDK 11.",
+                            "openshift.io/display-name": "Red Hat OpenJDK 11 (RHEL7)",
+                            "description": "Build and run Java applications using Maven and OpenJDK 11 upon RHEL7.",
                             "iconClass": "icon-rh-openjdk",
                             "tags": "builder,java,openjdk,hidden",
                             "supports": "java:11",
@@ -221,14 +212,14 @@
                         },
                         "from": {
                             "kind": "DockerImage",
-                            "name": "registry.redhat.io/openjdk/openjdk-11-rhel7:1.1"
+                            "name": "registry.access.redhat.com/openjdk/openjdk-11-rhel7:1.1"
                         }
                     },
                     {
                         "name": "1.10",
                         "annotations": {
-                            "openshift.io/display-name": "Red Hat OpenJDK 11",
-                            "description": "Build and run Java applications using Maven and OpenJDK 11.",
+                            "openshift.io/display-name": "Red Hat OpenJDK 11 (RHEL7)",
+                            "description": "Build and run Java applications using Maven and OpenJDK 11 upon RHEL7.",
                             "iconClass": "icon-rh-openjdk",
                             "tags": "builder,java,openjdk,hidden",
                             "supports": "java:11",
@@ -241,14 +232,14 @@
                         },
                         "from": {
                             "kind": "DockerImage",
-                            "name": "registry.redhat.io/openjdk/openjdk-11-rhel7:1.10"
+                            "name": "registry.access.redhat.com/openjdk/openjdk-11-rhel7:1.10"
                         }
                     },
                     {
                         "name": "1.11",
                         "annotations": {
-                            "openshift.io/display-name": "Red Hat OpenJDK 11",
-                            "description": "Build and run Java applications using Maven and OpenJDK 11.",
+                            "openshift.io/display-name": "Red Hat OpenJDK 11 (RHEL7)",
+                            "description": "Build and run Java applications using Maven and OpenJDK 11 upon RHEL7.",
                             "iconClass": "icon-rh-openjdk",
                             "tags": "builder,java,openjdk,hidden",
                             "supports": "java:11",
@@ -261,14 +252,14 @@
                         },
                         "from": {
                             "kind": "DockerImage",
-                            "name": "registry.redhat.io/openjdk/openjdk-11-rhel7:1.11"
+                            "name": "registry.access.redhat.com/openjdk/openjdk-11-rhel7:1.11"
                         }
                     },
                     {
                         "name": "1.12",
                         "annotations": {
-                            "openshift.io/display-name": "Red Hat OpenJDK 11",
-                            "description": "Build and run Java applications using Maven and OpenJDK 11.",
+                            "openshift.io/display-name": "Red Hat OpenJDK 11 (RHEL7)",
+                            "description": "Build and run Java applications using Maven and OpenJDK 11 upon RHEL7.",
                             "iconClass": "icon-rh-openjdk",
                             "tags": "builder,java,openjdk,hidden",
                             "supports": "java:11",
@@ -281,33 +272,28 @@
                         },
                         "from": {
                             "kind": "DockerImage",
-                            "name": "registry.redhat.io/openjdk/openjdk-11-rhel7:1.12"
+                            "name": "registry.access.redhat.com/openjdk/openjdk-11-rhel7:1.12"
                         }
                     }
                 ]
             }
-        },
-        {
+        },{
             "kind": "ImageStream",
             "apiVersion": "image.openshift.io/v1",
             "metadata": {
                 "name": "ubi8-openjdk-8",
                 "annotations": {
-                    "openshift.io/display-name": "Red Hat OpenJDK 1.8 (UBI8)",
-                    "openshift.io/provider-display-name": "Red Hat, Inc.",
-                    "version": "1.4.17"
-                },
-                "labels": {
-                    "xpaas": "1.4.17"
+                    "openshift.io/display-name": "Red Hat OpenJDK 8 (UBI8)",
+                    "openshift.io/provider-display-name": "Red Hat, Inc."
                 }
             },
             "spec": {
                 "tags": [
-                    {
+                                        {
                         "name": "1.3",
                         "annotations": {
-                            "openshift.io/display-name": "Red Hat OpenJDK 1.8 (UBI8)",
-                            "description": "Build and run Java applications using Maven and OpenJDK 1.8 upon UBI8.",
+                            "openshift.io/display-name": "Red Hat OpenJDK 8 (UBI8)",
+                            "description": "Build and run Java applications using Maven and OpenJDK 8 upon UBI8.",
                             "iconClass": "icon-rh-openjdk",
                             "tags": "builder,java,openjdk,ubi8,hidden",
                             "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts",
@@ -325,8 +311,8 @@
                     {
                         "name": "1.10",
                         "annotations": {
-                            "openshift.io/display-name": "Red Hat OpenJDK 1.8 (UBI8)",
-                            "description": "Build and run Java applications using Maven and OpenJDK 1.8 upon UBI8.",
+                            "openshift.io/display-name": "Red Hat OpenJDK 8 (UBI8)",
+                            "description": "Build and run Java applications using Maven and OpenJDK 8 upon UBI8.",
                             "iconClass": "icon-rh-openjdk",
                             "tags": "builder,java,openjdk,ubi8,hidden",
                             "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts",
@@ -344,8 +330,8 @@
                     {
                         "name": "1.11",
                         "annotations": {
-                            "openshift.io/display-name": "Red Hat OpenJDK 1.8 (UBI8)",
-                            "description": "Build and run Java applications using Maven and OpenJDK 1.8 upon UBI8.",
+                            "openshift.io/display-name": "Red Hat OpenJDK 8 (UBI8)",
+                            "description": "Build and run Java applications using Maven and OpenJDK 8 upon UBI8.",
                             "iconClass": "icon-rh-openjdk",
                             "tags": "builder,java,openjdk,ubi8,hidden",
                             "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts",
@@ -363,8 +349,8 @@
                     {
                         "name": "1.12",
                         "annotations": {
-                            "openshift.io/display-name": "Red Hat OpenJDK 1.8 (UBI8)",
-                            "description": "Build and run Java applications using Maven and OpenJDK 1.8 upon UBI8.",
+                            "openshift.io/display-name": "Red Hat OpenJDK 8 (UBI8)",
+                            "description": "Build and run Java applications using Maven and OpenJDK 8 upon UBI8.",
                             "iconClass": "icon-rh-openjdk",
                             "tags": "builder,java,openjdk,ubi8,hidden",
                             "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts",
@@ -382,23 +368,19 @@
                 ]
             }
         },
-        {
+{
             "kind": "ImageStream",
             "apiVersion": "image.openshift.io/v1",
             "metadata": {
                 "name": "ubi8-openjdk-11",
                 "annotations": {
                     "openshift.io/display-name": "Red Hat OpenJDK 11 (UBI8)",
-                    "openshift.io/provider-display-name": "Red Hat, Inc.",
-                    "version": "1.4.17"
-                },
-                "labels": {
-                    "xpaas": "1.4.17"
+                    "openshift.io/provider-display-name": "Red Hat, Inc."
                 }
             },
             "spec": {
                 "tags": [
-                    {
+                                        {
                         "name": "1.3",
                         "annotations": {
                             "openshift.io/display-name": "Red Hat OpenJDK 11 (UBI8)",
@@ -477,23 +459,19 @@
                 ]
             }
         },
-        {
+{
             "kind": "ImageStream",
             "apiVersion": "image.openshift.io/v1",
             "metadata": {
                 "name": "ubi8-openjdk-17",
                 "annotations": {
                     "openshift.io/display-name": "Red Hat OpenJDK 17 (UBI8)",
-                    "openshift.io/provider-display-name": "Red Hat, Inc.",
-                    "version": "1.4.17"
-                },
-                "labels": {
-                    "xpaas": "1.4.17"
+                    "openshift.io/provider-display-name": "Red Hat, Inc."
                 }
             },
             "spec": {
                 "tags": [
-                    {
+                                        {
                         "name": "1.11",
                         "annotations": {
                             "openshift.io/display-name": "Red Hat OpenJDK 17 (UBI8)",
@@ -533,8 +511,7 @@
                     }
                 ]
             }
-        },
-        {
+        },{
             "kind": "ImageStream",
             "apiVersion": "image.openshift.io/v1",
             "metadata": {
@@ -591,6 +568,26 @@
                         }
                     },
                     {
+                        "name": "8",
+                        "annotations": {
+                            "openshift.io/display-name": "Red Hat OpenJDK 8",
+                            "description": "Build and run Java applications using Maven and OpenJDK 8.",
+                            "iconClass": "icon-rh-openjdk",
+                            "tags": "builder,java,openjdk,hidden",
+                            "supports": "java:8,java",
+                            "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts",
+                            "sampleContextDir": "undertow-servlet",
+                            "version": "8"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
+                        },
+                        "from": {
+                            "kind": "DockerImage",
+                            "name": "registry.redhat.io/redhat-openjdk-18/openjdk18-openshift:latest"
+                        }
+                    },
+                    {
                         "name": "openjdk-11-ubi8",
                         "annotations": {
                             "openshift.io/display-name": "Red Hat OpenJDK 11 (UBI 8)",
@@ -617,6 +614,26 @@
                             "description": "Build and run Java applications using Maven and OpenJDK 11.",
                             "iconClass": "icon-rh-openjdk",
                             "tags": "builder,java,openjdk",
+                            "supports": "java:11,java",
+                            "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts",
+                            "sampleContextDir": "undertow-servlet",
+                            "version": "11"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
+                        },
+                        "from": {
+                            "kind": "DockerImage",
+                            "name": "registry.redhat.io/openjdk/openjdk-11-rhel7:latest"
+                        }
+                    },
+                    {
+                        "name": "11",
+                        "annotations": {
+                            "openshift.io/display-name": "Red Hat OpenJDK 11",
+                            "description": "Build and run Java applications using Maven and OpenJDK 11.",
+                            "iconClass": "icon-rh-openjdk",
+                            "tags": "builder,java,openjdk,hidden",
                             "supports": "java:11,java",
                             "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts",
                             "sampleContextDir": "undertow-servlet",

--- a/templates/image-streams-s390x.json
+++ b/templates/image-streams-s390x.json
@@ -160,6 +160,46 @@
                             "kind": "DockerImage",
                             "name": "registry.access.redhat.com/redhat-openjdk-18/openjdk18-openshift:1.12"
                         }
+                    },
+                    {
+                        "name": "1.14",
+                        "annotations": {
+                            "openshift.io/display-name": "Red Hat OpenJDK 8 (RHEL7)",
+                            "description": "Build and run Java applications using Maven and OpenJDK 8 upon RHEL7.",
+                            "iconClass": "icon-rh-openjdk",
+                            "tags": "builder,java,openjdk,hidden",
+                            "supports": "java:8",
+                            "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts",
+                            "sampleContextDir": "undertow-servlet",
+                            "version": "1.14"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
+                        },
+                        "from": {
+                            "kind": "DockerImage",
+                            "name": "registry.access.redhat.com/redhat-openjdk-18/openjdk18-openshift:1.14"
+                        }
+                    },
+                    {
+                        "name": "1.15",
+                        "annotations": {
+                            "openshift.io/display-name": "Red Hat OpenJDK 8 (RHEL7)",
+                            "description": "Build and run Java applications using Maven and OpenJDK 8 upon RHEL7.",
+                            "iconClass": "icon-rh-openjdk",
+                            "tags": "builder,java,openjdk,hidden",
+                            "supports": "java:8",
+                            "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts",
+                            "sampleContextDir": "undertow-servlet",
+                            "version": "1.15"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
+                        },
+                        "from": {
+                            "kind": "DockerImage",
+                            "name": "registry.access.redhat.com/redhat-openjdk-18/openjdk18-openshift:1.15"
+                        }
                     }
                 ]
             }
@@ -274,6 +314,46 @@
                             "kind": "DockerImage",
                             "name": "registry.access.redhat.com/openjdk/openjdk-11-rhel7:1.12"
                         }
+                    },
+                    {
+                        "name": "1.14",
+                        "annotations": {
+                            "openshift.io/display-name": "Red Hat OpenJDK 11 (RHEL7)",
+                            "description": "Build and run Java applications using Maven and OpenJDK 11 upon RHEL7.",
+                            "iconClass": "icon-rh-openjdk",
+                            "tags": "builder,java,openjdk,hidden",
+                            "supports": "java:11",
+                            "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts",
+                            "sampleContextDir": "undertow-servlet",
+                            "version": "1.14"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
+                        },
+                        "from": {
+                            "kind": "DockerImage",
+                            "name": "registry.access.redhat.com/openjdk/openjdk-11-rhel7:1.14"
+                        }
+                    },
+                    {
+                        "name": "1.15",
+                        "annotations": {
+                            "openshift.io/display-name": "Red Hat OpenJDK 11 (RHEL7)",
+                            "description": "Build and run Java applications using Maven and OpenJDK 11 upon RHEL7.",
+                            "iconClass": "icon-rh-openjdk",
+                            "tags": "builder,java,openjdk,hidden",
+                            "supports": "java:11",
+                            "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts",
+                            "sampleContextDir": "undertow-servlet",
+                            "version": "1.15"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
+                        },
+                        "from": {
+                            "kind": "DockerImage",
+                            "name": "registry.access.redhat.com/openjdk/openjdk-11-rhel7:1.15"
+                        }
                     }
                 ]
             }
@@ -363,6 +443,82 @@
                         "from": {
                             "kind": "DockerImage",
                             "name": "registry.access.redhat.com/ubi8/openjdk-8:1.12"
+                        }
+                    },
+                    {
+                        "name": "1.13",
+                        "annotations": {
+                            "openshift.io/display-name": "Red Hat OpenJDK 8 (UBI8)",
+                            "description": "Build and run Java applications using Maven and OpenJDK 8 upon UBI8.",
+                            "iconClass": "icon-rh-openjdk",
+                            "tags": "builder,java,openjdk,ubi8,hidden",
+                            "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts",
+                            "sampleContextDir": "undertow-servlet",
+                            "version": "1.13"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
+                        },
+                        "from": {
+                            "kind": "DockerImage",
+                            "name": "registry.access.redhat.com/ubi8/openjdk-8:1.13"
+                        }
+                    },
+                    {
+                        "name": "1.14",
+                        "annotations": {
+                            "openshift.io/display-name": "Red Hat OpenJDK 8 (UBI8)",
+                            "description": "Build and run Java applications using Maven and OpenJDK 8 upon UBI8.",
+                            "iconClass": "icon-rh-openjdk",
+                            "tags": "builder,java,openjdk,ubi8,hidden",
+                            "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts",
+                            "sampleContextDir": "undertow-servlet",
+                            "version": "1.14"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
+                        },
+                        "from": {
+                            "kind": "DockerImage",
+                            "name": "registry.access.redhat.com/ubi8/openjdk-8:1.14"
+                        }
+                    },
+                    {
+                        "name": "1.15",
+                        "annotations": {
+                            "openshift.io/display-name": "Red Hat OpenJDK 8 (UBI8)",
+                            "description": "Build and run Java applications using Maven and OpenJDK 8 upon UBI8.",
+                            "iconClass": "icon-rh-openjdk",
+                            "tags": "builder,java,openjdk,ubi8,hidden",
+                            "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts",
+                            "sampleContextDir": "undertow-servlet",
+                            "version": "1.15"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
+                        },
+                        "from": {
+                            "kind": "DockerImage",
+                            "name": "registry.access.redhat.com/ubi8/openjdk-8:1.15"
+                        }
+                    },
+                    {
+                        "name": "1.16",
+                        "annotations": {
+                            "openshift.io/display-name": "Red Hat OpenJDK 8 (UBI8)",
+                            "description": "Build and run Java applications using Maven and OpenJDK 8 upon UBI8.",
+                            "iconClass": "icon-rh-openjdk",
+                            "tags": "builder,java,openjdk,ubi8,hidden",
+                            "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts",
+                            "sampleContextDir": "undertow-servlet",
+                            "version": "1.16"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
+                        },
+                        "from": {
+                            "kind": "DockerImage",
+                            "name": "registry.access.redhat.com/ubi8/openjdk-8:1.16"
                         }
                     }
                 ]
@@ -455,6 +611,82 @@
                             "kind": "DockerImage",
                             "name": "registry.access.redhat.com/ubi8/openjdk-11:1.12"
                         }
+                    },
+                    {
+                        "name": "1.13",
+                        "annotations": {
+                            "openshift.io/display-name": "Red Hat OpenJDK 11 (UBI8)",
+                            "description": "Build and run Java applications using Maven and OpenJDK 11 upon UBI8.",
+                            "iconClass": "icon-rh-openjdk",
+                            "tags": "builder,java,openjdk,ubi8,hidden",
+                            "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts",
+                            "sampleContextDir": "undertow-servlet",
+                            "version": "1.13"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
+                        },
+                        "from": {
+                            "kind": "DockerImage",
+                            "name": "registry.access.redhat.com/ubi8/openjdk-11:1.13"
+                        }
+                    },
+                    {
+                        "name": "1.14",
+                        "annotations": {
+                            "openshift.io/display-name": "Red Hat OpenJDK 11 (UBI8)",
+                            "description": "Build and run Java applications using Maven and OpenJDK 11 upon UBI8.",
+                            "iconClass": "icon-rh-openjdk",
+                            "tags": "builder,java,openjdk,ubi8,hidden",
+                            "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts",
+                            "sampleContextDir": "undertow-servlet",
+                            "version": "1.14"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
+                        },
+                        "from": {
+                            "kind": "DockerImage",
+                            "name": "registry.access.redhat.com/ubi8/openjdk-11:1.14"
+                        }
+                    },
+                    {
+                        "name": "1.15",
+                        "annotations": {
+                            "openshift.io/display-name": "Red Hat OpenJDK 11 (UBI8)",
+                            "description": "Build and run Java applications using Maven and OpenJDK 11 upon UBI8.",
+                            "iconClass": "icon-rh-openjdk",
+                            "tags": "builder,java,openjdk,ubi8,hidden",
+                            "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts",
+                            "sampleContextDir": "undertow-servlet",
+                            "version": "1.15"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
+                        },
+                        "from": {
+                            "kind": "DockerImage",
+                            "name": "registry.access.redhat.com/ubi8/openjdk-11:1.15"
+                        }
+                    },
+                    {
+                        "name": "1.16",
+                        "annotations": {
+                            "openshift.io/display-name": "Red Hat OpenJDK 11 (UBI8)",
+                            "description": "Build and run Java applications using Maven and OpenJDK 11 upon UBI8.",
+                            "iconClass": "icon-rh-openjdk",
+                            "tags": "builder,java,openjdk,ubi8,hidden",
+                            "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts",
+                            "sampleContextDir": "undertow-servlet",
+                            "version": "1.16"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
+                        },
+                        "from": {
+                            "kind": "DockerImage",
+                            "name": "registry.access.redhat.com/ubi8/openjdk-11:1.16"
+                        }
                     }
                 ]
             }
@@ -507,6 +739,82 @@
                         "from": {
                             "kind": "DockerImage",
                             "name": "registry.access.redhat.com/ubi8/openjdk-17:1.12"
+                        }
+                    },
+                    {
+                        "name": "1.13",
+                        "annotations": {
+                            "openshift.io/display-name": "Red Hat OpenJDK 17 (UBI8)",
+                            "description": "Build and run Java applications using Maven and OpenJDK 17 upon UBI8.",
+                            "iconClass": "icon-rh-openjdk",
+                            "tags": "builder,java,openjdk,ubi8,hidden",
+                            "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts",
+                            "sampleContextDir": "undertow-servlet",
+                            "version": "1.13"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
+                        },
+                        "from": {
+                            "kind": "DockerImage",
+                            "name": "registry.access.redhat.com/ubi8/openjdk-17:1.13"
+                        }
+                    },
+                    {
+                        "name": "1.14",
+                        "annotations": {
+                            "openshift.io/display-name": "Red Hat OpenJDK 17 (UBI8)",
+                            "description": "Build and run Java applications using Maven and OpenJDK 17 upon UBI8.",
+                            "iconClass": "icon-rh-openjdk",
+                            "tags": "builder,java,openjdk,ubi8,hidden",
+                            "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts",
+                            "sampleContextDir": "undertow-servlet",
+                            "version": "1.14"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
+                        },
+                        "from": {
+                            "kind": "DockerImage",
+                            "name": "registry.access.redhat.com/ubi8/openjdk-17:1.14"
+                        }
+                    },
+                    {
+                        "name": "1.15",
+                        "annotations": {
+                            "openshift.io/display-name": "Red Hat OpenJDK 17 (UBI8)",
+                            "description": "Build and run Java applications using Maven and OpenJDK 17 upon UBI8.",
+                            "iconClass": "icon-rh-openjdk",
+                            "tags": "builder,java,openjdk,ubi8,hidden",
+                            "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts",
+                            "sampleContextDir": "undertow-servlet",
+                            "version": "1.15"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
+                        },
+                        "from": {
+                            "kind": "DockerImage",
+                            "name": "registry.access.redhat.com/ubi8/openjdk-17:1.15"
+                        }
+                    },
+                    {
+                        "name": "1.16",
+                        "annotations": {
+                            "openshift.io/display-name": "Red Hat OpenJDK 17 (UBI8)",
+                            "description": "Build and run Java applications using Maven and OpenJDK 17 upon UBI8.",
+                            "iconClass": "icon-rh-openjdk",
+                            "tags": "builder,java,openjdk,ubi8,hidden",
+                            "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts",
+                            "sampleContextDir": "undertow-servlet",
+                            "version": "1.16"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
+                        },
+                        "from": {
+                            "kind": "DockerImage",
+                            "name": "registry.access.redhat.com/ubi8/openjdk-17:1.16"
                         }
                     }
                 ]

--- a/templates/image-streams.json
+++ b/templates/image-streams.json
@@ -200,6 +200,46 @@
                             "kind": "DockerImage",
                             "name": "registry.access.redhat.com/redhat-openjdk-18/openjdk18-openshift:1.12"
                         }
+                    },
+                    {
+                        "name": "1.14",
+                        "annotations": {
+                            "openshift.io/display-name": "Red Hat OpenJDK 8 (RHEL7)",
+                            "description": "Build and run Java applications using Maven and OpenJDK 8 upon RHEL7.",
+                            "iconClass": "icon-rh-openjdk",
+                            "tags": "builder,java,openjdk,hidden",
+                            "supports": "java:8",
+                            "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts",
+                            "sampleContextDir": "undertow-servlet",
+                            "version": "1.14"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
+                        },
+                        "from": {
+                            "kind": "DockerImage",
+                            "name": "registry.access.redhat.com/redhat-openjdk-18/openjdk18-openshift:1.14"
+                        }
+                    },
+                    {
+                        "name": "1.15",
+                        "annotations": {
+                            "openshift.io/display-name": "Red Hat OpenJDK 8 (RHEL7)",
+                            "description": "Build and run Java applications using Maven and OpenJDK 8 upon RHEL7.",
+                            "iconClass": "icon-rh-openjdk",
+                            "tags": "builder,java,openjdk,hidden",
+                            "supports": "java:8",
+                            "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts",
+                            "sampleContextDir": "undertow-servlet",
+                            "version": "1.15"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
+                        },
+                        "from": {
+                            "kind": "DockerImage",
+                            "name": "registry.access.redhat.com/redhat-openjdk-18/openjdk18-openshift:1.15"
+                        }
                     }
                 ]
             }
@@ -314,6 +354,46 @@
                             "kind": "DockerImage",
                             "name": "registry.access.redhat.com/openjdk/openjdk-11-rhel7:1.12"
                         }
+                    },
+                    {
+                        "name": "1.14",
+                        "annotations": {
+                            "openshift.io/display-name": "Red Hat OpenJDK 11 (RHEL7)",
+                            "description": "Build and run Java applications using Maven and OpenJDK 11 upon RHEL7.",
+                            "iconClass": "icon-rh-openjdk",
+                            "tags": "builder,java,openjdk,hidden",
+                            "supports": "java:11",
+                            "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts",
+                            "sampleContextDir": "undertow-servlet",
+                            "version": "1.14"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
+                        },
+                        "from": {
+                            "kind": "DockerImage",
+                            "name": "registry.access.redhat.com/openjdk/openjdk-11-rhel7:1.14"
+                        }
+                    },
+                    {
+                        "name": "1.15",
+                        "annotations": {
+                            "openshift.io/display-name": "Red Hat OpenJDK 11 (RHEL7)",
+                            "description": "Build and run Java applications using Maven and OpenJDK 11 upon RHEL7.",
+                            "iconClass": "icon-rh-openjdk",
+                            "tags": "builder,java,openjdk,hidden",
+                            "supports": "java:11",
+                            "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts",
+                            "sampleContextDir": "undertow-servlet",
+                            "version": "1.15"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
+                        },
+                        "from": {
+                            "kind": "DockerImage",
+                            "name": "registry.access.redhat.com/openjdk/openjdk-11-rhel7:1.15"
+                        }
                     }
                 ]
             }
@@ -403,6 +483,82 @@
                         "from": {
                             "kind": "DockerImage",
                             "name": "registry.access.redhat.com/ubi8/openjdk-8:1.12"
+                        }
+                    },
+                    {
+                        "name": "1.13",
+                        "annotations": {
+                            "openshift.io/display-name": "Red Hat OpenJDK 8 (UBI8)",
+                            "description": "Build and run Java applications using Maven and OpenJDK 8 upon UBI8.",
+                            "iconClass": "icon-rh-openjdk",
+                            "tags": "builder,java,openjdk,ubi8,hidden",
+                            "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts",
+                            "sampleContextDir": "undertow-servlet",
+                            "version": "1.13"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
+                        },
+                        "from": {
+                            "kind": "DockerImage",
+                            "name": "registry.access.redhat.com/ubi8/openjdk-8:1.13"
+                        }
+                    },
+                    {
+                        "name": "1.14",
+                        "annotations": {
+                            "openshift.io/display-name": "Red Hat OpenJDK 8 (UBI8)",
+                            "description": "Build and run Java applications using Maven and OpenJDK 8 upon UBI8.",
+                            "iconClass": "icon-rh-openjdk",
+                            "tags": "builder,java,openjdk,ubi8,hidden",
+                            "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts",
+                            "sampleContextDir": "undertow-servlet",
+                            "version": "1.14"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
+                        },
+                        "from": {
+                            "kind": "DockerImage",
+                            "name": "registry.access.redhat.com/ubi8/openjdk-8:1.14"
+                        }
+                    },
+                    {
+                        "name": "1.15",
+                        "annotations": {
+                            "openshift.io/display-name": "Red Hat OpenJDK 8 (UBI8)",
+                            "description": "Build and run Java applications using Maven and OpenJDK 8 upon UBI8.",
+                            "iconClass": "icon-rh-openjdk",
+                            "tags": "builder,java,openjdk,ubi8,hidden",
+                            "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts",
+                            "sampleContextDir": "undertow-servlet",
+                            "version": "1.15"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
+                        },
+                        "from": {
+                            "kind": "DockerImage",
+                            "name": "registry.access.redhat.com/ubi8/openjdk-8:1.15"
+                        }
+                    },
+                    {
+                        "name": "1.16",
+                        "annotations": {
+                            "openshift.io/display-name": "Red Hat OpenJDK 8 (UBI8)",
+                            "description": "Build and run Java applications using Maven and OpenJDK 8 upon UBI8.",
+                            "iconClass": "icon-rh-openjdk",
+                            "tags": "builder,java,openjdk,ubi8,hidden",
+                            "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts",
+                            "sampleContextDir": "undertow-servlet",
+                            "version": "1.16"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
+                        },
+                        "from": {
+                            "kind": "DockerImage",
+                            "name": "registry.access.redhat.com/ubi8/openjdk-8:1.16"
                         }
                     }
                 ]
@@ -495,6 +651,82 @@
                             "kind": "DockerImage",
                             "name": "registry.access.redhat.com/ubi8/openjdk-11:1.12"
                         }
+                    },
+                    {
+                        "name": "1.13",
+                        "annotations": {
+                            "openshift.io/display-name": "Red Hat OpenJDK 11 (UBI8)",
+                            "description": "Build and run Java applications using Maven and OpenJDK 11 upon UBI8.",
+                            "iconClass": "icon-rh-openjdk",
+                            "tags": "builder,java,openjdk,ubi8,hidden",
+                            "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts",
+                            "sampleContextDir": "undertow-servlet",
+                            "version": "1.13"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
+                        },
+                        "from": {
+                            "kind": "DockerImage",
+                            "name": "registry.access.redhat.com/ubi8/openjdk-11:1.13"
+                        }
+                    },
+                    {
+                        "name": "1.14",
+                        "annotations": {
+                            "openshift.io/display-name": "Red Hat OpenJDK 11 (UBI8)",
+                            "description": "Build and run Java applications using Maven and OpenJDK 11 upon UBI8.",
+                            "iconClass": "icon-rh-openjdk",
+                            "tags": "builder,java,openjdk,ubi8,hidden",
+                            "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts",
+                            "sampleContextDir": "undertow-servlet",
+                            "version": "1.14"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
+                        },
+                        "from": {
+                            "kind": "DockerImage",
+                            "name": "registry.access.redhat.com/ubi8/openjdk-11:1.14"
+                        }
+                    },
+                    {
+                        "name": "1.15",
+                        "annotations": {
+                            "openshift.io/display-name": "Red Hat OpenJDK 11 (UBI8)",
+                            "description": "Build and run Java applications using Maven and OpenJDK 11 upon UBI8.",
+                            "iconClass": "icon-rh-openjdk",
+                            "tags": "builder,java,openjdk,ubi8,hidden",
+                            "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts",
+                            "sampleContextDir": "undertow-servlet",
+                            "version": "1.15"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
+                        },
+                        "from": {
+                            "kind": "DockerImage",
+                            "name": "registry.access.redhat.com/ubi8/openjdk-11:1.15"
+                        }
+                    },
+                    {
+                        "name": "1.16",
+                        "annotations": {
+                            "openshift.io/display-name": "Red Hat OpenJDK 11 (UBI8)",
+                            "description": "Build and run Java applications using Maven and OpenJDK 11 upon UBI8.",
+                            "iconClass": "icon-rh-openjdk",
+                            "tags": "builder,java,openjdk,ubi8,hidden",
+                            "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts",
+                            "sampleContextDir": "undertow-servlet",
+                            "version": "1.16"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
+                        },
+                        "from": {
+                            "kind": "DockerImage",
+                            "name": "registry.access.redhat.com/ubi8/openjdk-11:1.16"
+                        }
                     }
                 ]
             }
@@ -547,6 +779,82 @@
                         "from": {
                             "kind": "DockerImage",
                             "name": "registry.access.redhat.com/ubi8/openjdk-17:1.12"
+                        }
+                    },
+                    {
+                        "name": "1.13",
+                        "annotations": {
+                            "openshift.io/display-name": "Red Hat OpenJDK 17 (UBI8)",
+                            "description": "Build and run Java applications using Maven and OpenJDK 17 upon UBI8.",
+                            "iconClass": "icon-rh-openjdk",
+                            "tags": "builder,java,openjdk,ubi8,hidden",
+                            "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts",
+                            "sampleContextDir": "undertow-servlet",
+                            "version": "1.13"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
+                        },
+                        "from": {
+                            "kind": "DockerImage",
+                            "name": "registry.access.redhat.com/ubi8/openjdk-17:1.13"
+                        }
+                    },
+                    {
+                        "name": "1.14",
+                        "annotations": {
+                            "openshift.io/display-name": "Red Hat OpenJDK 17 (UBI8)",
+                            "description": "Build and run Java applications using Maven and OpenJDK 17 upon UBI8.",
+                            "iconClass": "icon-rh-openjdk",
+                            "tags": "builder,java,openjdk,ubi8,hidden",
+                            "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts",
+                            "sampleContextDir": "undertow-servlet",
+                            "version": "1.14"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
+                        },
+                        "from": {
+                            "kind": "DockerImage",
+                            "name": "registry.access.redhat.com/ubi8/openjdk-17:1.14"
+                        }
+                    },
+                    {
+                        "name": "1.15",
+                        "annotations": {
+                            "openshift.io/display-name": "Red Hat OpenJDK 17 (UBI8)",
+                            "description": "Build and run Java applications using Maven and OpenJDK 17 upon UBI8.",
+                            "iconClass": "icon-rh-openjdk",
+                            "tags": "builder,java,openjdk,ubi8,hidden",
+                            "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts",
+                            "sampleContextDir": "undertow-servlet",
+                            "version": "1.15"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
+                        },
+                        "from": {
+                            "kind": "DockerImage",
+                            "name": "registry.access.redhat.com/ubi8/openjdk-17:1.15"
+                        }
+                    },
+                    {
+                        "name": "1.16",
+                        "annotations": {
+                            "openshift.io/display-name": "Red Hat OpenJDK 17 (UBI8)",
+                            "description": "Build and run Java applications using Maven and OpenJDK 17 upon UBI8.",
+                            "iconClass": "icon-rh-openjdk",
+                            "tags": "builder,java,openjdk,ubi8,hidden",
+                            "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts",
+                            "sampleContextDir": "undertow-servlet",
+                            "version": "1.16"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
+                        },
+                        "from": {
+                            "kind": "DockerImage",
+                            "name": "registry.access.redhat.com/ubi8/openjdk-17:1.16"
                         }
                     }
                 ]

--- a/templates/image-streams.json
+++ b/templates/image-streams.json
@@ -15,21 +15,17 @@
             "metadata": {
                 "name": "redhat-openjdk18-openshift",
                 "annotations": {
-                    "openshift.io/display-name": "Red Hat OpenJDK 8",
-                    "openshift.io/provider-display-name": "Red Hat, Inc.",
-                    "version": "1.4.17"
-                },
-                "labels": {
-                    "xpaas": "1.4.17"
+                    "openshift.io/display-name": "Red Hat OpenJDK 8 (RHEL7)",
+                    "openshift.io/provider-display-name": "Red Hat, Inc."
                 }
             },
             "spec": {
                 "tags": [
-                    {
+                                        {
                         "name": "1.3",
                         "annotations": {
-                            "openshift.io/display-name": "Red Hat OpenJDK 8",
-                            "description": "Build and run Java applications using Maven and OpenJDK 8.",
+                            "openshift.io/display-name": "Red Hat OpenJDK 8 (RHEL7)",
+                            "description": "Build and run Java applications using Maven and OpenJDK 8 upon RHEL7.",
                             "iconClass": "icon-rh-openjdk",
                             "tags": "builder,java,openjdk,hidden",
                             "supports": "java:8",
@@ -42,14 +38,14 @@
                         },
                         "from": {
                             "kind": "DockerImage",
-                            "name": "registry.redhat.io/redhat-openjdk-18/openjdk18-openshift:1.3"
+                            "name": "registry.access.redhat.com/redhat-openjdk-18/openjdk18-openshift:1.3"
                         }
                     },
                     {
                         "name": "1.4",
                         "annotations": {
-                            "openshift.io/display-name": "Red Hat OpenJDK 8",
-                            "description": "Build and run Java applications using Maven and OpenJDK 8.",
+                            "openshift.io/display-name": "Red Hat OpenJDK 8 (RHEL7)",
+                            "description": "Build and run Java applications using Maven and OpenJDK 8 upon RHEL7.",
                             "iconClass": "icon-rh-openjdk",
                             "tags": "builder,java,openjdk,hidden",
                             "supports": "java:8",
@@ -62,14 +58,14 @@
                         },
                         "from": {
                             "kind": "DockerImage",
-                            "name": "registry.redhat.io/redhat-openjdk-18/openjdk18-openshift:1.4"
+                            "name": "registry.access.redhat.com/redhat-openjdk-18/openjdk18-openshift:1.4"
                         }
                     },
                     {
                         "name": "1.5",
                         "annotations": {
-                            "openshift.io/display-name": "Red Hat OpenJDK 8",
-                            "description": "Build and run Java applications using Maven and OpenJDK 8.",
+                            "openshift.io/display-name": "Red Hat OpenJDK 8 (RHEL7)",
+                            "description": "Build and run Java applications using Maven and OpenJDK 8 upon RHEL7.",
                             "iconClass": "icon-rh-openjdk",
                             "tags": "builder,java,openjdk,hidden",
                             "supports": "java:8",
@@ -82,14 +78,14 @@
                         },
                         "from": {
                             "kind": "DockerImage",
-                            "name": "registry.redhat.io/redhat-openjdk-18/openjdk18-openshift:1.5"
+                            "name": "registry.access.redhat.com/redhat-openjdk-18/openjdk18-openshift:1.5"
                         }
                     },
                     {
                         "name": "1.6",
                         "annotations": {
-                            "openshift.io/display-name": "Red Hat OpenJDK 8",
-                            "description": "Build and run Java applications using Maven and OpenJDK 8.",
+                            "openshift.io/display-name": "Red Hat OpenJDK 8 (RHEL7)",
+                            "description": "Build and run Java applications using Maven and OpenJDK 8 upon RHEL7.",
                             "iconClass": "icon-rh-openjdk",
                             "tags": "builder,java,openjdk,hidden",
                             "supports": "java:8",
@@ -102,14 +98,14 @@
                         },
                         "from": {
                             "kind": "DockerImage",
-                            "name": "registry.redhat.io/redhat-openjdk-18/openjdk18-openshift:1.6"
+                            "name": "registry.access.redhat.com/redhat-openjdk-18/openjdk18-openshift:1.6"
                         }
                     },
                     {
                         "name": "1.7",
                         "annotations": {
-                            "openshift.io/display-name": "Red Hat OpenJDK 8",
-                            "description": "Build and run Java applications using Maven and OpenJDK 8.",
+                            "openshift.io/display-name": "Red Hat OpenJDK 8 (RHEL7)",
+                            "description": "Build and run Java applications using Maven and OpenJDK 8 upon RHEL7.",
                             "iconClass": "icon-rh-openjdk",
                             "tags": "builder,java,openjdk,hidden",
                             "supports": "java:8",
@@ -122,14 +118,14 @@
                         },
                         "from": {
                             "kind": "DockerImage",
-                            "name": "registry.redhat.io/redhat-openjdk-18/openjdk18-openshift:1.7"
+                            "name": "registry.access.redhat.com/redhat-openjdk-18/openjdk18-openshift:1.7"
                         }
                     },
                     {
                         "name": "1.8",
                         "annotations": {
-                            "openshift.io/display-name": "Red Hat OpenJDK 8",
-                            "description": "Build and run Java applications using Maven and OpenJDK 8.",
+                            "openshift.io/display-name": "Red Hat OpenJDK 8 (RHEL7)",
+                            "description": "Build and run Java applications using Maven and OpenJDK 8 upon RHEL7.",
                             "iconClass": "icon-rh-openjdk",
                             "tags": "builder,java,openjdk,hidden",
                             "supports": "java:8",
@@ -142,14 +138,14 @@
                         },
                         "from": {
                             "kind": "DockerImage",
-                            "name": "registry.redhat.io/redhat-openjdk-18/openjdk18-openshift:1.8"
+                            "name": "registry.access.redhat.com/redhat-openjdk-18/openjdk18-openshift:1.8"
                         }
                     },
                     {
                         "name": "1.10",
                         "annotations": {
-                            "openshift.io/display-name": "Red Hat OpenJDK 8",
-                            "description": "Build and run Java applications using Maven and OpenJDK 8.",
+                            "openshift.io/display-name": "Red Hat OpenJDK 8 (RHEL7)",
+                            "description": "Build and run Java applications using Maven and OpenJDK 8 upon RHEL7.",
                             "iconClass": "icon-rh-openjdk",
                             "tags": "builder,java,openjdk,hidden",
                             "supports": "java:8",
@@ -162,14 +158,14 @@
                         },
                         "from": {
                             "kind": "DockerImage",
-                            "name": "registry.redhat.io/redhat-openjdk-18/openjdk18-openshift:1.10"
+                            "name": "registry.access.redhat.com/redhat-openjdk-18/openjdk18-openshift:1.10"
                         }
                     },
                     {
                         "name": "1.11",
                         "annotations": {
-                            "openshift.io/display-name": "Red Hat OpenJDK 8",
-                            "description": "Build and run Java applications using Maven and OpenJDK 8.",
+                            "openshift.io/display-name": "Red Hat OpenJDK 8 (RHEL7)",
+                            "description": "Build and run Java applications using Maven and OpenJDK 8 upon RHEL7.",
                             "iconClass": "icon-rh-openjdk",
                             "tags": "builder,java,openjdk,hidden",
                             "supports": "java:8",
@@ -182,14 +178,14 @@
                         },
                         "from": {
                             "kind": "DockerImage",
-                            "name": "registry.redhat.io/redhat-openjdk-18/openjdk18-openshift:1.11"
+                            "name": "registry.access.redhat.com/redhat-openjdk-18/openjdk18-openshift:1.11"
                         }
                     },
                     {
                         "name": "1.12",
                         "annotations": {
-                            "openshift.io/display-name": "Red Hat OpenJDK 8",
-                            "description": "Build and run Java applications using Maven and OpenJDK 8.",
+                            "openshift.io/display-name": "Red Hat OpenJDK 8 (RHEL7)",
+                            "description": "Build and run Java applications using Maven and OpenJDK 8 upon RHEL7.",
                             "iconClass": "icon-rh-openjdk",
                             "tags": "builder,java,openjdk,hidden",
                             "supports": "java:8",
@@ -202,33 +198,28 @@
                         },
                         "from": {
                             "kind": "DockerImage",
-                            "name": "registry.redhat.io/redhat-openjdk-18/openjdk18-openshift:1.12"
+                            "name": "registry.access.redhat.com/redhat-openjdk-18/openjdk18-openshift:1.12"
                         }
                     }
                 ]
             }
-        },
-        {
+        },{
             "kind": "ImageStream",
             "apiVersion": "image.openshift.io/v1",
             "metadata": {
                 "name": "openjdk-11-rhel7",
                 "annotations": {
-                    "openshift.io/display-name": "Red Hat OpenJDK 11",
-                    "openshift.io/provider-display-name": "Red Hat, Inc.",
-                    "version": "1.4.17"
-                },
-                "labels": {
-                    "xpaas": "1.4.17"
+                    "openshift.io/display-name": "Red Hat OpenJDK 11 (RHEL7)",
+                    "openshift.io/provider-display-name": "Red Hat, Inc."
                 }
             },
             "spec": {
                 "tags": [
-                    {
+                                        {
                         "name": "1.0",
                         "annotations": {
-                            "openshift.io/display-name": "Red Hat OpenJDK 11",
-                            "description": "Build and run Java applications using Maven and OpenJDK 11.",
+                            "openshift.io/display-name": "Red Hat OpenJDK 11 (RHEL7)",
+                            "description": "Build and run Java applications using Maven and OpenJDK 11 upon RHEL7.",
                             "iconClass": "icon-rh-openjdk",
                             "tags": "builder,java,openjdk,hidden",
                             "supports": "java:11",
@@ -241,14 +232,14 @@
                         },
                         "from": {
                             "kind": "DockerImage",
-                            "name": "registry.redhat.io/openjdk/openjdk-11-rhel7:1.0"
+                            "name": "registry.access.redhat.com/openjdk/openjdk-11-rhel7:1.0"
                         }
                     },
                     {
                         "name": "1.1",
                         "annotations": {
-                            "openshift.io/display-name": "Red Hat OpenJDK 11",
-                            "description": "Build and run Java applications using Maven and OpenJDK 11.",
+                            "openshift.io/display-name": "Red Hat OpenJDK 11 (RHEL7)",
+                            "description": "Build and run Java applications using Maven and OpenJDK 11 upon RHEL7.",
                             "iconClass": "icon-rh-openjdk",
                             "tags": "builder,java,openjdk,hidden",
                             "supports": "java:11",
@@ -261,14 +252,14 @@
                         },
                         "from": {
                             "kind": "DockerImage",
-                            "name": "registry.redhat.io/openjdk/openjdk-11-rhel7:1.1"
+                            "name": "registry.access.redhat.com/openjdk/openjdk-11-rhel7:1.1"
                         }
                     },
                     {
                         "name": "1.10",
                         "annotations": {
-                            "openshift.io/display-name": "Red Hat OpenJDK 11",
-                            "description": "Build and run Java applications using Maven and OpenJDK 11.",
+                            "openshift.io/display-name": "Red Hat OpenJDK 11 (RHEL7)",
+                            "description": "Build and run Java applications using Maven and OpenJDK 11 upon RHEL7.",
                             "iconClass": "icon-rh-openjdk",
                             "tags": "builder,java,openjdk,hidden",
                             "supports": "java:11",
@@ -281,14 +272,14 @@
                         },
                         "from": {
                             "kind": "DockerImage",
-                            "name": "registry.redhat.io/openjdk/openjdk-11-rhel7:1.10"
+                            "name": "registry.access.redhat.com/openjdk/openjdk-11-rhel7:1.10"
                         }
                     },
                     {
                         "name": "1.11",
                         "annotations": {
-                            "openshift.io/display-name": "Red Hat OpenJDK 11",
-                            "description": "Build and run Java applications using Maven and OpenJDK 11.",
+                            "openshift.io/display-name": "Red Hat OpenJDK 11 (RHEL7)",
+                            "description": "Build and run Java applications using Maven and OpenJDK 11 upon RHEL7.",
                             "iconClass": "icon-rh-openjdk",
                             "tags": "builder,java,openjdk,hidden",
                             "supports": "java:11",
@@ -301,14 +292,14 @@
                         },
                         "from": {
                             "kind": "DockerImage",
-                            "name": "registry.redhat.io/openjdk/openjdk-11-rhel7:1.11"
+                            "name": "registry.access.redhat.com/openjdk/openjdk-11-rhel7:1.11"
                         }
                     },
                     {
                         "name": "1.12",
                         "annotations": {
-                            "openshift.io/display-name": "Red Hat OpenJDK 11",
-                            "description": "Build and run Java applications using Maven and OpenJDK 11.",
+                            "openshift.io/display-name": "Red Hat OpenJDK 11 (RHEL7)",
+                            "description": "Build and run Java applications using Maven and OpenJDK 11 upon RHEL7.",
                             "iconClass": "icon-rh-openjdk",
                             "tags": "builder,java,openjdk,hidden",
                             "supports": "java:11",
@@ -321,33 +312,28 @@
                         },
                         "from": {
                             "kind": "DockerImage",
-                            "name": "registry.redhat.io/openjdk/openjdk-11-rhel7:1.12"
+                            "name": "registry.access.redhat.com/openjdk/openjdk-11-rhel7:1.12"
                         }
                     }
                 ]
             }
-        },
-        {
+        },{
             "kind": "ImageStream",
             "apiVersion": "image.openshift.io/v1",
             "metadata": {
                 "name": "ubi8-openjdk-8",
                 "annotations": {
-                    "openshift.io/display-name": "Red Hat OpenJDK 1.8 (UBI8)",
-                    "openshift.io/provider-display-name": "Red Hat, Inc.",
-                    "version": "1.4.17"
-                },
-                "labels": {
-                    "xpaas": "1.4.17"
+                    "openshift.io/display-name": "Red Hat OpenJDK 8 (UBI8)",
+                    "openshift.io/provider-display-name": "Red Hat, Inc."
                 }
             },
             "spec": {
                 "tags": [
-                    {
+                                        {
                         "name": "1.3",
                         "annotations": {
-                            "openshift.io/display-name": "Red Hat OpenJDK 1.8 (UBI8)",
-                            "description": "Build and run Java applications using Maven and OpenJDK 1.8 upon UBI8.",
+                            "openshift.io/display-name": "Red Hat OpenJDK 8 (UBI8)",
+                            "description": "Build and run Java applications using Maven and OpenJDK 8 upon UBI8.",
                             "iconClass": "icon-rh-openjdk",
                             "tags": "builder,java,openjdk,ubi8,hidden",
                             "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts",
@@ -365,8 +351,8 @@
                     {
                         "name": "1.10",
                         "annotations": {
-                            "openshift.io/display-name": "Red Hat OpenJDK 1.8 (UBI8)",
-                            "description": "Build and run Java applications using Maven and OpenJDK 1.8 upon UBI8.",
+                            "openshift.io/display-name": "Red Hat OpenJDK 8 (UBI8)",
+                            "description": "Build and run Java applications using Maven and OpenJDK 8 upon UBI8.",
                             "iconClass": "icon-rh-openjdk",
                             "tags": "builder,java,openjdk,ubi8,hidden",
                             "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts",
@@ -384,8 +370,8 @@
                     {
                         "name": "1.11",
                         "annotations": {
-                            "openshift.io/display-name": "Red Hat OpenJDK 1.8 (UBI8)",
-                            "description": "Build and run Java applications using Maven and OpenJDK 1.8 upon UBI8.",
+                            "openshift.io/display-name": "Red Hat OpenJDK 8 (UBI8)",
+                            "description": "Build and run Java applications using Maven and OpenJDK 8 upon UBI8.",
                             "iconClass": "icon-rh-openjdk",
                             "tags": "builder,java,openjdk,ubi8,hidden",
                             "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts",
@@ -403,8 +389,8 @@
                     {
                         "name": "1.12",
                         "annotations": {
-                            "openshift.io/display-name": "Red Hat OpenJDK 1.8 (UBI8)",
-                            "description": "Build and run Java applications using Maven and OpenJDK 1.8 upon UBI8.",
+                            "openshift.io/display-name": "Red Hat OpenJDK 8 (UBI8)",
+                            "description": "Build and run Java applications using Maven and OpenJDK 8 upon UBI8.",
                             "iconClass": "icon-rh-openjdk",
                             "tags": "builder,java,openjdk,ubi8,hidden",
                             "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts",
@@ -422,27 +408,23 @@
                 ]
             }
         },
-        {
+{
             "kind": "ImageStream",
             "apiVersion": "image.openshift.io/v1",
             "metadata": {
                 "name": "ubi8-openjdk-11",
                 "annotations": {
                     "openshift.io/display-name": "Red Hat OpenJDK 11 (UBI8)",
-                    "openshift.io/provider-display-name": "Red Hat, Inc.",
-                    "version": "1.4.17"
-                },
-                "labels": {
-                    "xpaas": "1.4.17"
+                    "openshift.io/provider-display-name": "Red Hat, Inc."
                 }
             },
             "spec": {
                 "tags": [
-                    {
+                                        {
                         "name": "1.3",
                         "annotations": {
                             "openshift.io/display-name": "Red Hat OpenJDK 11 (UBI8)",
-                            "description": "Build and run Java applications using Maven and OpenJDK 11 upon RHEL8.",
+                            "description": "Build and run Java applications using Maven and OpenJDK 11 upon UBI8.",
                             "iconClass": "icon-rh-openjdk",
                             "tags": "builder,java,openjdk,ubi8,hidden",
                             "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts",
@@ -461,7 +443,7 @@
                         "name": "1.10",
                         "annotations": {
                             "openshift.io/display-name": "Red Hat OpenJDK 11 (UBI8)",
-                            "description": "Build and run Java applications using Maven and OpenJDK 11 upon RHEL8.",
+                            "description": "Build and run Java applications using Maven and OpenJDK 11 upon UBI8.",
                             "iconClass": "icon-rh-openjdk",
                             "tags": "builder,java,openjdk,ubi8,hidden",
                             "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts",
@@ -480,7 +462,7 @@
                         "name": "1.11",
                         "annotations": {
                             "openshift.io/display-name": "Red Hat OpenJDK 11 (UBI8)",
-                            "description": "Build and run Java applications using Maven and OpenJDK 11 upon RHEL8.",
+                            "description": "Build and run Java applications using Maven and OpenJDK 11 upon UBI8.",
                             "iconClass": "icon-rh-openjdk",
                             "tags": "builder,java,openjdk,ubi8,hidden",
                             "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts",
@@ -499,7 +481,7 @@
                         "name": "1.12",
                         "annotations": {
                             "openshift.io/display-name": "Red Hat OpenJDK 11 (UBI8)",
-                            "description": "Build and run Java applications using Maven and OpenJDK 11 upon RHEL8.",
+                            "description": "Build and run Java applications using Maven and OpenJDK 11 upon UBI8.",
                             "iconClass": "icon-rh-openjdk",
                             "tags": "builder,java,openjdk,ubi8,hidden",
                             "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts",
@@ -517,27 +499,23 @@
                 ]
             }
         },
-        {
+{
             "kind": "ImageStream",
             "apiVersion": "image.openshift.io/v1",
             "metadata": {
                 "name": "ubi8-openjdk-17",
                 "annotations": {
                     "openshift.io/display-name": "Red Hat OpenJDK 17 (UBI8)",
-                    "openshift.io/provider-display-name": "Red Hat, Inc.",
-                    "version": "1.4.17"
-                },
-                "labels": {
-                    "xpaas": "1.4.17"
+                    "openshift.io/provider-display-name": "Red Hat, Inc."
                 }
             },
             "spec": {
                 "tags": [
-                    {
+                                        {
                         "name": "1.11",
                         "annotations": {
                             "openshift.io/display-name": "Red Hat OpenJDK 17 (UBI8)",
-                            "description": "Build and run Java applications using Maven and OpenJDK 17 upon RHEL8.",
+                            "description": "Build and run Java applications using Maven and OpenJDK 17 upon UBI8.",
                             "iconClass": "icon-rh-openjdk",
                             "tags": "builder,java,openjdk,ubi8,hidden",
                             "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts",
@@ -556,7 +534,7 @@
                         "name": "1.12",
                         "annotations": {
                             "openshift.io/display-name": "Red Hat OpenJDK 17 (UBI8)",
-                            "description": "Build and run Java applications using Maven and OpenJDK 17 upon RHEL8.",
+                            "description": "Build and run Java applications using Maven and OpenJDK 17 upon UBI8.",
                             "iconClass": "icon-rh-openjdk",
                             "tags": "builder,java,openjdk,ubi8,hidden",
                             "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts",
@@ -573,8 +551,7 @@
                     }
                 ]
             }
-        },
-        {
+        },{
             "kind": "ImageStream",
             "apiVersion": "image.openshift.io/v1",
             "metadata": {

--- a/templates/runtime-image-streams.json
+++ b/templates/runtime-image-streams.json
@@ -92,6 +92,78 @@
                             "kind": "DockerImage",
                             "name": "registry.access.redhat.com/ubi8/openjdk-8-runtime:1.12"
                         }
+                    },
+                    {
+                        "name": "1.13",
+                        "annotations": {
+                            "openshift.io/display-name": "Red Hat OpenJDK 8 Runtime (UBI8)",
+                            "description": "Run Java applications using OpenJDK 8 upon UBI8.",
+                            "iconClass": "icon-rh-openjdk",
+                            "tags": "java,openjdk,ubi8",
+                            
+                            "version": "1.13"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
+                        },
+                        "from": {
+                            "kind": "DockerImage",
+                            "name": "registry.access.redhat.com/ubi8/openjdk-8-runtime:1.13"
+                        }
+                    },
+                    {
+                        "name": "1.14",
+                        "annotations": {
+                            "openshift.io/display-name": "Red Hat OpenJDK 8 Runtime (UBI8)",
+                            "description": "Run Java applications using OpenJDK 8 upon UBI8.",
+                            "iconClass": "icon-rh-openjdk",
+                            "tags": "java,openjdk,ubi8",
+                            
+                            "version": "1.14"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
+                        },
+                        "from": {
+                            "kind": "DockerImage",
+                            "name": "registry.access.redhat.com/ubi8/openjdk-8-runtime:1.14"
+                        }
+                    },
+                    {
+                        "name": "1.15",
+                        "annotations": {
+                            "openshift.io/display-name": "Red Hat OpenJDK 8 Runtime (UBI8)",
+                            "description": "Run Java applications using OpenJDK 8 upon UBI8.",
+                            "iconClass": "icon-rh-openjdk",
+                            "tags": "java,openjdk,ubi8",
+                            
+                            "version": "1.15"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
+                        },
+                        "from": {
+                            "kind": "DockerImage",
+                            "name": "registry.access.redhat.com/ubi8/openjdk-8-runtime:1.15"
+                        }
+                    },
+                    {
+                        "name": "1.16",
+                        "annotations": {
+                            "openshift.io/display-name": "Red Hat OpenJDK 8 Runtime (UBI8)",
+                            "description": "Run Java applications using OpenJDK 8 upon UBI8.",
+                            "iconClass": "icon-rh-openjdk",
+                            "tags": "java,openjdk,ubi8",
+                            
+                            "version": "1.16"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
+                        },
+                        "from": {
+                            "kind": "DockerImage",
+                            "name": "registry.access.redhat.com/ubi8/openjdk-8-runtime:1.16"
+                        }
                     }
                 ]
             }
@@ -179,6 +251,78 @@
                             "kind": "DockerImage",
                             "name": "registry.access.redhat.com/ubi8/openjdk-11-runtime:1.12"
                         }
+                    },
+                    {
+                        "name": "1.13",
+                        "annotations": {
+                            "openshift.io/display-name": "Red Hat OpenJDK 11 Runtime (UBI8)",
+                            "description": "Run Java applications using OpenJDK 11 upon UBI8.",
+                            "iconClass": "icon-rh-openjdk",
+                            "tags": "java,openjdk,ubi8",
+                            
+                            "version": "1.13"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
+                        },
+                        "from": {
+                            "kind": "DockerImage",
+                            "name": "registry.access.redhat.com/ubi8/openjdk-11-runtime:1.13"
+                        }
+                    },
+                    {
+                        "name": "1.14",
+                        "annotations": {
+                            "openshift.io/display-name": "Red Hat OpenJDK 11 Runtime (UBI8)",
+                            "description": "Run Java applications using OpenJDK 11 upon UBI8.",
+                            "iconClass": "icon-rh-openjdk",
+                            "tags": "java,openjdk,ubi8",
+                            
+                            "version": "1.14"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
+                        },
+                        "from": {
+                            "kind": "DockerImage",
+                            "name": "registry.access.redhat.com/ubi8/openjdk-11-runtime:1.14"
+                        }
+                    },
+                    {
+                        "name": "1.15",
+                        "annotations": {
+                            "openshift.io/display-name": "Red Hat OpenJDK 11 Runtime (UBI8)",
+                            "description": "Run Java applications using OpenJDK 11 upon UBI8.",
+                            "iconClass": "icon-rh-openjdk",
+                            "tags": "java,openjdk,ubi8",
+                            
+                            "version": "1.15"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
+                        },
+                        "from": {
+                            "kind": "DockerImage",
+                            "name": "registry.access.redhat.com/ubi8/openjdk-11-runtime:1.15"
+                        }
+                    },
+                    {
+                        "name": "1.16",
+                        "annotations": {
+                            "openshift.io/display-name": "Red Hat OpenJDK 11 Runtime (UBI8)",
+                            "description": "Run Java applications using OpenJDK 11 upon UBI8.",
+                            "iconClass": "icon-rh-openjdk",
+                            "tags": "java,openjdk,ubi8",
+                            
+                            "version": "1.16"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
+                        },
+                        "from": {
+                            "kind": "DockerImage",
+                            "name": "registry.access.redhat.com/ubi8/openjdk-11-runtime:1.16"
+                        }
                     }
                 ]
             }
@@ -229,6 +373,78 @@
                         "from": {
                             "kind": "DockerImage",
                             "name": "registry.access.redhat.com/ubi8/openjdk-17-runtime:1.12"
+                        }
+                    },
+                    {
+                        "name": "1.13",
+                        "annotations": {
+                            "openshift.io/display-name": "Red Hat OpenJDK 17 Runtime (UBI8)",
+                            "description": "Run Java applications using OpenJDK 17 upon UBI8.",
+                            "iconClass": "icon-rh-openjdk",
+                            "tags": "java,openjdk,ubi8",
+                            
+                            "version": "1.13"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
+                        },
+                        "from": {
+                            "kind": "DockerImage",
+                            "name": "registry.access.redhat.com/ubi8/openjdk-17-runtime:1.13"
+                        }
+                    },
+                    {
+                        "name": "1.14",
+                        "annotations": {
+                            "openshift.io/display-name": "Red Hat OpenJDK 17 Runtime (UBI8)",
+                            "description": "Run Java applications using OpenJDK 17 upon UBI8.",
+                            "iconClass": "icon-rh-openjdk",
+                            "tags": "java,openjdk,ubi8",
+                            
+                            "version": "1.14"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
+                        },
+                        "from": {
+                            "kind": "DockerImage",
+                            "name": "registry.access.redhat.com/ubi8/openjdk-17-runtime:1.14"
+                        }
+                    },
+                    {
+                        "name": "1.15",
+                        "annotations": {
+                            "openshift.io/display-name": "Red Hat OpenJDK 17 Runtime (UBI8)",
+                            "description": "Run Java applications using OpenJDK 17 upon UBI8.",
+                            "iconClass": "icon-rh-openjdk",
+                            "tags": "java,openjdk,ubi8",
+                            
+                            "version": "1.15"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
+                        },
+                        "from": {
+                            "kind": "DockerImage",
+                            "name": "registry.access.redhat.com/ubi8/openjdk-17-runtime:1.15"
+                        }
+                    },
+                    {
+                        "name": "1.16",
+                        "annotations": {
+                            "openshift.io/display-name": "Red Hat OpenJDK 17 Runtime (UBI8)",
+                            "description": "Run Java applications using OpenJDK 17 upon UBI8.",
+                            "iconClass": "icon-rh-openjdk",
+                            "tags": "java,openjdk,ubi8",
+                            
+                            "version": "1.16"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
+                        },
+                        "from": {
+                            "kind": "DockerImage",
+                            "name": "registry.access.redhat.com/ubi8/openjdk-17-runtime:1.16"
                         }
                     }
                 ]

--- a/templates/runtime-image-streams.json
+++ b/templates/runtime-image-streams.json
@@ -15,19 +15,20 @@
             "metadata": {
                 "name": "ubi8-openjdk-8-runtime",
                 "annotations": {
-                    "openshift.io/display-name": "Red Hat OpenJDK 1.8 Runtime (UBI8)",
+                    "openshift.io/display-name": "Red Hat OpenJDK 8 Runtime (UBI8)",
                     "openshift.io/provider-display-name": "Red Hat, Inc."
                 }
             },
             "spec": {
                 "tags": [
-                    {
+                                        {
                         "name": "1.9",
                         "annotations": {
-                            "openshift.io/display-name": "Red Hat OpenJDK 1.8 Runtime (UBI8)",
-                            "description": "Run Java applications using OpenJDK 1.8 upon UBI8.",
+                            "openshift.io/display-name": "Red Hat OpenJDK 8 Runtime (UBI8)",
+                            "description": "Run Java applications using OpenJDK 8 upon UBI8.",
                             "iconClass": "icon-rh-openjdk",
                             "tags": "java,openjdk,ubi8",
+                            
                             "version": "1.9"
                         },
                         "referencePolicy": {
@@ -41,10 +42,11 @@
                     {
                         "name": "1.10",
                         "annotations": {
-                            "openshift.io/display-name": "Red Hat OpenJDK 1.8 Runtime (UBI8)",
-                            "description": "Run Java applications using OpenJDK 1.8 upon UBI8.",
+                            "openshift.io/display-name": "Red Hat OpenJDK 8 Runtime (UBI8)",
+                            "description": "Run Java applications using OpenJDK 8 upon UBI8.",
                             "iconClass": "icon-rh-openjdk",
                             "tags": "java,openjdk,ubi8",
+                            
                             "version": "1.10"
                         },
                         "referencePolicy": {
@@ -58,10 +60,11 @@
                     {
                         "name": "1.11",
                         "annotations": {
-                            "openshift.io/display-name": "Red Hat OpenJDK 1.8 Runtime (UBI8)",
-                            "description": "Run Java applications using OpenJDK 1.8 upon UBI8.",
+                            "openshift.io/display-name": "Red Hat OpenJDK 8 Runtime (UBI8)",
+                            "description": "Run Java applications using OpenJDK 8 upon UBI8.",
                             "iconClass": "icon-rh-openjdk",
                             "tags": "java,openjdk,ubi8",
+                            
                             "version": "1.11"
                         },
                         "referencePolicy": {
@@ -75,10 +78,11 @@
                     {
                         "name": "1.12",
                         "annotations": {
-                            "openshift.io/display-name": "Red Hat OpenJDK 1.8 Runtime (UBI8)",
-                            "description": "Run Java applications using OpenJDK 1.8 upon UBI8.",
+                            "openshift.io/display-name": "Red Hat OpenJDK 8 Runtime (UBI8)",
+                            "description": "Run Java applications using OpenJDK 8 upon UBI8.",
                             "iconClass": "icon-rh-openjdk",
                             "tags": "java,openjdk,ubi8",
+                            
                             "version": "1.12"
                         },
                         "referencePolicy": {
@@ -92,7 +96,7 @@
                 ]
             }
         },
-        {
+{
             "kind": "ImageStream",
             "apiVersion": "image.openshift.io/v1",
             "metadata": {
@@ -104,15 +108,14 @@
             },
             "spec": {
                 "tags": [
-                    {
+                                        {
                         "name": "1.9",
                         "annotations": {
                             "openshift.io/display-name": "Red Hat OpenJDK 11 Runtime (UBI8)",
-                            "description": "Run Java applications using OpenJDK 11 upon RHEL8.",
+                            "description": "Run Java applications using OpenJDK 11 upon UBI8.",
                             "iconClass": "icon-rh-openjdk",
                             "tags": "java,openjdk,ubi8",
-                            "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts",
-                            "sampleContextDir": "undertow-servlet",
+                            
                             "version": "1.9"
                         },
                         "referencePolicy": {
@@ -127,11 +130,10 @@
                         "name": "1.10",
                         "annotations": {
                             "openshift.io/display-name": "Red Hat OpenJDK 11 Runtime (UBI8)",
-                            "description": "Run Java applications using OpenJDK 11 upon RHEL8.",
+                            "description": "Run Java applications using OpenJDK 11 upon UBI8.",
                             "iconClass": "icon-rh-openjdk",
                             "tags": "java,openjdk,ubi8",
-                            "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts",
-                            "sampleContextDir": "undertow-servlet",
+                            
                             "version": "1.10"
                         },
                         "referencePolicy": {
@@ -146,11 +148,10 @@
                         "name": "1.11",
                         "annotations": {
                             "openshift.io/display-name": "Red Hat OpenJDK 11 Runtime (UBI8)",
-                            "description": "Run Java applications using OpenJDK 11 upon RHEL8.",
+                            "description": "Run Java applications using OpenJDK 11 upon UBI8.",
                             "iconClass": "icon-rh-openjdk",
                             "tags": "java,openjdk,ubi8",
-                            "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts",
-                            "sampleContextDir": "undertow-servlet",
+                            
                             "version": "1.11"
                         },
                         "referencePolicy": {
@@ -165,11 +166,10 @@
                         "name": "1.12",
                         "annotations": {
                             "openshift.io/display-name": "Red Hat OpenJDK 11 Runtime (UBI8)",
-                            "description": "Run Java applications using OpenJDK 11 upon RHEL8.",
+                            "description": "Run Java applications using OpenJDK 11 upon UBI8.",
                             "iconClass": "icon-rh-openjdk",
                             "tags": "java,openjdk,ubi8",
-                            "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts",
-                            "sampleContextDir": "undertow-servlet",
+                            
                             "version": "1.12"
                         },
                         "referencePolicy": {
@@ -183,7 +183,7 @@
                 ]
             }
         },
-        {
+{
             "kind": "ImageStream",
             "apiVersion": "image.openshift.io/v1",
             "metadata": {
@@ -195,15 +195,14 @@
             },
             "spec": {
                 "tags": [
-                    {
+                                        {
                         "name": "1.11",
                         "annotations": {
                             "openshift.io/display-name": "Red Hat OpenJDK 17 Runtime (UBI8)",
-                            "description": "Run Java applications using OpenJDK 17 upon RHEL8.",
+                            "description": "Run Java applications using OpenJDK 17 upon UBI8.",
                             "iconClass": "icon-rh-openjdk",
                             "tags": "java,openjdk,ubi8",
-                            "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts",
-                            "sampleContextDir": "undertow-servlet",
+                            
                             "version": "1.11"
                         },
                         "referencePolicy": {
@@ -218,11 +217,10 @@
                         "name": "1.12",
                         "annotations": {
                             "openshift.io/display-name": "Red Hat OpenJDK 17 Runtime (UBI8)",
-                            "description": "Run Java applications using OpenJDK 17 upon RHEL8.",
+                            "description": "Run Java applications using OpenJDK 17 upon UBI8.",
                             "iconClass": "icon-rh-openjdk",
                             "tags": "java,openjdk,ubi8",
-                            "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts",
-                            "sampleContextDir": "undertow-servlet",
+                            
                             "version": "1.12"
                         },
                         "referencePolicy": {
@@ -235,8 +233,7 @@
                     }
                 ]
             }
-        },
-        {
+        },{
             "kind": "ImageStream",
             "apiVersion": "image.openshift.io/v1",
             "metadata": {

--- a/templates/templates/community-javaImageStream.jinja
+++ b/templates/templates/community-javaImageStream.jinja
@@ -1,0 +1,135 @@
+        {
+            "kind": "ImageStream",
+            "apiVersion": "image.openshift.io/v1",
+            "metadata": {
+                "name": "java",
+                "annotations": {
+                    "openshift.io/display-name": "Red Hat OpenJDK",
+                    "openshift.io/provider-display-name": "Red Hat, Inc."
+                }
+            },
+            "spec": {
+                "tags": [
+                    {
+                        "name": "openjdk-8-ubi8",
+                        "annotations": {
+                            "openshift.io/display-name": "Red Hat OpenJDK 8 (UBI 8)",
+                            "description": "Build and run Java applications using Maven and OpenJDK 1.8 upon UBI8.",
+                            "iconClass": "icon-rh-openjdk",
+                            "tags": "builder,java,openjdk",
+                            "supports": "java:8,java",
+                            "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts",
+                            "sampleContextDir": "undertow-servlet",
+                            "version": "8"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
+                        },
+                        "from": {
+                            "kind": "DockerImage",
+                            "name": "registry.access.redhat.com/ubi8/openjdk-8:latest"
+                        }
+                    },
+                    {
+                        "name": "8",
+                        "annotations": {
+                            "openshift.io/display-name": "Red Hat OpenJDK 8",
+                            "description": "Build and run Java applications using Maven and OpenJDK 1.8 upon UBI8.",
+                            "iconClass": "icon-rh-openjdk",
+                            "tags": "builder,java,openjdk,hidden",
+                            "supports": "java:8,java",
+                            "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts",
+                            "sampleContextDir": "undertow-servlet",
+                            "version": "8"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
+                        },
+                        "from": {
+                            "kind": "DockerImage",
+                            "name": "registry.access.redhat.com/ubi8/openjdk-8:latest"
+                        }
+                    },
+                    {
+                        "name": "openjdk-11-ubi8",
+                        "annotations": {
+                            "openshift.io/display-name": "Red Hat OpenJDK 11 (UBI 8)",
+                            "description": "Build and run Java applications using Maven and OpenJDK 11 upon UBI8.",
+                            "iconClass": "icon-rh-openjdk",
+                            "tags": "builder,java,openjdk",
+                            "supports": "java:11,java",
+                            "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts",
+                            "sampleContextDir": "undertow-servlet",
+                            "version": "11"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
+                        },
+                        "from": {
+                            "kind": "DockerImage",
+                            "name": "registry.access.redhat.com/ubi8/openjdk-11:latest"
+                        }
+                    },
+                    {
+                        "name": "11",
+                        "annotations": {
+                            "openshift.io/display-name": "Red Hat OpenJDK 11",
+                            "description": "Build and run Java applications using Maven and OpenJDK 11 upon UBI8.",
+                            "iconClass": "icon-rh-openjdk",
+                            "tags": "builder,java,openjdk,hidden",
+                            "supports": "java:11,java",
+                            "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts",
+                            "sampleContextDir": "undertow-servlet",
+                            "version": "11"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
+                        },
+                        "from": {
+                            "kind": "DockerImage",
+                            "name": "registry.access.redhat.com/ubi8/openjdk-11:latest"
+                        }
+                    },
+                    {
+                        "name": "openjdk-17-ubi8",
+                        "annotations": {
+                            "openshift.io/display-name": "Red Hat OpenJDK 17 (UBI 8)",
+                            "description": "Build and run Java applications using Maven and OpenJDK 17 upon UBI8.",
+                            "iconClass": "icon-rh-openjdk",
+                            "tags": "builder,java,openjdk",
+                            "supports": "java:17,java",
+                            "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts",
+                            "sampleContextDir": "undertow-servlet",
+                            "version": "17"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
+                        },
+                        "from": {
+                            "kind": "DockerImage",
+                            "name": "registry.access.redhat.com/ubi8/openjdk-17:latest"
+                        }
+                    },
+                    {
+                        "name": "latest",
+                        "annotations": {
+                            "openshift.io/display-name": "Java (Latest)",
+                            "description": "Build and run Java applications using Maven.",
+                            "iconClass": "icon-rh-openjdk",
+                            "tags": "builder,java,openjdk",
+                            "supports": "java",
+                            "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts",
+                            "sampleContextDir": "undertow-servlet",
+                            "version": "latest"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
+                        },
+                        "from": {
+                            "kind": "ImageStreamTag",
+                            "name": "openjdk-17-ubi8"
+                        }
+                    }
+                ]
+            }
+        }

--- a/templates/templates/imagestream.jinja
+++ b/templates/templates/imagestream.jinja
@@ -1,0 +1,16 @@
+{
+            "kind": "ImageStream",
+            "apiVersion": "image.openshift.io/v1",
+            "metadata": {
+                "name": {% if name %}"{{name}}"{% else %}"{{rhel}}-openjdk-{{openjdk}}"{% endif %},
+                "annotations": {
+                    "openshift.io/display-name": "{% if displayName %}{{displayName}}{% else %}Red Hat OpenJDK {{openjdk}} ({{ rhel.upper() }}){% endif %}",
+                    "openshift.io/provider-display-name": "Red Hat, Inc."
+                }
+            },
+            "spec": {
+                "tags": [
+                    {{tags}}
+                ]
+            }
+        }

--- a/templates/templates/java-runtimeImageStream.jinja
+++ b/templates/templates/java-runtimeImageStream.jinja
@@ -1,0 +1,87 @@
+{
+            "kind": "ImageStream",
+            "apiVersion": "image.openshift.io/v1",
+            "metadata": {
+                "name": "java-runtime",
+                "annotations": {
+                    "openshift.io/display-name": "Red Hat OpenJDK Runtime",
+                    "openshift.io/provider-display-name": "Red Hat, Inc."
+                }
+            },
+            "spec": {
+                "tags": [
+                    {
+                        "name": "openjdk-8-ubi8",
+                        "annotations": {
+                            "openshift.io/display-name": "Red Hat OpenJDK 1.8 Runtime (UBI8)",
+                            "description": "Run Java applications using OpenJDK 1.8 upon UBI8.",
+                            "iconClass": "icon-rh-openjdk",
+                            "tags": "java:8,openjdk,ubi8",
+                            "version": "8"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
+                        },
+                        "from": {
+                            "kind": "DockerImage",
+                            "name": "registry.access.redhat.com/ubi8/openjdk-8-runtime:latest"
+                        }
+                    },
+                    {
+                        "name": "openjdk-11-ubi8",
+                        "annotations": {
+                            "openshift.io/display-name": "Red Hat OpenJDK 11 Runtime (UBI8)",
+                            "description": "Run Java applications using OpenJDK 11 upon UBI8.",
+                            "iconClass": "icon-rh-openjdk",
+                            "tags": "java:11,openjdk,ubi8",
+                            "version": "11"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
+                        },
+                        "from": {
+                            "kind": "DockerImage",
+                            "name": "registry.access.redhat.com/ubi8/openjdk-11-runtime:latest"
+                        }
+                    },
+                    {
+                        "name": "openjdk-17-ubi8",
+                        "annotations": {
+                            "openshift.io/display-name": "Red Hat OpenJDK 17 Runtime (UBI8)",
+                            "description": "Run Java applications using OpenJDK 17 upon RHEL8.",
+                            "iconClass": "icon-rh-openjdk",
+                            "tags": "java:17,openjdk,ubi8",
+                            "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts",
+                            "sampleContextDir": "undertow-servlet",
+                            "version": "17"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
+                        },
+                        "from": {
+                            "kind": "DockerImage",
+                            "name": "registry.access.redhat.com/ubi8/openjdk-17-runtime:latest"
+                        }
+                    },
+                    {
+                        "name": "latest",
+                        "annotations": {
+                            "openshift.io/display-name": "Java Runtime (Latest)",
+                            "iconClass": "icon-rh-openjdk",
+                            "tags": "java,openjdk",
+                            "supports": "java",
+                            "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts",
+                            "sampleContextDir": "undertow-servlet",
+                            "version": "latest"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
+                        },
+                        "from": {
+                            "kind": "ImageStreamTag",
+                            "name": "openjdk-17-ubi8"
+                        }
+                    }
+                ]
+            }
+        }

--- a/templates/templates/javaImageStream.jinja
+++ b/templates/templates/javaImageStream.jinja
@@ -1,0 +1,179 @@
+{
+            "kind": "ImageStream",
+            "apiVersion": "image.openshift.io/v1",
+            "metadata": {
+                "name": "java",
+                "annotations": {
+                    "openshift.io/display-name": "Red Hat OpenJDK",
+                    "openshift.io/provider-display-name": "Red Hat, Inc.",
+                    "version": "1.4.17"
+                },
+                "labels": {
+                    "xpaas": "1.4.17"
+                }
+            },
+            "spec": {
+                "tags": [
+                    {
+                        "name": "openjdk-8-ubi8",
+                        "annotations": {
+                            "openshift.io/display-name": "Red Hat OpenJDK 8 (UBI 8)",
+                            "description": "Build and run Java applications using Maven and OpenJDK 8.",
+                            "iconClass": "icon-rh-openjdk",
+                            "tags": "builder,java,openjdk",
+                            "supports": "java:8,java",
+                            "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts",
+                            "sampleContextDir": "undertow-servlet",
+                            "version": "8"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
+                        },
+                        "from": {
+                            "kind": "DockerImage",
+                            "name": "registry.redhat.io/ubi8/openjdk-8:latest"
+                        }
+                    },
+                    {
+                        "name": "openjdk-8-el7",
+                        "annotations": {
+                            "openshift.io/display-name": "Red Hat OpenJDK 8 (RHEL 7)",
+                            "description": "Build and run Java applications using Maven and OpenJDK 8.",
+                            "iconClass": "icon-rh-openjdk",
+                            "tags": "builder,java,openjdk",
+                            "supports": "java:8,java",
+                            "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts",
+                            "sampleContextDir": "undertow-servlet",
+                            "version": "8"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
+                        },
+                        "from": {
+                            "kind": "DockerImage",
+                            "name": "registry.redhat.io/redhat-openjdk-18/openjdk18-openshift:latest"
+                        }
+                    },
+                    {
+                        "name": "8",
+                        "annotations": {
+                            "openshift.io/display-name": "Red Hat OpenJDK 8",
+                            "description": "Build and run Java applications using Maven and OpenJDK 8.",
+                            "iconClass": "icon-rh-openjdk",
+                            "tags": "builder,java,openjdk,hidden",
+                            "supports": "java:8,java",
+                            "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts",
+                            "sampleContextDir": "undertow-servlet",
+                            "version": "8"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
+                        },
+                        "from": {
+                            "kind": "DockerImage",
+                            "name": "registry.redhat.io/redhat-openjdk-18/openjdk18-openshift:latest"
+                        }
+                    },
+                    {
+                        "name": "openjdk-11-ubi8",
+                        "annotations": {
+                            "openshift.io/display-name": "Red Hat OpenJDK 11 (UBI 8)",
+                            "description": "Build and run Java applications using Maven and OpenJDK 11.",
+                            "iconClass": "icon-rh-openjdk",
+                            "tags": "builder,java,openjdk",
+                            "supports": "java:11,java",
+                            "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts",
+                            "sampleContextDir": "undertow-servlet",
+                            "version": "11"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
+                        },
+                        "from": {
+                            "kind": "DockerImage",
+                            "name": "registry.redhat.io/ubi8/openjdk-11:latest"
+                        }
+                    },
+                    {
+                        "name": "openjdk-11-el7",
+                        "annotations": {
+                            "openshift.io/display-name": "Red Hat OpenJDK 11 (RHEL 7)",
+                            "description": "Build and run Java applications using Maven and OpenJDK 11.",
+                            "iconClass": "icon-rh-openjdk",
+                            "tags": "builder,java,openjdk",
+                            "supports": "java:11,java",
+                            "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts",
+                            "sampleContextDir": "undertow-servlet",
+                            "version": "11"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
+                        },
+                        "from": {
+                            "kind": "DockerImage",
+                            "name": "registry.redhat.io/openjdk/openjdk-11-rhel7:latest"
+                        }
+                    },
+                    {
+                        "name": "11",
+                        "annotations": {
+                            "openshift.io/display-name": "Red Hat OpenJDK 11",
+                            "description": "Build and run Java applications using Maven and OpenJDK 11.",
+                            "iconClass": "icon-rh-openjdk",
+                            "tags": "builder,java,openjdk,hidden",
+                            "supports": "java:11,java",
+                            "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts",
+                            "sampleContextDir": "undertow-servlet",
+                            "version": "11"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
+                        },
+                        "from": {
+                            "kind": "DockerImage",
+                            "name": "registry.redhat.io/openjdk/openjdk-11-rhel7:latest"
+                        }
+                    },
+                    {
+                        "name": "openjdk-17-ubi8",
+                        "annotations": {
+                            "openshift.io/display-name": "Red Hat OpenJDK 17 (UBI 8)",
+                            "description": "Build and run Java applications using Maven and OpenJDK 17.",
+                            "iconClass": "icon-rh-openjdk",
+                            "tags": "builder,java,openjdk",
+                            "supports": "java:17,java",
+                            "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts",
+                            "sampleContextDir": "undertow-servlet",
+                            "version": "17"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
+                        },
+                        "from": {
+                            "kind": "DockerImage",
+                            "name": "registry.redhat.io/ubi8/openjdk-17:latest"
+                        }
+                    },
+                    {
+                        "name": "latest",
+                        "annotations": {
+                            "openshift.io/display-name": "Java (Latest)",
+                            "description": "Build and run Java applications using Maven.",
+                            "iconClass": "icon-rh-openjdk",
+                            "tags": "builder,java,openjdk",
+                            "supports": "java",
+                            "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts",
+                            "sampleContextDir": "undertow-servlet",
+                            "version": "latest"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
+                        },
+                        "from": {
+                            "kind": "ImageStreamTag",
+                            "name": "openjdk-17-ubi8"
+                        }
+                    }
+                ]
+            }
+        }

--- a/templates/templates/tag.jinja
+++ b/templates/templates/tag.jinja
@@ -1,0 +1,21 @@
+                    {
+                        "name": {%if name %}"{{name}}"{% else %}"{{version}}"{% endif %},
+                        "annotations": {
+                            "openshift.io/display-name": "{% if displayName %}{{displayName}}{% else %}Red Hat OpenJDK {{openjdk}} ({{rhel.upper()}}){% endif %}",
+                            "description": "{% if description %}{{description}}{% else %}Build and run Java applications using Maven and OpenJDK {{openjdk}} upon {{rhel.upper()}}.{% endif %}",
+                            "iconClass": "icon-rh-openjdk",
+                            "tags": "{% if tags %}{{tags}}{% else %}builder,java,openjdk,{{rhel}}{% endif %}",
+                            {% if supports %}"supports": "{{supports}}",
+                            {% endif %}{% if sampleRepo
+                            %}"sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts",
+                            "sampleContextDir": "undertow-servlet",{% endif %}
+                            "version": "{{version}}"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
+                        },
+                        "from": {%if from_ %}{{from_}}{% else %}{
+                            "kind": "DockerImage",
+                            "name": "registry.access.redhat.com/{{containerName}}:{{tag}}"
+                        }{% endif %}
+                    }

--- a/templates/templates/template.jinja
+++ b/templates/templates/template.jinja
@@ -1,0 +1,14 @@
+{
+    "kind": "List",
+    "apiVersion": "v1",
+    "metadata": {
+        "name": "{% if name %}{{name}}{% else %}{{rhel}}-openjdk-image-stream{% endif %}",
+        "annotations": {
+            "description": "{% if description %}{{description}}{% else %}ImageStream definition for Red Hat {{rhel.upper() }} OpenJDK.{% endif %}",
+            "openshift.io/provider-display-name": "Red Hat, Inc."
+        }
+    },
+    "items": [
+        {{items}}
+    ]
+}


### PR DESCRIPTION
https://issues.redhat.com/browse/OPENJDK-2048

This PR adds a Python script* which generates the ImageStream template files in `templates/*` using data on version ranges, architecture exceptions, etc. from `data.yaml`.

I've split the PR up into 5 commits to make review easier.

1. First we add a very simple GitHub Action to verify the templates are valid JSON (pass them through jq)
2. The generator script (`templates/generateImageStreamTemplates.py`), its data source (`templates/data.yaml`) and template snippets (`templates/templates/*`) are added. The data source is configured to match the versions that are included in the _current templates_.
3. Commit the result of running the script. There are some differences from the static templates, documented in the commit message.
4. Update `data.yaml` to reflect the current latest shipped version of the containers. (The original templates were out of date, which motivated this PR.)
5. Commit the result of running the script again: New Image versions are appended in the right places

Fixes #270.

_* using the same libraries as Cekit, to maximize the chance other folks might work on this in future._