### PR TITLE
[OPENJDK-2145] Update/add usage: labels to UBI8 images

### DIFF
--- a/ubi8-openjdk-11-runtime.yaml
+++ b/ubi8-openjdk-11-runtime.yaml
@@ -18,8 +18,12 @@ labels:
   value: "Red Hat OpenJDK <openjdk@redhat.com>"
 - name: "com.redhat.component"
   value: "openjdk-11-runtime-ubi8-container"
+- name: "usage"
+  value: &docs "https://jboss-container-images.github.io/openjdk/"
 - name: "com.redhat.license_terms"
   value: "https://www.redhat.com/en/about/red-hat-end-user-license-agreements#UBI"
+- name: "org.opencontainers.image.documentation"
+  value: *docs
 
 envs:
 - name: "JBOSS_IMAGE_NAME"

--- a/ubi8-openjdk-11.yaml
+++ b/ubi8-openjdk-11.yaml
@@ -19,7 +19,7 @@ labels:
 - name: "com.redhat.component"
   value: "openjdk-11-ubi8-container"
 - name: "usage"
-  value: &docs "https://access.redhat.com/documentation/en-us/openjdk/11/html/using_source-to-image_for_openshift_with_red_hat_build_of_openjdk_11/index"
+  value: &docs "https://jboss-container-images.github.io/openjdk/"
 - name: "com.redhat.license_terms"
   value: "https://www.redhat.com/en/about/red-hat-end-user-license-agreements#UBI"
 - name: "org.opencontainers.image.documentation"

--- a/ubi8-openjdk-11.yaml
+++ b/ubi8-openjdk-11.yaml
@@ -19,9 +19,11 @@ labels:
 - name: "com.redhat.component"
   value: "openjdk-11-ubi8-container"
 - name: "usage"
-  value: "https://access.redhat.com/documentation/en-us/openjdk/11/html/using_openjdk_11_source-to-image_for_openshift/index"
+  value: &docs "https://access.redhat.com/documentation/en-us/openjdk/11/html/using_source-to-image_for_openshift_with_red_hat_build_of_openjdk_11/index"
 - name: "com.redhat.license_terms"
   value: "https://www.redhat.com/en/about/red-hat-end-user-license-agreements#UBI"
+- name: "org.opencontainers.image.documentation"
+  value: *docs
 
 envs:
 - name: PATH

--- a/ubi8-openjdk-17-runtime.yaml
+++ b/ubi8-openjdk-17-runtime.yaml
@@ -19,9 +19,11 @@ labels:
 - name: "com.redhat.component"
   value: "openjdk-17-runtime-ubi8-container"
 - name: "usage"
-  value: "https://access.redhat.com/documentation/en-us/red_hat_jboss_middleware_for_openshift/3/html/red_hat_java_s2i_for_openshift/"
+  value: &docs "https://jboss-container-images.github.io/openjdk/"
 - name: "com.redhat.license_terms"
   value: "https://www.redhat.com/en/about/red-hat-end-user-license-agreements#UBI"
+- name: "org.opencontainers.image.documentation"
+  value: *docs
 
 envs:
 - name: "JBOSS_IMAGE_NAME"

--- a/ubi8-openjdk-17.yaml
+++ b/ubi8-openjdk-17.yaml
@@ -19,9 +19,11 @@ labels:
 - name: "com.redhat.component"
   value: "openjdk-17-ubi8-container"
 - name: "usage"
-  value: "https://access.redhat.com/documentation/en-us/red_hat_jboss_middleware_for_openshift/3/html/red_hat_java_s2i_for_openshift/"
+  value: &docs "https://jboss-container-images.github.io/openjdk/"
 - name: "com.redhat.license_terms"
   value: "https://www.redhat.com/en/about/red-hat-end-user-license-agreements#UBI"
+- name: "org.opencontainers.image.documentation"
+  value: *docs
 
 envs:
 - name: PATH

--- a/ubi8-openjdk-8-runtime.yaml
+++ b/ubi8-openjdk-8-runtime.yaml
@@ -18,8 +18,12 @@ labels:
   value: "Red Hat OpenJDK <openjdk@redhat.com>"
 - name: "com.redhat.component"
   value: "openjdk-8-runtime-ubi8-container"
+- name: "usage"
+  value: &docs "https://jboss-container-images.github.io/openjdk/"
 - name: "com.redhat.license_terms"
   value: "https://www.redhat.com/en/about/red-hat-end-user-license-agreements#UBI"
+- name: "org.opencontainers.image.documentation"
+  value: *docs
 
 envs:
 - name: "JBOSS_IMAGE_NAME"

--- a/ubi8-openjdk-8.yaml
+++ b/ubi8-openjdk-8.yaml
@@ -19,9 +19,11 @@ labels:
 - name: "com.redhat.component"
   value: "openjdk-8-ubi8-container"
 - name: "usage"
-  value: "https://access.redhat.com/documentation/en-us/openjdk/8/html/using_openjdk_8_source-to-image_for_openshift/index"
+  value: &docs "https://access.redhat.com/documentation/en-us/openjdk/8/html/using_openjdk_8_source-to-image_for_openshift/index"
 - name: "com.redhat.license_terms"
   value: "https://www.redhat.com/en/about/red-hat-end-user-license-agreements#UBI"
+- name: "org.opencontainers.image.documentation"
+  value: *docs
 
 envs:
 - name: PATH

--- a/ubi8-openjdk-8.yaml
+++ b/ubi8-openjdk-8.yaml
@@ -19,7 +19,7 @@ labels:
 - name: "com.redhat.component"
   value: "openjdk-8-ubi8-container"
 - name: "usage"
-  value: &docs "https://access.redhat.com/documentation/en-us/openjdk/8/html/using_openjdk_8_source-to-image_for_openshift/index"
+  value: &docs "https://jboss-container-images.github.io/openjdk/"
 - name: "com.redhat.license_terms"
   value: "https://www.redhat.com/en/about/red-hat-end-user-license-agreements#UBI"
 - name: "org.opencontainers.image.documentation"


### PR DESCRIPTION
https://issues.redhat.com/browse/OPENJDK-2145

Add a usage: label to JDK11-runtime and JDK8-runtime, pointing at <https://jboss-container-images.github.io/openjdk/>, which is probably the best option for the time being. We don't have specific Red Hat customer documentation for runtime images.

Alter the usage: label for JDK17 to
<https://jboss-container-images.github.io/openjdk/>, as the old value was for OpenShift 3.x era documentation.

Adjust the usage: label for JDK11 to a fixed URI for the same document (It changed at some point in the past and we didn't notice sooner.)

For all UBI8 images, additionally define a second label org.opencontainers.image.documentation with the same value, following the OpenContainers Spec, Pre-Defined Annotation Keys: <https://specs.opencontainers.org/image-spec/annotations/>