### PR TITLE
Openjdk 2034 another test S2I_TARGET_DEPLOYMENTS_DIR and JAVA_APP_DIR

### DIFF
--- a/tests/features/java/runtime.feature
+++ b/tests/features/java/runtime.feature
@@ -43,26 +43,26 @@ Feature: Openshift OpenJDK Runtime tests
   Then container log should not contain exec: bar': not found
 
   @ubi9
-  Scenario: Check default JAVA_APP_DIR (OPENJDK-2033)
+  Scenario: Check default JAVA_APP_DIR (OPENJDK-2034)
   When container is ready
   Then available container log should contain INFO running in /deployments
 
   @ubi9
-  Scenario: Check custom JAVA_APP_DIR (OPENJDK-2033)
+  Scenario: Check custom JAVA_APP_DIR (OPENJDK-2034)
     Given container is started with env
     | variable     | value         |
     | JAVA_APP_DIR | /home/default |
   Then available container log should contain INFO running in /home/default
 
   @ubi9
-  Scenario: Check relative path JAVA_APP_DIR (OPENJDK-2033)
+  Scenario: Check relative path JAVA_APP_DIR (OPENJDK-2034)
     Given container is started with env
     | variable     | value  |
     | JAVA_APP_DIR | .      |
   Then available container log should contain INFO running in /home/default
 
   @ubi9
-  Scenario: Check non-existent path JAVA_APP_DIR (OPENJDK-2033)
+  Scenario: Check non-existent path JAVA_APP_DIR (OPENJDK-2034)
     Given container is started with env
     | variable     | value  |
     | JAVA_APP_DIR | /nope  |

--- a/tests/features/java/runtime.feature
+++ b/tests/features/java/runtime.feature
@@ -67,3 +67,11 @@ Feature: Openshift OpenJDK Runtime tests
     | variable     | value  |
     | JAVA_APP_DIR | /nope  |
   Then available container log should contain ERROR No directory /nope found for auto detection
+
+  # Builder images only
+  Scenario: Ensure JAVA_APP_DIR and S2I work together (OPENJDK-2034)
+    Given s2i build https://github.com/jboss-openshift/openshift-quickstarts from undertow-servlet
+       | variable                   | value         |
+       | JAVA_APP_DIR               | /home/default |
+       | S2I_TARGET_DEPLOYMENTS_DIR | /home/default |
+    Then container log should contain /home/default/undertow-servlet.jar


### PR DESCRIPTION
https://issues.redhat.com/browse/OPENJDK-2034

    The S2I process puts the build application in /deployments unless
    overridden by S2I_TARGET_DEPLOYMENTS_DIR. Add a test to ensure that
    S2I_TARGET_DEPLOYMENTS_DIR and JAVA_APP_DIR set to the same value
    work as intended.