### PR TITLE
[OPENJDK-2372] singleton-jdk: force-set more java alternatives

### DIFF
--- a/modules/singleton-jdk/configure.sh
+++ b/modules/singleton-jdk/configure.sh
@@ -15,7 +15,9 @@ fi
 # our stated JAVA_VERSION-JAVA_VENDOR (e.g.: 11-openjdk; 1.8.0-openj9)
 rpm -e --nodeps $(rpm -qa java-* | grep -v "^java-${JAVA_VERSION}-${JAVA_VENDOR}")
 
-# workaround for https://issues.redhat.com/browse/RHEL-3437
+# workaround for <https://issues.redhat.com/browse/RHEL-3437>
+# The alternative link groups touched here need to match up with those set in
+# modules/jdk/*/configure.sh
 _arch="$(uname -m)"
 for alt in java javac java_sdk_openjdk jre_openjdk; do
   alternatives --set "$alt" "java-${JAVA_VERSION}-${JAVA_VENDOR}.${_arch}"

--- a/modules/singleton-jdk/configure.sh
+++ b/modules/singleton-jdk/configure.sh
@@ -16,4 +16,7 @@ fi
 rpm -e --nodeps $(rpm -qa java-* | grep -v "^java-${JAVA_VERSION}-${JAVA_VENDOR}")
 
 # workaround for https://bugzilla.redhat.com/show_bug.cgi?id=2089626
-alternatives --set java "java-${JAVA_VERSION}-${JAVA_VENDOR}.$(uname -m)"
+_arch="$(uname -m)"
+for alt in java javac java_sdk_openjdk jre_openjdk; do
+  alternatives --set "$alt" "$java-${JAVA_VERSION}-${JAVA_VENDOR}.${_arch}"
+done

--- a/modules/singleton-jdk/configure.sh
+++ b/modules/singleton-jdk/configure.sh
@@ -18,7 +18,7 @@ rpm -e --nodeps $(rpm -qa java-* | grep -v "^java-${JAVA_VERSION}-${JAVA_VENDOR}
 # workaround for <https://issues.redhat.com/browse/RHEL-3437>
 # The alternative link groups touched here need to match up with those set in
 # modules/jdk/*/configure.sh
-_arch="$(uname -m)"
+_arch="$(uname -i)"
 for alt in java javac java_sdk_openjdk jre_openjdk; do
   alternatives --set "$alt" "java-${JAVA_VERSION}-${JAVA_VENDOR}.${_arch}"
 done

--- a/modules/singleton-jdk/configure.sh
+++ b/modules/singleton-jdk/configure.sh
@@ -18,5 +18,5 @@ rpm -e --nodeps $(rpm -qa java-* | grep -v "^java-${JAVA_VERSION}-${JAVA_VENDOR}
 # workaround for https://issues.redhat.com/browse/RHEL-3437
 _arch="$(uname -m)"
 for alt in java javac java_sdk_openjdk jre_openjdk; do
-  alternatives --set "$alt" "$java-${JAVA_VERSION}-${JAVA_VENDOR}.${_arch}"
+  alternatives --set "$alt" "java-${JAVA_VERSION}-${JAVA_VENDOR}.${_arch}"
 done

--- a/modules/singleton-jdk/configure.sh
+++ b/modules/singleton-jdk/configure.sh
@@ -15,7 +15,7 @@ fi
 # our stated JAVA_VERSION-JAVA_VENDOR (e.g.: 11-openjdk; 1.8.0-openj9)
 rpm -e --nodeps $(rpm -qa java-* | grep -v "^java-${JAVA_VERSION}-${JAVA_VENDOR}")
 
-# workaround for https://bugzilla.redhat.com/show_bug.cgi?id=2089626
+# workaround for https://issues.redhat.com/browse/RHEL-3437
 _arch="$(uname -m)"
 for alt in java javac java_sdk_openjdk jre_openjdk; do
   alternatives --set "$alt" "$java-${JAVA_VERSION}-${JAVA_VENDOR}.${_arch}"


### PR DESCRIPTION
This is to fix a race situation where, sometimes, removing JDK8 after installing JDK11 results in the jre_openjdk link group being empty. For further information

* https://issues.redhat.com/browse/OPENJDK-2372
* https://issues.redhat.com/browse/RHEL-3437
* https://issues.redhat.com/browse/RHEL-3444

(UBI8 cherry-pick to follow)