### PR TITLE
[OPENJDK-2144] Update/add usage: label to UBI9 images

### DIFF
--- a/ubi9-openjdk-11-runtime.yaml
+++ b/ubi9-openjdk-11-runtime.yaml
@@ -18,8 +18,12 @@ labels:
   value: "Red Hat OpenJDK <openjdk@redhat.com>"
 - name: "com.redhat.component"
   value: "openjdk-11-runtime-ubi9-container"
+- name: "usage"
+  value: &docs "https://jboss-container-images.github.io/openjdk/"
 - name: "com.redhat.license_terms"
   value: "https://www.redhat.com/en/about/red-hat-end-user-license-agreements#UBI"
+- name: "org.opencontainers.image.documentation"
+  value: *docs
 
 envs:
 - name: "JBOSS_IMAGE_NAME"

--- a/ubi9-openjdk-11.yaml
+++ b/ubi9-openjdk-11.yaml
@@ -19,9 +19,11 @@ labels:
 - name: "com.redhat.component"
   value: "openjdk-11-ubi9-container"
 - name: "usage"
-  value: "https://access.redhat.com/documentation/en-us/openjdk/11/html/using_openjdk_11_source-to-image_for_openshift/index"
+  value: &docs "https://jboss-container-images.github.io/openjdk/"
 - name: "com.redhat.license_terms"
   value: "https://www.redhat.com/en/about/red-hat-end-user-license-agreements#UBI"
+- name: "org.opencontainers.image.documentation"
+  value: *docs
 
 envs:
 - name: PATH

--- a/ubi9-openjdk-17-runtime.yaml
+++ b/ubi9-openjdk-17-runtime.yaml
@@ -19,9 +19,11 @@ labels:
 - name: "com.redhat.component"
   value: "openjdk-17-runtime-ubi9-container"
 - name: "usage"
-  value: "https://access.redhat.com/documentation/en-us/red_hat_jboss_middleware_for_openshift/3/html/red_hat_java_s2i_for_openshift/"
+  value: &docs "https://jboss-container-images.github.io/openjdk/"
 - name: "com.redhat.license_terms"
   value: "https://www.redhat.com/en/about/red-hat-end-user-license-agreements#UBI"
+- name: "org.opencontainers.image.documentation"
+  value: *docs
 
 envs:
 - name: "JBOSS_IMAGE_NAME"

--- a/ubi9-openjdk-17.yaml
+++ b/ubi9-openjdk-17.yaml
@@ -19,9 +19,11 @@ labels:
 - name: "com.redhat.component"
   value: "openjdk-17-ubi9-container"
 - name: "usage"
-  value: "https://access.redhat.com/documentation/en-us/red_hat_jboss_middleware_for_openshift/3/html/red_hat_java_s2i_for_openshift/"
+  value: &docs "https://jboss-container-images.github.io/openjdk/"
 - name: "com.redhat.license_terms"
   value: "https://www.redhat.com/en/about/red-hat-end-user-license-agreements#UBI"
+- name: "org.opencontainers.image.documentation"
+  value: *docs
 
 envs:
 - name: PATH


### PR DESCRIPTION
https://issues.redhat.com/browse/OPENJDK-2144

ubi9/openjdk-11-runtime was lacking a usage: label.

ubi9/openjdk-11's usage: label was pointing at Red Hat customer documentation "Using source-to-image for OpenShift with Red Hat build of OpenJDK 11". However,

 * at some point the URI has broken
 * this document was written for UBI8 and is incorrect for UBI9

The two UBI9/JDK17 images pointed at OpenShift 3-era documentation which is similarly out-of-date.

Set all of them to <https://jboss-container-images.github.io/openjdk/>, which is arguably the best candidate for the time being.

Additionally, define a second label org.opencontainers.image.documentation with the same value, following the OpenContainers Spec, Pre-Defined Annotation Keys:
<https://specs.opencontainers.org/image-spec/annotations/>