### PR TITLE
deliberately break a JSON template to test GHA

### DIFF
--- a/templates/image-streams.json
+++ b/templates/image-streams.json
@@ -498,6 +498,10 @@
                         },
                         "referencePolicy": {
                             "type": "Local"
+
+                            this is not a valid
+                            json file
+
                         },
                         "from": {
                             "kind": "DockerImage",


### PR DESCRIPTION
This is simply a test that the GH action to validate the templates is validating the copy of the templates in the PR branch, rather than the target branch. This PR deliberately breaks one of them. This should not be merged.