### PR TITLE
[OPENJDK-1548] [rhel-8] unset MAVEN_ARGS for Maven (and OPENJDK-2068, OPENJDK-2069)

### DIFF
--- a/modules/maven/default/artifacts/opt/jboss/container/maven/default/maven.sh
+++ b/modules/maven/default/artifacts/opt/jboss/container/maven/default/maven.sh
@@ -81,8 +81,11 @@ function maven_build() {
   log_info "Using MAVEN_OPTS ${MAVEN_OPTS}"
   log_info "Using $(mvn $MAVEN_ARGS --version)"
   log_info "Running 'mvn $MAVEN_ARGS $goals'"
-  # Execute the actual build
-  mvn $MAVEN_ARGS $goals
+
+  # Execute the actual build (ensuring MAVEN_ARGS is unset, OPENJDK-1548)
+  REAL_MAVEN_ARGS="$MAVEN_ARGS"
+  unset MAVEN_ARGS
+  mvn $REAL_MAVEN_ARGS $goals
   
   popd &> /dev/null
   

--- a/tests/OPENJDK-1548/README.md
+++ b/tests/OPENJDK-1548/README.md
@@ -1,0 +1,18 @@
+# Test for OPENJDK-1548
+
+<https://issues.redhat.com/browse/OPENJDK-1548>
+
+This is a minimal Maven project for which the `validate` target will fail
+if the environment variable `MAVEN_ARGS` is defined.
+
+This is achieved using the Enforcer plugin. We could not use the
+`requireEnvironmentVariable` built-in rule as it can only fail if a variable
+is undefined, rather than if it is. Instead we use `evaluateBeanshell` and
+a very short Beanshell expression.
+
+Maven expands strings of the form `${env.foo}` within the POM only if the
+variable is defined. That is, when `MAVEN_ARGS` is not defined in the
+environment, the string `${env.MAVEN_ARGS}` is passed through unaltered.
+If the variable is defined (including defined but empty), Maven will expand
+it. Some string concatenation trickery is needed to match against the
+un-expanded form.

--- a/tests/OPENJDK-1548/pom.xml
+++ b/tests/OPENJDK-1548/pom.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project>
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>org.acme</groupId>
+  <artifactId>getting-started</artifactId>
+  <version>1.0.0-SNAPSHOT</version>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-enforcer-plugin</artifactId>
+        <version>3.3.0</version>
+        <executions>
+
+          <!-- ensure the environment variable MAVEN_ARGS is unset -->
+          <execution>
+            <id>enforce-beanshell</id>
+            <goals>
+              <goal>enforce</goal>
+            </goals>
+            <configuration>
+              <rules>
+                <evaluateBeanshell>
+                  <condition>"${env.MAVEN_ARGS}".equals("${env."+"MAVEN_ARGS}")</condition>
+                </evaluateBeanshell>
+              </rules>
+              <fail>true</fail>
+            </configuration>
+          </execution>
+
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/tests/features/java/java_s2i.feature
+++ b/tests/features/java/java_s2i.feature
@@ -322,3 +322,8 @@ Feature: Openshift OpenJDK S2I tests
        | ns     | http://maven.apache.org/SETTINGS/1.0.0 |
     Then XML file /tmp/artifacts/configuration/settings.xml should have 1 elements on XPath //ns:server[ns:id='myrepo']
     Then XML file /tmp/artifacts/configuration/settings.xml should have 1 elements on XPath //ns:profile[ns:id='myrepo-profile']/ns:repositories/ns:repository[ns:url='http://repo.example.com:8080/maven2/']
+
+  Scenario: Ensure the environment is cleaned when executing mvn (OPENJDK-1548)
+      Given s2i build https://github.com/jmtd/openjdk from tests/OPENJDK-1548 with env using OPENJDK-1548-maven-args
+       | variable           | value    |
+       | MAVEN_ARGS         | validate |

--- a/tests/features/java/java_s2i.feature
+++ b/tests/features/java/java_s2i.feature
@@ -293,3 +293,15 @@ Feature: Openshift OpenJDK S2I tests
     Given s2i build https://github.com/jboss-openshift/openshift-examples from spring-boot-sample-simple/target
     Then s2i build log should not contain skipping directory .
     And  run find /deployments in container and check its output for spring-boot-sample-simple-1.5.0.BUILD-SNAPSHOT.jar
+
+  # OPENJDK-2068: MAVEN_REPO_URL and MAVEN_REPO_ID
+  Scenario: Check MAVEN_REPO_URL generates Maven settings and profile configuration
+    Given s2i build https://github.com/jboss-openshift/openshift-examples from spring-boot-sample-simple/target
+       | variable       | value                                |
+       | MAVEN_REPO_URL | http://repo.example.com:8080/maven2/ |
+       | MAVEN_REPO_ID  | myrepo                               |
+    And XML namespaces
+       | prefix | url                                    |
+       | ns     | http://maven.apache.org/SETTINGS/1.0.0 |
+    Then XML file /tmp/artifacts/configuration/settings.xml should have 1 elements on XPath //ns:server[ns:id='myrepo']
+    Then XML file /tmp/artifacts/configuration/settings.xml should have 1 elements on XPath //ns:profile[ns:id='myrepo-profile']/ns:repositories/ns:repository[ns:url='http://repo.example.com:8080/maven2/']


### PR DESCRIPTION
This is principally a cherry-pick of the three commits from [OPENJDK-1549](https://issues.redhat.com/browse/OPENJDK-1549) (ubi9 version of trhis issue)

However, merge conflicts resulted due to not having handled the test/doc-only changes
from [OPENJDK-2068](https://issues.redhat.com/browse/OPENJDK-2068) and [OPENJDK-2069](https://issues.redhat.com/browse/OPENJDK-2069) yet, so I have included them in this PR as well to cut down on admin. (I hope this does not complicate review.)

The new test that invokes the local Maven project references my fork/this PR branch due to the chicken-and-egg problem, and can be resolved (with a PR similar to #375) after this one is merged.