### PR TITLE
[OPENJDK-1549] reference main repo/branch in test

### DIFF
--- a/tests/features/java/java_s2i.feature
+++ b/tests/features/java/java_s2i.feature
@@ -168,6 +168,6 @@ Feature: Openshift OpenJDK S2I tests
     Then XML file /tmp/artifacts/configuration/settings.xml should have 1 elements on XPath //ns:profile[ns:id='myrepo-profile']/ns:repositories/ns:repository[ns:url='http://repo.example.com:8080/maven2/']
 
   Scenario: Ensure the environment is cleaned when executing mvn (OPENJDK-1549)
-      Given s2i build https://github.com/jmtd/openjdk from tests/OPENJDK-1549 with env using OPENJDK-1549-maven-args-take-2
+      Given s2i build https://github.com/jboss-container-images/openjdk from tests/OPENJDK-1549 with env using ubi9
        | variable           | value    |
        | MAVEN_ARGS         | validate |


### PR DESCRIPTION
Now that the PR that introduced tests/OPENJDK-1549 exists in the ubi9 branch, we can reference the main repository and ubi9 branch in the behave test.

https://issues.redhat.com/browse/OPENJDK-1549