### PR TITLE
[OPENJDK-2063] Tweak run scripts to support docker multistage build for jlinked JRE container application

### DIFF
--- a/modules/run/artifacts/opt/jboss/container/java/run/run-env.sh
+++ b/modules/run/artifacts/opt/jboss/container/java/run/run-env.sh
@@ -1,6 +1,0 @@
-#!/bin/sh
-
-# Default the application dir to the S2I deployment dir
-if [ -z "$JAVA_APP_DIR" ]
-then JAVA_APP_DIR=/deployments
-fi

--- a/modules/run/artifacts/opt/jboss/container/java/run/run-java.sh
+++ b/modules/run/artifacts/opt/jboss/container/java/run/run-java.sh
@@ -4,8 +4,8 @@
 set -eo pipefail
 
 #These are defined explicitly here to avoid defining them in templates/jlink/Dockerfile
-export JBOSS_CONTAINER_UTIL_LOGGING_MODULE="/opt/jboss/container/util/logging"
-export JBOSS_CONTAINER_JAVA_RUN_MODULE="/opt/jboss/container/java/run"
+export JBOSS_CONTAINER_UTIL_LOGGING_MODULE="${JBOSS_CONTAINER_UTIL_LOGGING_MODULE-/opt/jboss/container/util/logging}"
+export JBOSS_CONTAINER_JAVA_RUN_MODULE="${JBOSS_CONTAINER_JAVA_RUN_MODULE-/opt/jboss/container/java/run}"
 
 #This is moved here after deleting run-env.sh
 # Default the application dir to the S2I deployment dir

--- a/modules/run/artifacts/opt/jboss/container/java/run/run-java.sh
+++ b/modules/run/artifacts/opt/jboss/container/java/run/run-java.sh
@@ -3,6 +3,13 @@
 # Fail on a single failed command
 set -eo pipefail
 
+#These are defined explicitly here to avoid defining them in templates/jlink/Dockerfile
+export JBOSS_CONTAINER_UTIL_LOGGING_MODULE="/opt/jboss/container/util/logging"
+export JBOSS_CONTAINER_JAVA_RUN_MODULE="/opt/jboss/container/java/run"
+
+#This is moved here after deleting run-env.sh
+export JAVA_APP_DIR=/deployments
+
 source "$JBOSS_CONTAINER_UTIL_LOGGING_MODULE/logging.sh"
 
 # ==========================================================
@@ -96,13 +103,8 @@ load_env() {
   if [ -z "${JAVA_APP_DIR}" ]; then
     # XXX: is this correct?  This is defaulted above to /deployments.  Should we
     # define a default to the old /opt/java-run?
-    JAVA_APP_DIR="${JBOSS_CONTAINER_JAVA_RUN_MODULE}"
-  else
-    if [ -f "${JAVA_APP_DIR}/${run_env_sh}" ]; then
-      source "${JAVA_APP_DIR}/${run_env_sh}"
-    fi
+    export JAVA_APP_DIR="${JBOSS_CONTAINER_JAVA_RUN_MODULE}"
   fi
-  export JAVA_APP_DIR
 
   # JAVA_LIB_DIR defaults to JAVA_APP_DIR
   export JAVA_LIB_DIR="${JAVA_LIB_DIR:-${JAVA_APP_DIR}}"

--- a/modules/run/artifacts/opt/jboss/container/java/run/run-java.sh
+++ b/modules/run/artifacts/opt/jboss/container/java/run/run-java.sh
@@ -3,14 +3,12 @@
 # Fail on a single failed command
 set -eo pipefail
 
-#These are defined explicitly here to avoid defining them in templates/jlink/Dockerfile
 export JBOSS_CONTAINER_UTIL_LOGGING_MODULE="${JBOSS_CONTAINER_UTIL_LOGGING_MODULE-/opt/jboss/container/util/logging}"
 export JBOSS_CONTAINER_JAVA_RUN_MODULE="${JBOSS_CONTAINER_JAVA_RUN_MODULE-/opt/jboss/container/java/run}"
 
-#This is moved here after deleting run-env.sh
 # Default the application dir to the S2I deployment dir
 if [ -z "$JAVA_APP_DIR" ]
-then JAVA_APP_DIR=/deployments
+  then JAVA_APP_DIR=/deployments
 fi
 
 source "$JBOSS_CONTAINER_UTIL_LOGGING_MODULE/logging.sh"

--- a/modules/run/artifacts/opt/jboss/container/java/run/run-java.sh
+++ b/modules/run/artifacts/opt/jboss/container/java/run/run-java.sh
@@ -8,7 +8,10 @@ export JBOSS_CONTAINER_UTIL_LOGGING_MODULE="/opt/jboss/container/util/logging"
 export JBOSS_CONTAINER_JAVA_RUN_MODULE="/opt/jboss/container/java/run"
 
 #This is moved here after deleting run-env.sh
-export JAVA_APP_DIR=/deployments
+# Default the application dir to the S2I deployment dir
+if [ -z "$JAVA_APP_DIR" ]
+then JAVA_APP_DIR=/deployments
+fi
 
 source "$JBOSS_CONTAINER_UTIL_LOGGING_MODULE/logging.sh"
 
@@ -100,11 +103,11 @@ load_env() {
 
   # Check also $JAVA_APP_DIR. Overrides other defaults
   # It's valid to set the app dir in the default script
-  if [ -z "${JAVA_APP_DIR}" ]; then
-    # XXX: is this correct?  This is defaulted above to /deployments.  Should we
-    # define a default to the old /opt/java-run?
-    export JAVA_APP_DIR="${JBOSS_CONTAINER_JAVA_RUN_MODULE}"
+  if [ -f "${JAVA_APP_DIR}/${run_env_sh}" ]; then
+      source "${JAVA_APP_DIR}/${run_env_sh}"
   fi
+
+  export JAVA_APP_DIR
 
   # JAVA_LIB_DIR defaults to JAVA_APP_DIR
   export JAVA_LIB_DIR="${JAVA_LIB_DIR:-${JAVA_APP_DIR}}"


### PR DESCRIPTION
https://issues.redhat.com/browse/OPENJDK-2063

This PR is to address GH issues 
https://github.com/jboss-container-images/openjdk/issues/394
https://github.com/jboss-container-images/openjdk/issues/395

which are some sub-tasks for above mentioned JIRA tracker.

I haven't removed the definition of JBOSS_CONTAINER_UTIL_LOGGING_MODULE from modules/util/logging/module.yaml because it is referenced in modules/maven/* and modules/s2i/* in multiple files. So I feel its not a good idea to define it in all those files.