### PR TITLE
[OPENJDK-1964] Clarify permitted format for MAVEN_REPOS

### DIFF
--- a/modules/maven/api/module.yaml
+++ b/modules/maven/api/module.yaml
@@ -36,8 +36,15 @@ envs:
   description: Directory to use as the local Maven repository.
   example: /home/jboss/.m2/repository
 - name: "MAVEN_REPOS"
-  example: "dev-one,qe-two"
-  description: "If set, multi-repo support is enabled, and other MAVEN_REPO_* variables will be prefixed. For example: DEV_ONE_MAVEN_REPO_URL and QE_TWO_MAVEN_REPO_URL"
+  example: "DEV-ONE,QE-TWO"
+  description: >
+    Enables multi-repo support. Specify a comma-delimited list of capitalized
+    repository identifiers. The configuration for each repository will be
+    determined by correspondingly prefixed `MAVEN_REPO_*` variables. Any dashes
+    in repository names will be replaced with underscores. For example:
+    Specifying `DEV-ONE,QE-TWO` configures two repositories and their
+    URLs will be read from `DEV_ONE_MAVEN_REPO_URL` and
+    `QE_TWO_MAVEN_REPO_URL`.
 - name: "prefix_MAVEN_REPO_ID"
   example: "my-repo-id"
   description: "Maven repository id"


### PR DESCRIPTION
Expand the documentation for MAVEN_REPOS to make it clear that it must be specified in uppercase, and that hyphens/dashes are replaced by underscores.

https://issues.redhat.com/browse/OPENJDK-2069