### PR TITLE
[OPENJDK-2093] explicit tzdata-java dependency in container

### DIFF
--- a/modules/jdk/11/module.yaml
+++ b/modules/jdk/11/module.yaml
@@ -25,6 +25,7 @@ envs:
 packages:
   install:
   - java-11-openjdk-devel
+  - tzdata-java
 
 modules:
   install:

--- a/modules/jre/11/module.yaml
+++ b/modules/jre/11/module.yaml
@@ -25,6 +25,7 @@ envs:
 packages:
   install:
   - java-11-openjdk-headless
+  - tzdata-java
 
 modules:
   install:


### PR DESCRIPTION
This is a temporary measure to mitigate a regression in the OpenJDK 11 RPMs for the 2023-07 CPU update (which accidentally dropped the dependency on tzdata-java).

https://issues.redhat.com/browse/OPENJDK-2093

This means we can ship the next container update independently of this issue being addressed in the RPMs.