### PR TITLE
Change GHA runners to ubuntu-latest

### DIFF
--- a/.github/workflows/gendocs.yml
+++ b/.github/workflows/gendocs.yml
@@ -20,7 +20,7 @@ concurrency:
 jobs:
   gendocs:
     name: Generate documentation
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
     steps:

--- a/.github/workflows/image-workflow-template.yml
+++ b/.github/workflows/image-workflow-template.yml
@@ -10,7 +10,7 @@ env:
 jobs:
   openjdkci:
     name: OpenJDK S2I Build and Test
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
     steps:


### PR DESCRIPTION
This is a hail-mary change: we are experiencing problems with GHA runs timing out (behave tests taking up to five hours to run). We were running on a not-current GHA runner version, and I think the old runners get fewer resources than the newer ones.