### PR TITLE
[OPENJDK-2199] Update tests to refer new application source repository

### DIFF
--- a/tests/features/java.security.feature
+++ b/tests/features/java.security.feature
@@ -2,5 +2,5 @@
 @ubi9/openjdk-17
 Feature: Openshift S2I tests
   Scenario: Check networkaddress.cache.negative.ttl has been set correctly
-    Given s2i build https://github.com/jboss-openshift/openshift-examples/ from binary-cli-security-property
+    Given s2i build https://github.com/jhuttana/openjdk-test-applications/tree/pick_relevant_sources from binary-cli-security-property
     Then s2i build log should contain networkaddress.cache.negative.ttl=0

--- a/tests/features/java.security.feature
+++ b/tests/features/java.security.feature
@@ -2,5 +2,5 @@
 @ubi9/openjdk-17
 Feature: Openshift S2I tests
   Scenario: Check networkaddress.cache.negative.ttl has been set correctly
-    Given s2i build https://github.com/jhuttana/openjdk-test-applications from binary-cli-security-property using pick_relevant_sources
+    Given s2i build https://github.com/jboss-container-images/openjdk-test-applications from binary-cli-security-property
     Then s2i build log should contain networkaddress.cache.negative.ttl=0

--- a/tests/features/java.security.feature
+++ b/tests/features/java.security.feature
@@ -2,5 +2,5 @@
 @ubi9/openjdk-17
 Feature: Openshift S2I tests
   Scenario: Check networkaddress.cache.negative.ttl has been set correctly
-    Given s2i build https://github.com/jhuttana/openjdk-test-applications/tree/pick_relevant_sources from binary-cli-security-property
+    Given s2i build https://github.com/jhuttana/openjdk-test-applications from binary-cli-security-property using pick_relevant_sources
     Then s2i build log should contain networkaddress.cache.negative.ttl=0

--- a/tests/features/java/java_s2i.feature
+++ b/tests/features/java/java_s2i.feature
@@ -7,7 +7,7 @@ Feature: Openshift OpenJDK S2I tests
 
   # handles mirror/repository configuration; proxy configuration
   Scenario: run the s2i and check the maven mirror and proxy have been initialised in the default settings.xml, uses http_proxy
-    Given s2i build https://github.com/jhuttana/openjdk-test-applications from spring-boot-sample-simple using pick_relevant_sources
+    Given s2i build https://github.com/jboss-container-images/openjdk-test-applications from spring-boot-sample-simple
        | variable           | value                                            |
        | MAVEN_ARGS         | -v                                               |
        | MAVEN_MIRROR_URL   | http://127.0.0.1:8080/repository/internal/       |
@@ -20,7 +20,7 @@ Feature: Openshift OpenJDK S2I tests
 
   # proxy auth configuration (success case) + nonProxyHosts
   Scenario: run the s2i and check the maven mirror, proxy (including username and password) and non proxy have been initialised in the default settings.xml, uses http_proxy
-    Given s2i build https://github.com/jhuttana/openjdk-test-applications from spring-boot-sample-simple using pick_relevant_sources
+    Given s2i build https://github.com/jboss-container-images/openjdk-test-applications from spring-boot-sample-simple
        | variable           | value                                            |
        | MAVEN_ARGS         | -v                                               |
        | http_proxy         | myuser:mypass@127.0.0.1:8080                     |
@@ -32,7 +32,7 @@ Feature: Openshift OpenJDK S2I tests
 
   # proxy auth configuration (fail case: no password supplied)
   Scenario: run the s2i and check the maven mirror, proxy (including username) and non proxy have been initialised in the default settings.xml, uses http_proxy
-    Given s2i build https://github.com/jhuttana/openjdk-test-applications from spring-boot-sample-simple using pick_relevant_sources
+    Given s2i build https://github.com/jboss-container-images/openjdk-test-applications from spring-boot-sample-simple
        | variable           | value                                            |
        | MAVEN_ARGS         | -v                                               |
        | http_proxy         | myuser@127.0.0.1:8080                            |
@@ -43,7 +43,7 @@ Feature: Openshift OpenJDK S2I tests
 
   # handles mirror/repository configuration; proxy configuration
   Scenario: run the s2i and check the maven mirror and proxy have been initialised in the default settings.xml, uses http_proxy
-    Given s2i build https://github.com/jhuttana/openjdk-test-applications from spring-boot-sample-simple using pick_relevant_sources
+    Given s2i build https://github.com/jboss-container-images/openjdk-test-applications from spring-boot-sample-simple
        | variable           | value                                            |
        | MAVEN_ARGS         | -v                                               |
        | MAVEN_MIRROR_URL   | http://127.0.0.1:8080/repository/internal/       |
@@ -56,7 +56,7 @@ Feature: Openshift OpenJDK S2I tests
 
   # HTTP_PROXY (all caps) ignored
   Scenario: run the s2i and check the maven mirror and proxy have been initialised in the default settings.xml, uses http_proxy and HTTP_PROXY
-    Given s2i build https://github.com/jhuttana/openjdk-test-applications from spring-boot-sample-simple using pick_relevant_sources
+    Given s2i build https://github.com/jboss-container-images/openjdk-test-applications from spring-boot-sample-simple
        | variable           | value                                            |
        | MAVEN_ARGS         | -v                                               |
        | http_proxy         | 127.0.0.2:9090                                   |
@@ -69,7 +69,7 @@ Feature: Openshift OpenJDK S2I tests
 
   # handles mirror/repository configuration; https proxy configuration
   Scenario: run the s2i and check the maven mirror and proxy have been initialised in the default settings.xml, uses https_proxy
-    Given s2i build https://github.com/jhuttana/openjdk-test-applications from spring-boot-sample-simple using pick_relevant_sources
+    Given s2i build https://github.com/jboss-container-images/openjdk-test-applications from spring-boot-sample-simple
        | variable           | value                                            |
        | MAVEN_ARGS         | -v                                               |
        | MAVEN_MIRROR_URL   | http://127.0.0.1:8080/repository/internal/       |
@@ -82,7 +82,7 @@ Feature: Openshift OpenJDK S2I tests
 
   # https proxy auth configuration (success case) + nonProxyHosts
   Scenario: run the s2i and check the maven mirror, proxy (including username and password) and non proxy have been initialised in the default settings.xml, uses https_proxy
-    Given s2i build https://github.com/jhuttana/openjdk-test-applications from spring-boot-sample-simple using pick_relevant_sources
+    Given s2i build https://github.com/jboss-container-images/openjdk-test-applications from spring-boot-sample-simple
        | variable           | value                                            |
        | MAVEN_ARGS         | -v                                               |
        | https_proxy        | myuser:mypass@127.0.0.1:8080                     |
@@ -94,7 +94,7 @@ Feature: Openshift OpenJDK S2I tests
 
   # https proxy auth configuration (fail case: no password supplied)
   Scenario: run the s2i and check the maven mirror, proxy (including username) and non proxy have been initialised in the default settings.xml, uses https_proxy
-    Given s2i build https://github.com/jhuttana/openjdk-test-applications from spring-boot-sample-simple using pick_relevant_sources
+    Given s2i build https://github.com/jboss-container-images/openjdk-test-applications from spring-boot-sample-simple
        | variable           | value                                            |
        | MAVEN_ARGS         | -v                                               |
        | https_proxy        | myuser@127.0.0.1:8080                            |
@@ -104,7 +104,7 @@ Feature: Openshift OpenJDK S2I tests
     Then XML file /tmp/artifacts/configuration/settings.xml should have 1 elements on XPath //ns:proxy[ns:id='genproxy'][ns:active='true'][ns:protocol='https'][ns:host='127.0.0.1'][ns:port='8080']
 
   Scenario: run s2i assemble and check no_proxy is honoured with multiple entries
-    Given s2i build https://github.com/jhuttana/openjdk-test-applications from spring-boot-sample-simple using pick_relevant_sources
+    Given s2i build https://github.com/jboss-container-images/openjdk-test-applications from spring-boot-sample-simple
        | variable           | value                                            |
        | MAVEN_ARGS         | -v                                               |
        | MAVEN_MIRROR_URL   | http://127.0.0.1:8080/repository/internal/       |
@@ -127,20 +127,20 @@ Feature: Openshift OpenJDK S2I tests
 
   # CLOUD-579
   Scenario: Test that maven is executed in batch mode
-    Given s2i build https://github.com/jhuttana/openjdk-test-applications from spring-boot-sample-simple using pick_relevant_sources
+    Given s2i build https://github.com/jboss-container-images/openjdk-test-applications from spring-boot-sample-simple
     Then s2i build log should contain --batch-mode
     And s2i build log should not contain \r
 
   # CLOUD-3095 - context dir should be recursively copied into the image
   # "/target" suffix is important here; it triggers a different code-path (no source build)
   Scenario: Ensure binary-only mode copies binaries into the target image
-    Given s2i build https://github.com/jhuttana/openjdk-test-applications from spring-boot-sample-simple/target using pick_relevant_sources
+    Given s2i build https://github.com/jboss-container-images/openjdk-test-applications from spring-boot-sample-simple/target
     Then s2i build log should not contain skipping directory .
     And  run find /deployments in container and check its output for spring-boot-sample-simple-1.5.0.BUILD-SNAPSHOT.jar
 
   # OPENJDK-1954 - MAVEN_REPOS
   Scenario: run the s2i and check the maven mirror and proxy have been initialised in the default settings.xml, uses http_proxy
-    Given s2i build https://github.com/jhuttana/openjdk-test-applications from spring-boot-sample-simple/target using pick_relevant_sources
+    Given s2i build https://github.com/jboss-container-images/openjdk-test-applications from spring-boot-sample-simple/target
        | variable                | value                                |
        | MAVEN_REPOS             | TESTREPO,ANOTHER                     |
        | TESTREPO_MAVEN_REPO_URL | http://repo.example.com:8080/maven2/ |
@@ -157,7 +157,7 @@ Feature: Openshift OpenJDK S2I tests
 
   # OPENJDK-1961: MAVEN_REPO_URL and MAVEN_REPO_ID
   Scenario: Check MAVEN_REPO_URL generates Maven settings and profile configuration
-    Given s2i build https://github.com/jhuttana/openjdk-test-applications from spring-boot-sample-simple/target using pick_relevant_sources
+    Given s2i build https://github.com/jboss-container-images/openjdk-test-applications from spring-boot-sample-simple/target
        | variable       | value                                |
        | MAVEN_REPO_URL | http://repo.example.com:8080/maven2/ |
        | MAVEN_REPO_ID  | myrepo                               |
@@ -168,6 +168,6 @@ Feature: Openshift OpenJDK S2I tests
     Then XML file /tmp/artifacts/configuration/settings.xml should have 1 elements on XPath //ns:profile[ns:id='myrepo-profile']/ns:repositories/ns:repository[ns:url='http://repo.example.com:8080/maven2/']
 
   Scenario: Ensure the environment is cleaned when executing mvn (OPENJDK-1549)
-      Given s2i build https://github.com/jhuttana/openjdk-test-applications from OPENJDK-1549 with env using pick_relevant_sources
+      Given s2i build https://github.com/jboss-container-images/openjdk-test-applications from OPENJDK-1549 with env
        | variable           | value    |
        | MAVEN_ARGS         | validate |

--- a/tests/features/java/java_s2i.feature
+++ b/tests/features/java/java_s2i.feature
@@ -134,7 +134,7 @@ Feature: Openshift OpenJDK S2I tests
   # CLOUD-3095 - context dir should be recursively copied into the image
   # "/target" suffix is important here; it triggers a different code-path (no source build)
   Scenario: Ensure binary-only mode copies binaries into the target image
-    Given s2i build https://github.com/jhuttana/openjdk-test-applications/tree/pick_relevant_sources from spring-boot-sample-simple/target
+    Given s2i build https://github.com/jhuttana/openjdk-test-applications from spring-boot-sample-simple/target using pick_relevant_sources
     Then s2i build log should not contain skipping directory .
     And  run find /deployments in container and check its output for spring-boot-sample-simple-1.5.0.BUILD-SNAPSHOT.jar
 
@@ -168,6 +168,6 @@ Feature: Openshift OpenJDK S2I tests
     Then XML file /tmp/artifacts/configuration/settings.xml should have 1 elements on XPath //ns:profile[ns:id='myrepo-profile']/ns:repositories/ns:repository[ns:url='http://repo.example.com:8080/maven2/']
 
   Scenario: Ensure the environment is cleaned when executing mvn (OPENJDK-1549)
-      Given s2i build https://github.com/jhuttana/openjdk-test-applications from tests/OPENJDK-1549 with env using pick_relevant_sources
+      Given s2i build https://github.com/jhuttana/openjdk-test-applications from OPENJDK-1549 with env using pick_relevant_sources
        | variable           | value    |
        | MAVEN_ARGS         | validate |

--- a/tests/features/java/java_s2i.feature
+++ b/tests/features/java/java_s2i.feature
@@ -7,7 +7,7 @@ Feature: Openshift OpenJDK S2I tests
 
   # handles mirror/repository configuration; proxy configuration
   Scenario: run the s2i and check the maven mirror and proxy have been initialised in the default settings.xml, uses http_proxy
-    Given s2i build https://github.com/jboss-openshift/openshift-examples from spring-boot-sample-simple
+    Given s2i build https://github.com/jhuttana/openjdk-test-applications/tree/pick_relevant_sources from spring-boot-sample-simple
        | variable           | value                                            |
        | MAVEN_ARGS         | -v                                               |
        | MAVEN_MIRROR_URL   | http://127.0.0.1:8080/repository/internal/       |
@@ -20,7 +20,7 @@ Feature: Openshift OpenJDK S2I tests
 
   # proxy auth configuration (success case) + nonProxyHosts
   Scenario: run the s2i and check the maven mirror, proxy (including username and password) and non proxy have been initialised in the default settings.xml, uses http_proxy
-    Given s2i build https://github.com/jboss-openshift/openshift-examples from spring-boot-sample-simple
+    Given s2i build https://github.com/jhuttana/openjdk-test-applications/tree/pick_relevant_sources from spring-boot-sample-simple
        | variable           | value                                            |
        | MAVEN_ARGS         | -v                                               |
        | http_proxy         | myuser:mypass@127.0.0.1:8080                     |
@@ -32,7 +32,7 @@ Feature: Openshift OpenJDK S2I tests
 
   # proxy auth configuration (fail case: no password supplied)
   Scenario: run the s2i and check the maven mirror, proxy (including username) and non proxy have been initialised in the default settings.xml, uses http_proxy
-    Given s2i build https://github.com/jboss-openshift/openshift-examples from spring-boot-sample-simple
+    Given s2i build https://github.com/jhuttana/openjdk-test-applications/tree/pick_relevant_sources from spring-boot-sample-simple
        | variable           | value                                            |
        | MAVEN_ARGS         | -v                                               |
        | http_proxy         | myuser@127.0.0.1:8080                            |
@@ -43,7 +43,7 @@ Feature: Openshift OpenJDK S2I tests
 
   # handles mirror/repository configuration; proxy configuration
   Scenario: run the s2i and check the maven mirror and proxy have been initialised in the default settings.xml, uses http_proxy
-    Given s2i build https://github.com/jboss-openshift/openshift-examples from spring-boot-sample-simple
+    Given s2i build https://github.com/jhuttana/openjdk-test-applications/tree/pick_relevant_sources from spring-boot-sample-simple
        | variable           | value                                            |
        | MAVEN_ARGS         | -v                                               |
        | MAVEN_MIRROR_URL   | http://127.0.0.1:8080/repository/internal/       |
@@ -56,7 +56,7 @@ Feature: Openshift OpenJDK S2I tests
 
   # HTTP_PROXY (all caps) ignored
   Scenario: run the s2i and check the maven mirror and proxy have been initialised in the default settings.xml, uses http_proxy and HTTP_PROXY
-    Given s2i build https://github.com/jboss-openshift/openshift-examples from spring-boot-sample-simple
+    Given s2i build https://github.com/jhuttana/openjdk-test-applications/tree/pick_relevant_sources from spring-boot-sample-simple
        | variable           | value                                            |
        | MAVEN_ARGS         | -v                                               |
        | http_proxy         | 127.0.0.2:9090                                   |
@@ -69,7 +69,7 @@ Feature: Openshift OpenJDK S2I tests
 
   # handles mirror/repository configuration; https proxy configuration
   Scenario: run the s2i and check the maven mirror and proxy have been initialised in the default settings.xml, uses https_proxy
-    Given s2i build https://github.com/jboss-openshift/openshift-examples from spring-boot-sample-simple
+    Given s2i build https://github.com/jhuttana/openjdk-test-applications/tree/pick_relevant_sources from spring-boot-sample-simple
        | variable           | value                                            |
        | MAVEN_ARGS         | -v                                               |
        | MAVEN_MIRROR_URL   | http://127.0.0.1:8080/repository/internal/       |
@@ -82,7 +82,7 @@ Feature: Openshift OpenJDK S2I tests
 
   # https proxy auth configuration (success case) + nonProxyHosts
   Scenario: run the s2i and check the maven mirror, proxy (including username and password) and non proxy have been initialised in the default settings.xml, uses https_proxy
-    Given s2i build https://github.com/jboss-openshift/openshift-examples from spring-boot-sample-simple
+    Given s2i build https://github.com/jhuttana/openjdk-test-applications/tree/pick_relevant_sources from spring-boot-sample-simple
        | variable           | value                                            |
        | MAVEN_ARGS         | -v                                               |
        | https_proxy        | myuser:mypass@127.0.0.1:8080                     |
@@ -94,7 +94,7 @@ Feature: Openshift OpenJDK S2I tests
 
   # https proxy auth configuration (fail case: no password supplied)
   Scenario: run the s2i and check the maven mirror, proxy (including username) and non proxy have been initialised in the default settings.xml, uses https_proxy
-    Given s2i build https://github.com/jboss-openshift/openshift-examples from spring-boot-sample-simple
+    Given s2i build https://github.com/jhuttana/openjdk-test-applications/tree/pick_relevant_sources from spring-boot-sample-simple
        | variable           | value                                            |
        | MAVEN_ARGS         | -v                                               |
        | https_proxy        | myuser@127.0.0.1:8080                            |
@@ -104,7 +104,7 @@ Feature: Openshift OpenJDK S2I tests
     Then XML file /tmp/artifacts/configuration/settings.xml should have 1 elements on XPath //ns:proxy[ns:id='genproxy'][ns:active='true'][ns:protocol='https'][ns:host='127.0.0.1'][ns:port='8080']
 
   Scenario: run s2i assemble and check no_proxy is honoured with multiple entries
-    Given s2i build https://github.com/jboss-openshift/openshift-examples from spring-boot-sample-simple
+    Given s2i build https://github.com/jhuttana/openjdk-test-applications/tree/pick_relevant_sources from spring-boot-sample-simple
        | variable           | value                                            |
        | MAVEN_ARGS         | -v                                               |
        | MAVEN_MIRROR_URL   | http://127.0.0.1:8080/repository/internal/       |
@@ -127,20 +127,20 @@ Feature: Openshift OpenJDK S2I tests
 
   # CLOUD-579
   Scenario: Test that maven is executed in batch mode
-    Given s2i build https://github.com/jboss-openshift/openshift-examples from spring-boot-sample-simple
+    Given s2i build https://github.com/jhuttana/openjdk-test-applications/tree/pick_relevant_sources from spring-boot-sample-simple
     Then s2i build log should contain --batch-mode
     And s2i build log should not contain \r
 
   # CLOUD-3095 - context dir should be recursively copied into the image
   # "/target" suffix is important here; it triggers a different code-path (no source build)
   Scenario: Ensure binary-only mode copies binaries into the target image
-    Given s2i build https://github.com/jboss-openshift/openshift-examples from spring-boot-sample-simple/target
+    Given s2i build https://github.com/jhuttana/openjdk-test-applications/tree/pick_relevant_sources from spring-boot-sample-simple/target
     Then s2i build log should not contain skipping directory .
     And  run find /deployments in container and check its output for spring-boot-sample-simple-1.5.0.BUILD-SNAPSHOT.jar
 
   # OPENJDK-1954 - MAVEN_REPOS
   Scenario: run the s2i and check the maven mirror and proxy have been initialised in the default settings.xml, uses http_proxy
-    Given s2i build https://github.com/jboss-openshift/openshift-examples from spring-boot-sample-simple/target
+    Given s2i build https://github.com/jhuttana/openjdk-test-applications/tree/pick_relevant_sources from spring-boot-sample-simple/target
        | variable                | value                                |
        | MAVEN_REPOS             | TESTREPO,ANOTHER                     |
        | TESTREPO_MAVEN_REPO_URL | http://repo.example.com:8080/maven2/ |
@@ -157,7 +157,7 @@ Feature: Openshift OpenJDK S2I tests
 
   # OPENJDK-1961: MAVEN_REPO_URL and MAVEN_REPO_ID
   Scenario: Check MAVEN_REPO_URL generates Maven settings and profile configuration
-    Given s2i build https://github.com/jboss-openshift/openshift-examples from spring-boot-sample-simple/target
+    Given s2i build https://github.com/jhuttana/openjdk-test-applications/tree/pick_relevant_sources from spring-boot-sample-simple/target
        | variable       | value                                |
        | MAVEN_REPO_URL | http://repo.example.com:8080/maven2/ |
        | MAVEN_REPO_ID  | myrepo                               |
@@ -168,6 +168,6 @@ Feature: Openshift OpenJDK S2I tests
     Then XML file /tmp/artifacts/configuration/settings.xml should have 1 elements on XPath //ns:profile[ns:id='myrepo-profile']/ns:repositories/ns:repository[ns:url='http://repo.example.com:8080/maven2/']
 
   Scenario: Ensure the environment is cleaned when executing mvn (OPENJDK-1549)
-      Given s2i build https://github.com/jboss-container-images/openjdk from tests/OPENJDK-1549 with env using ubi9
+      Given s2i build https://github.com/jhuttana/openjdk-test-applications/tree/pick_relevant_sources from tests/OPENJDK-1549 with env
        | variable           | value    |
        | MAVEN_ARGS         | validate |

--- a/tests/features/java/java_s2i.feature
+++ b/tests/features/java/java_s2i.feature
@@ -7,7 +7,7 @@ Feature: Openshift OpenJDK S2I tests
 
   # handles mirror/repository configuration; proxy configuration
   Scenario: run the s2i and check the maven mirror and proxy have been initialised in the default settings.xml, uses http_proxy
-    Given s2i build https://github.com/jhuttana/openjdk-test-applications/tree/pick_relevant_sources from spring-boot-sample-simple
+    Given s2i build https://github.com/jhuttana/openjdk-test-applications from spring-boot-sample-simple using pick_relevant_sources
        | variable           | value                                            |
        | MAVEN_ARGS         | -v                                               |
        | MAVEN_MIRROR_URL   | http://127.0.0.1:8080/repository/internal/       |
@@ -20,7 +20,7 @@ Feature: Openshift OpenJDK S2I tests
 
   # proxy auth configuration (success case) + nonProxyHosts
   Scenario: run the s2i and check the maven mirror, proxy (including username and password) and non proxy have been initialised in the default settings.xml, uses http_proxy
-    Given s2i build https://github.com/jhuttana/openjdk-test-applications/tree/pick_relevant_sources from spring-boot-sample-simple
+    Given s2i build https://github.com/jhuttana/openjdk-test-applications from spring-boot-sample-simple using pick_relevant_sources
        | variable           | value                                            |
        | MAVEN_ARGS         | -v                                               |
        | http_proxy         | myuser:mypass@127.0.0.1:8080                     |
@@ -32,7 +32,7 @@ Feature: Openshift OpenJDK S2I tests
 
   # proxy auth configuration (fail case: no password supplied)
   Scenario: run the s2i and check the maven mirror, proxy (including username) and non proxy have been initialised in the default settings.xml, uses http_proxy
-    Given s2i build https://github.com/jhuttana/openjdk-test-applications/tree/pick_relevant_sources from spring-boot-sample-simple
+    Given s2i build https://github.com/jhuttana/openjdk-test-applications from spring-boot-sample-simple using pick_relevant_sources
        | variable           | value                                            |
        | MAVEN_ARGS         | -v                                               |
        | http_proxy         | myuser@127.0.0.1:8080                            |
@@ -43,7 +43,7 @@ Feature: Openshift OpenJDK S2I tests
 
   # handles mirror/repository configuration; proxy configuration
   Scenario: run the s2i and check the maven mirror and proxy have been initialised in the default settings.xml, uses http_proxy
-    Given s2i build https://github.com/jhuttana/openjdk-test-applications/tree/pick_relevant_sources from spring-boot-sample-simple
+    Given s2i build https://github.com/jhuttana/openjdk-test-applications from spring-boot-sample-simple using pick_relevant_sources
        | variable           | value                                            |
        | MAVEN_ARGS         | -v                                               |
        | MAVEN_MIRROR_URL   | http://127.0.0.1:8080/repository/internal/       |
@@ -56,7 +56,7 @@ Feature: Openshift OpenJDK S2I tests
 
   # HTTP_PROXY (all caps) ignored
   Scenario: run the s2i and check the maven mirror and proxy have been initialised in the default settings.xml, uses http_proxy and HTTP_PROXY
-    Given s2i build https://github.com/jhuttana/openjdk-test-applications/tree/pick_relevant_sources from spring-boot-sample-simple
+    Given s2i build https://github.com/jhuttana/openjdk-test-applications from spring-boot-sample-simple using pick_relevant_sources
        | variable           | value                                            |
        | MAVEN_ARGS         | -v                                               |
        | http_proxy         | 127.0.0.2:9090                                   |
@@ -69,7 +69,7 @@ Feature: Openshift OpenJDK S2I tests
 
   # handles mirror/repository configuration; https proxy configuration
   Scenario: run the s2i and check the maven mirror and proxy have been initialised in the default settings.xml, uses https_proxy
-    Given s2i build https://github.com/jhuttana/openjdk-test-applications/tree/pick_relevant_sources from spring-boot-sample-simple
+    Given s2i build https://github.com/jhuttana/openjdk-test-applications from spring-boot-sample-simple using pick_relevant_sources
        | variable           | value                                            |
        | MAVEN_ARGS         | -v                                               |
        | MAVEN_MIRROR_URL   | http://127.0.0.1:8080/repository/internal/       |
@@ -82,7 +82,7 @@ Feature: Openshift OpenJDK S2I tests
 
   # https proxy auth configuration (success case) + nonProxyHosts
   Scenario: run the s2i and check the maven mirror, proxy (including username and password) and non proxy have been initialised in the default settings.xml, uses https_proxy
-    Given s2i build https://github.com/jhuttana/openjdk-test-applications/tree/pick_relevant_sources from spring-boot-sample-simple
+    Given s2i build https://github.com/jhuttana/openjdk-test-applications from spring-boot-sample-simple using pick_relevant_sources
        | variable           | value                                            |
        | MAVEN_ARGS         | -v                                               |
        | https_proxy        | myuser:mypass@127.0.0.1:8080                     |
@@ -94,7 +94,7 @@ Feature: Openshift OpenJDK S2I tests
 
   # https proxy auth configuration (fail case: no password supplied)
   Scenario: run the s2i and check the maven mirror, proxy (including username) and non proxy have been initialised in the default settings.xml, uses https_proxy
-    Given s2i build https://github.com/jhuttana/openjdk-test-applications/tree/pick_relevant_sources from spring-boot-sample-simple
+    Given s2i build https://github.com/jhuttana/openjdk-test-applications from spring-boot-sample-simple using pick_relevant_sources
        | variable           | value                                            |
        | MAVEN_ARGS         | -v                                               |
        | https_proxy        | myuser@127.0.0.1:8080                            |
@@ -104,7 +104,7 @@ Feature: Openshift OpenJDK S2I tests
     Then XML file /tmp/artifacts/configuration/settings.xml should have 1 elements on XPath //ns:proxy[ns:id='genproxy'][ns:active='true'][ns:protocol='https'][ns:host='127.0.0.1'][ns:port='8080']
 
   Scenario: run s2i assemble and check no_proxy is honoured with multiple entries
-    Given s2i build https://github.com/jhuttana/openjdk-test-applications/tree/pick_relevant_sources from spring-boot-sample-simple
+    Given s2i build https://github.com/jhuttana/openjdk-test-applications from spring-boot-sample-simple using pick_relevant_sources
        | variable           | value                                            |
        | MAVEN_ARGS         | -v                                               |
        | MAVEN_MIRROR_URL   | http://127.0.0.1:8080/repository/internal/       |
@@ -127,7 +127,7 @@ Feature: Openshift OpenJDK S2I tests
 
   # CLOUD-579
   Scenario: Test that maven is executed in batch mode
-    Given s2i build https://github.com/jhuttana/openjdk-test-applications/tree/pick_relevant_sources from spring-boot-sample-simple
+    Given s2i build https://github.com/jhuttana/openjdk-test-applications from spring-boot-sample-simple using pick_relevant_sources
     Then s2i build log should contain --batch-mode
     And s2i build log should not contain \r
 
@@ -140,7 +140,7 @@ Feature: Openshift OpenJDK S2I tests
 
   # OPENJDK-1954 - MAVEN_REPOS
   Scenario: run the s2i and check the maven mirror and proxy have been initialised in the default settings.xml, uses http_proxy
-    Given s2i build https://github.com/jhuttana/openjdk-test-applications/tree/pick_relevant_sources from spring-boot-sample-simple/target
+    Given s2i build https://github.com/jhuttana/openjdk-test-applications from spring-boot-sample-simple/target using pick_relevant_sources
        | variable                | value                                |
        | MAVEN_REPOS             | TESTREPO,ANOTHER                     |
        | TESTREPO_MAVEN_REPO_URL | http://repo.example.com:8080/maven2/ |
@@ -157,7 +157,7 @@ Feature: Openshift OpenJDK S2I tests
 
   # OPENJDK-1961: MAVEN_REPO_URL and MAVEN_REPO_ID
   Scenario: Check MAVEN_REPO_URL generates Maven settings and profile configuration
-    Given s2i build https://github.com/jhuttana/openjdk-test-applications/tree/pick_relevant_sources from spring-boot-sample-simple/target
+    Given s2i build https://github.com/jhuttana/openjdk-test-applications from spring-boot-sample-simple/target using pick_relevant_sources
        | variable       | value                                |
        | MAVEN_REPO_URL | http://repo.example.com:8080/maven2/ |
        | MAVEN_REPO_ID  | myrepo                               |
@@ -168,6 +168,6 @@ Feature: Openshift OpenJDK S2I tests
     Then XML file /tmp/artifacts/configuration/settings.xml should have 1 elements on XPath //ns:profile[ns:id='myrepo-profile']/ns:repositories/ns:repository[ns:url='http://repo.example.com:8080/maven2/']
 
   Scenario: Ensure the environment is cleaned when executing mvn (OPENJDK-1549)
-      Given s2i build https://github.com/jhuttana/openjdk-test-applications/tree/pick_relevant_sources from tests/OPENJDK-1549 with env
+      Given s2i build https://github.com/jhuttana/openjdk-test-applications from tests/OPENJDK-1549 with env using pick_relevant_sources
        | variable           | value    |
        | MAVEN_ARGS         | validate |

--- a/tests/features/java/java_s2i_inc.feature
+++ b/tests/features/java/java_s2i_inc.feature
@@ -4,12 +4,12 @@ Feature: Openshift OpenJDK S2I tests
 
   # test incremental builds
   Scenario: Check incremental builds cache .m2
-    Given s2i build https://github.com/jhuttana/openjdk-test-applications/tree/pick_relevant_sources from undertow-servlet
+    Given s2i build https://github.com/jhuttana/openjdk-test-applications from undertow-servlet using pick_relevant_sources
         | variable    | value               |
         | JAVA_ARGS   | Hello from CTF test |
     Then container log should contain /deployments/undertow-servlet.jar Hello from CTF test
      And s2i build log should contain Downloading from central:
-    Given s2i build https://github.com/jhuttana/openjdk-test-applications/tree/pick_relevant_sources from undertow-servlet with env and incremental
+    Given s2i build https://github.com/jhuttana/openjdk-test-applications from undertow-servlet with env and incremental using pick_relevant_sources
         | variable    | value               |
         | JAVA_ARGS   | Hello from CTF test |
     Then container log should contain /deployments/undertow-servlet.jar Hello from CTF test

--- a/tests/features/java/java_s2i_inc.feature
+++ b/tests/features/java/java_s2i_inc.feature
@@ -4,12 +4,12 @@ Feature: Openshift OpenJDK S2I tests
 
   # test incremental builds
   Scenario: Check incremental builds cache .m2
-    Given s2i build https://github.com/jhuttana/openjdk-test-applications from undertow-servlet using pick_relevant_sources
+    Given s2i build https://github.com/jboss-container-images/openjdk-test-applications from undertow-servlet
         | variable    | value               |
         | JAVA_ARGS   | Hello from CTF test |
     Then container log should contain /deployments/undertow-servlet.jar Hello from CTF test
      And s2i build log should contain Downloading from central:
-    Given s2i build https://github.com/jhuttana/openjdk-test-applications from undertow-servlet with env and incremental using pick_relevant_sources
+    Given s2i build https://github.com/jboss-container-images/openjdk-test-applications from undertow-servlet with env and incremental
         | variable    | value               |
         | JAVA_ARGS   | Hello from CTF test |
     Then container log should contain /deployments/undertow-servlet.jar Hello from CTF test

--- a/tests/features/java/java_s2i_inc.feature
+++ b/tests/features/java/java_s2i_inc.feature
@@ -4,12 +4,12 @@ Feature: Openshift OpenJDK S2I tests
 
   # test incremental builds
   Scenario: Check incremental builds cache .m2
-    Given s2i build https://github.com/jboss-openshift/openshift-quickstarts from undertow-servlet
+    Given s2i build https://github.com/jhuttana/openjdk-test-applications/tree/pick_relevant_sources from undertow-servlet
         | variable    | value               |
         | JAVA_ARGS   | Hello from CTF test |
     Then container log should contain /deployments/undertow-servlet.jar Hello from CTF test
      And s2i build log should contain Downloading from central:
-    Given s2i build https://github.com/jboss-openshift/openshift-quickstarts from undertow-servlet with env and incremental
+    Given s2i build https://github.com/jhuttana/openjdk-test-applications/tree/pick_relevant_sources from undertow-servlet with env and incremental
         | variable    | value               |
         | JAVA_ARGS   | Hello from CTF test |
     Then container log should contain /deployments/undertow-servlet.jar Hello from CTF test

--- a/tests/features/java/memory.feature
+++ b/tests/features/java/memory.feature
@@ -36,5 +36,5 @@ Feature: OPENJDK-559 JVM Memory tests
   @ubi9/openjdk-11
   @ubi9/openjdk-17
   Scenario: Ensure Maven doesn't use MaxRAMPercentage=80
-    Given s2i build https://github.com/jhuttana/openjdk-test-applications/tree/pick_relevant_sources from spring-boot-sample-simple
+    Given s2i build https://github.com/jhuttana/openjdk-test-applications from spring-boot-sample-simple using pick_relevant_sources
     Then s2i build log should match regex INFO Using MAVEN_OPTS.*-XX:MaxRAMPercentage=25.0$

--- a/tests/features/java/memory.feature
+++ b/tests/features/java/memory.feature
@@ -36,5 +36,5 @@ Feature: OPENJDK-559 JVM Memory tests
   @ubi9/openjdk-11
   @ubi9/openjdk-17
   Scenario: Ensure Maven doesn't use MaxRAMPercentage=80
-    Given s2i build https://github.com/jhuttana/openjdk-test-applications from spring-boot-sample-simple using pick_relevant_sources
+    Given s2i build https://github.com/jboss-container-images/openjdk-test-applications from spring-boot-sample-simple
     Then s2i build log should match regex INFO Using MAVEN_OPTS.*-XX:MaxRAMPercentage=25.0$

--- a/tests/features/java/memory.feature
+++ b/tests/features/java/memory.feature
@@ -36,5 +36,5 @@ Feature: OPENJDK-559 JVM Memory tests
   @ubi9/openjdk-11
   @ubi9/openjdk-17
   Scenario: Ensure Maven doesn't use MaxRAMPercentage=80
-    Given s2i build https://github.com/jboss-openshift/openshift-examples from spring-boot-sample-simple
+    Given s2i build https://github.com/jhuttana/openjdk-test-applications/tree/pick_relevant_sources from spring-boot-sample-simple
     Then s2i build log should match regex INFO Using MAVEN_OPTS.*-XX:MaxRAMPercentage=25.0$

--- a/tests/features/java/openjdk_s2i.feature
+++ b/tests/features/java/openjdk_s2i.feature
@@ -3,7 +3,7 @@
 @ubi9/openjdk-17
 Feature: Openshift OpenJDK-only S2I tests
   Scenario: Check java perf dir owned by default (CLOUD-2070, OPENJDK-91)
-    Given s2i build https://github.com/jboss-openshift/openshift-quickstarts from undertow-servlet
+    Given s2i build https://github.com/jhuttana/openjdk-test-applications/tree/pick_relevant_sources from undertow-servlet
     Then run jstat -gc 1 1000 1 in container and check its output for S0C
     And run stat --printf="%U %G" /tmp/hsperfdata_default/ in container and check its output for default root
 

--- a/tests/features/java/openjdk_s2i.feature
+++ b/tests/features/java/openjdk_s2i.feature
@@ -8,7 +8,7 @@ Feature: Openshift OpenJDK-only S2I tests
     And run stat --printf="%U %G" /tmp/hsperfdata_default/ in container and check its output for default root
 
   Scenario: Ensure Quarkus CDS doesn't fail due to timestamp mismatch (OPENDJK-1673)
-    Given s2i build https://github.com/jhuttana/openjdk-test-applications/tree/pick_relevant_sources from getting-started
+    Given s2i build https://github.com/jhuttana/openjdk-test-applications from getting-started using pick_relevant_sources
     Then container log should not contain A jar file is not the one used while building the shared archive file
 
   Scenario: quarkus fast-jar layout works out-of-the-box (OPENJDK-631)

--- a/tests/features/java/openjdk_s2i.feature
+++ b/tests/features/java/openjdk_s2i.feature
@@ -3,16 +3,16 @@
 @ubi9/openjdk-17
 Feature: Openshift OpenJDK-only S2I tests
   Scenario: Check java perf dir owned by default (CLOUD-2070, OPENJDK-91)
-    Given s2i build https://github.com/jhuttana/openjdk-test-applications from undertow-servlet using pick_relevant_sources
+    Given s2i build https://github.com/jboss-container-images/openjdk-test-applications from undertow-servlet
     Then run jstat -gc 1 1000 1 in container and check its output for S0C
     And run stat --printf="%U %G" /tmp/hsperfdata_default/ in container and check its output for default root
 
   Scenario: Ensure Quarkus CDS doesn't fail due to timestamp mismatch (OPENDJK-1673)
-    Given s2i build https://github.com/jhuttana/openjdk-test-applications from getting-started using pick_relevant_sources
+    Given s2i build https://github.com/jboss-container-images/openjdk-test-applications from getting-started
     Then container log should not contain A jar file is not the one used while building the shared archive file
 
   Scenario: quarkus fast-jar layout works out-of-the-box (OPENJDK-631)
-    Given s2i build https://github.com/jhuttana/openjdk-test-applications from quarkus-quickstarts/getting-started-3.0.1.Final-nos2i using pick_relevant_sources
+    Given s2i build https://github.com/jboss-container-images/openjdk-test-applications from quarkus-quickstarts/getting-started-3.0.1.Final-nos2i
     Then container log should contain INFO quarkus fast-jar package type detected
     And  container log should contain -jar /deployments/quarkus-app/quarkus-run.jar
     And  container log should contain (main) getting-started 1.0.0-SNAPSHOT on JVM (powered by Quarkus
@@ -21,7 +21,7 @@ Feature: Openshift OpenJDK-only S2I tests
     And  container log should not contain no main manifest attribute
 
   Scenario: quarkus uber-jar layout works out-of-the-box (OPENJDK-631)
-    Given s2i build https://github.com/jhuttana/openjdk-test-applications from quarkus-quickstarts/getting-started-3.0.1.Final-nos2i with env using pick_relevant_sources
+    Given s2i build https://github.com/jboss-container-images/openjdk-test-applications from quarkus-quickstarts/getting-started-3.0.1.Final-nos2i with env
        | variable             | value    |
        | QUARKUS_PACKAGE_TYPE | uber-jar |
     Then container log should not contain INFO quarkus fast-jar package type detected

--- a/tests/features/java/openjdk_s2i.feature
+++ b/tests/features/java/openjdk_s2i.feature
@@ -8,11 +8,11 @@ Feature: Openshift OpenJDK-only S2I tests
     And run stat --printf="%U %G" /tmp/hsperfdata_default/ in container and check its output for default root
 
   Scenario: Ensure Quarkus CDS doesn't fail due to timestamp mismatch (OPENDJK-1673)
-    Given s2i build https://github.com/jerboaa/quarkus-quickstarts from getting-started using quickstart-2.16-s2i-cds
+    Given s2i build https://github.com/jhuttana/openjdk-test-applications/tree/pick_relevant_sources from getting-started
     Then container log should not contain A jar file is not the one used while building the shared archive file
 
   Scenario: quarkus fast-jar layout works out-of-the-box (OPENJDK-631)
-    Given s2i build https://github.com/jmtd/openshift-quickstarts from quarkus-quickstarts/getting-started-3.0.1.Final-nos2i using OPENJDK-631-quarkus-fast-jar
+    Given s2i build https://github.com/jhuttana/openjdk-test-applications/tree/pick_relevant_sources from quarkus-quickstarts/getting-started-3.0.1.Final-nos2i
     Then container log should contain INFO quarkus fast-jar package type detected
     And  container log should contain -jar /deployments/quarkus-app/quarkus-run.jar
     And  container log should contain (main) getting-started 1.0.0-SNAPSHOT on JVM (powered by Quarkus
@@ -21,7 +21,7 @@ Feature: Openshift OpenJDK-only S2I tests
     And  container log should not contain no main manifest attribute
 
   Scenario: quarkus uber-jar layout works out-of-the-box (OPENJDK-631)
-    Given s2i build https://github.com/jmtd/openshift-quickstarts from quarkus-quickstarts/getting-started-3.0.1.Final-nos2i with env using OPENJDK-631-quarkus-fast-jar
+    Given s2i build https://github.com/jhuttana/openjdk-test-applications/tree/pick_relevant_sources from quarkus-quickstarts/getting-started-3.0.1.Final-nos2i with env
        | variable             | value    |
        | QUARKUS_PACKAGE_TYPE | uber-jar |
     Then container log should not contain INFO quarkus fast-jar package type detected

--- a/tests/features/java/openjdk_s2i.feature
+++ b/tests/features/java/openjdk_s2i.feature
@@ -3,7 +3,7 @@
 @ubi9/openjdk-17
 Feature: Openshift OpenJDK-only S2I tests
   Scenario: Check java perf dir owned by default (CLOUD-2070, OPENJDK-91)
-    Given s2i build https://github.com/jhuttana/openjdk-test-applications/tree/pick_relevant_sources from undertow-servlet
+    Given s2i build https://github.com/jhuttana/openjdk-test-applications from undertow-servlet using pick_relevant_sources
     Then run jstat -gc 1 1000 1 in container and check its output for S0C
     And run stat --printf="%U %G" /tmp/hsperfdata_default/ in container and check its output for default root
 
@@ -12,7 +12,7 @@ Feature: Openshift OpenJDK-only S2I tests
     Then container log should not contain A jar file is not the one used while building the shared archive file
 
   Scenario: quarkus fast-jar layout works out-of-the-box (OPENJDK-631)
-    Given s2i build https://github.com/jhuttana/openjdk-test-applications/tree/pick_relevant_sources from quarkus-quickstarts/getting-started-3.0.1.Final-nos2i
+    Given s2i build https://github.com/jhuttana/openjdk-test-applications from quarkus-quickstarts/getting-started-3.0.1.Final-nos2i using pick_relevant_sources
     Then container log should contain INFO quarkus fast-jar package type detected
     And  container log should contain -jar /deployments/quarkus-app/quarkus-run.jar
     And  container log should contain (main) getting-started 1.0.0-SNAPSHOT on JVM (powered by Quarkus
@@ -21,7 +21,7 @@ Feature: Openshift OpenJDK-only S2I tests
     And  container log should not contain no main manifest attribute
 
   Scenario: quarkus uber-jar layout works out-of-the-box (OPENJDK-631)
-    Given s2i build https://github.com/jhuttana/openjdk-test-applications/tree/pick_relevant_sources from quarkus-quickstarts/getting-started-3.0.1.Final-nos2i with env
+    Given s2i build https://github.com/jhuttana/openjdk-test-applications from quarkus-quickstarts/getting-started-3.0.1.Final-nos2i with env using pick_relevant_sources
        | variable             | value    |
        | QUARKUS_PACKAGE_TYPE | uber-jar |
     Then container log should not contain INFO quarkus fast-jar package type detected

--- a/tests/features/java/ports.feature
+++ b/tests/features/java/ports.feature
@@ -3,7 +3,7 @@
 Feature: Openshift OpenJDK port tests
 
   Scenario: Check ports are available
-    Given s2i build https://github.com/jhuttana/openjdk-test-applications/tree/pick_relevant_sources from undertow-servlet
+    Given s2i build https://github.com/jhuttana/openjdk-test-applications from undertow-servlet using pick_relevant_sources
     Then check that port 8080 is open
     Then check that port 8443 is open
     Then inspect container

--- a/tests/features/java/ports.feature
+++ b/tests/features/java/ports.feature
@@ -3,7 +3,7 @@
 Feature: Openshift OpenJDK port tests
 
   Scenario: Check ports are available
-    Given s2i build https://github.com/jhuttana/openjdk-test-applications from undertow-servlet using pick_relevant_sources
+    Given s2i build https://github.com/jboss-container-images/openjdk-test-applications from undertow-servlet
     Then check that port 8080 is open
     Then check that port 8443 is open
     Then inspect container

--- a/tests/features/java/ports.feature
+++ b/tests/features/java/ports.feature
@@ -3,7 +3,7 @@
 Feature: Openshift OpenJDK port tests
 
   Scenario: Check ports are available
-    Given s2i build https://github.com/jboss-openshift/openshift-quickstarts from undertow-servlet
+    Given s2i build https://github.com/jhuttana/openjdk-test-applications/tree/pick_relevant_sources from undertow-servlet
     Then check that port 8080 is open
     Then check that port 8443 is open
     Then inspect container

--- a/tests/features/java/runtime.feature
+++ b/tests/features/java/runtime.feature
@@ -3,7 +3,7 @@
 Feature: Openshift OpenJDK Runtime tests
 
   Scenario: Ensure JAVA_ARGS is passed through, diagnostic options work correctly, JVM_ARGS not present in run script, OPENJDK-474 JAVA_ARGS not repeated
-    Given s2i build https://github.com/jhuttana/openjdk-test-applications/tree/pick_relevant_sources from undertow-servlet
+    Given s2i build https://github.com/jhuttana/openjdk-test-applications from undertow-servlet using pick_relevant_sources
        | variable         | value  |
        | JAVA_ARGS        | unique |
        | JAVA_DIAGNOSTICS | true   |
@@ -70,7 +70,7 @@ Feature: Openshift OpenJDK Runtime tests
 
   # Builder images only
   Scenario: Ensure JAVA_APP_DIR and S2I work together (OPENJDK-2034)
-    Given s2i build https://github.com/jhuttana/openjdk-test-applications/tree/pick_relevant_sources from undertow-servlet
+    Given s2i build https://github.com/jhuttana/openjdk-test-applications from undertow-servlet using pick_relevant_sources
        | variable                   | value         |
        | JAVA_APP_DIR               | /home/default |
        | S2I_TARGET_DEPLOYMENTS_DIR | /home/default |

--- a/tests/features/java/runtime.feature
+++ b/tests/features/java/runtime.feature
@@ -3,7 +3,7 @@
 Feature: Openshift OpenJDK Runtime tests
 
   Scenario: Ensure JAVA_ARGS is passed through, diagnostic options work correctly, JVM_ARGS not present in run script, OPENJDK-474 JAVA_ARGS not repeated
-    Given s2i build https://github.com/jboss-openshift/openshift-quickstarts from undertow-servlet
+    Given s2i build https://github.com/jhuttana/openjdk-test-applications/tree/pick_relevant_sources from undertow-servlet
        | variable         | value  |
        | JAVA_ARGS        | unique |
        | JAVA_DIAGNOSTICS | true   |
@@ -70,7 +70,7 @@ Feature: Openshift OpenJDK Runtime tests
 
   # Builder images only
   Scenario: Ensure JAVA_APP_DIR and S2I work together (OPENJDK-2034)
-    Given s2i build https://github.com/jboss-openshift/openshift-quickstarts from undertow-servlet
+    Given s2i build https://github.com/jhuttana/openjdk-test-applications/tree/pick_relevant_sources from undertow-servlet
        | variable                   | value         |
        | JAVA_APP_DIR               | /home/default |
        | S2I_TARGET_DEPLOYMENTS_DIR | /home/default |

--- a/tests/features/java/runtime.feature
+++ b/tests/features/java/runtime.feature
@@ -3,7 +3,7 @@
 Feature: Openshift OpenJDK Runtime tests
 
   Scenario: Ensure JAVA_ARGS is passed through, diagnostic options work correctly, JVM_ARGS not present in run script, OPENJDK-474 JAVA_ARGS not repeated
-    Given s2i build https://github.com/jhuttana/openjdk-test-applications from undertow-servlet using pick_relevant_sources
+    Given s2i build https://github.com/jboss-container-images/openjdk-test-applications from undertow-servlet
        | variable         | value  |
        | JAVA_ARGS        | unique |
        | JAVA_DIAGNOSTICS | true   |
@@ -70,7 +70,7 @@ Feature: Openshift OpenJDK Runtime tests
 
   # Builder images only
   Scenario: Ensure JAVA_APP_DIR and S2I work together (OPENJDK-2034)
-    Given s2i build https://github.com/jhuttana/openjdk-test-applications from undertow-servlet using pick_relevant_sources
+    Given s2i build https://github.com/jboss-container-images/openjdk-test-applications from undertow-servlet
        | variable                   | value         |
        | JAVA_APP_DIR               | /home/default |
        | S2I_TARGET_DEPLOYMENTS_DIR | /home/default |

--- a/tests/features/s2i-core.feature
+++ b/tests/features/s2i-core.feature
@@ -3,5 +3,5 @@
 Feature: Openshift S2I tests
   # OPENJDK-84 - /tmp/src should not be present after build
   Scenario: run an s2i build and check that /tmp/src has been removed afterwards
-    Given s2i build https://github.com/jhuttana/openjdk-test-applications/tree/pick_relevant_sources from spring-boot-sample-simple
+    Given s2i build https://github.com/jhuttana/openjdk-test-applications from spring-boot-sample-simple using pick_relevant_sources
     Then run stat /tmp/src in container and immediately check its output does not contain File:

--- a/tests/features/s2i-core.feature
+++ b/tests/features/s2i-core.feature
@@ -3,5 +3,5 @@
 Feature: Openshift S2I tests
   # OPENJDK-84 - /tmp/src should not be present after build
   Scenario: run an s2i build and check that /tmp/src has been removed afterwards
-    Given s2i build https://github.com/jboss-openshift/openshift-examples from spring-boot-sample-simple
+    Given s2i build https://github.com/jhuttana/openjdk-test-applications/tree/pick_relevant_sources from spring-boot-sample-simple
     Then run stat /tmp/src in container and immediately check its output does not contain File:

--- a/tests/features/s2i-core.feature
+++ b/tests/features/s2i-core.feature
@@ -3,5 +3,5 @@
 Feature: Openshift S2I tests
   # OPENJDK-84 - /tmp/src should not be present after build
   Scenario: run an s2i build and check that /tmp/src has been removed afterwards
-    Given s2i build https://github.com/jhuttana/openjdk-test-applications from spring-boot-sample-simple using pick_relevant_sources
+    Given s2i build https://github.com/jboss-container-images/openjdk-test-applications from spring-boot-sample-simple
     Then run stat /tmp/src in container and immediately check its output does not contain File:


### PR DESCRIPTION
This is in support of https://github.com/jboss-container-images/openjdk-test-applications/pull/1 which in-turn addresses
Jira ticket: https://issues.redhat.com/browse/OPENJDK-2199
GH Issue: https://github.com/jboss-container-images/openjdk/issues/400

Could you please take a look?


