### PR TITLE
[OPENJDK-2408] s2i: use --archive flag for rsync

### DIFF
--- a/modules/s2i/bash/artifacts/opt/jboss/container/java/s2i/maven-s2i-overrides
+++ b/modules/s2i/bash/artifacts/opt/jboss/container/java/s2i/maven-s2i-overrides
@@ -29,7 +29,7 @@ function maven_s2i_custom_binary_build() {
     binary_dir="${S2I_SOURCE_DIR}"
   fi
   log_info "Copying binaries from ${binary_dir} to ${S2I_TARGET_DEPLOYMENTS_DIR} ..."
-  rsync -rl --out-format='%n' "${binary_dir}"/ "${S2I_TARGET_DEPLOYMENTS_DIR}"
+  rsync --archive --out-format='%n' "${binary_dir}"/ "${S2I_TARGET_DEPLOYMENTS_DIR}"
 }
 
 function maven_s2i_deploy_artifacts_override() {

--- a/modules/s2i/core/artifacts/opt/jboss/container/s2i/core/s2i-core
+++ b/modules/s2i/core/artifacts/opt/jboss/container/s2i/core/s2i-core
@@ -53,7 +53,7 @@ function s2i_core_copy_configuration() {
         mkdir -pm 775 "${S2I_TARGET_CONFIGURATION_DIR}"
       fi
       log_info "Copying configuration from $(realpath --relative-to ${S2I_SOURCE_DIR} ${1}/${S2I_SOURCE_CONFIGURATION_DIR}) to ${S2I_TARGET_CONFIGURATION_DIR}..."
-      rsync -rl --out-format='%n' "${1}/${S2I_SOURCE_CONFIGURATION_DIR}"/ "${S2I_TARGET_CONFIGURATION_DIR}"
+      rsync --archive --out-format='%n' "${1}/${S2I_SOURCE_CONFIGURATION_DIR}"/ "${S2I_TARGET_CONFIGURATION_DIR}"
     fi
   fi 
 }
@@ -70,7 +70,7 @@ function s2i_core_copy_data() {
         mkdir -pm 775 "${S2I_TARGET_DATA_DIR}"
       fi
       log_info "Copying app data from $(realpath --relative-to ${S2I_SOURCE_DIR} ${1}/${S2I_SOURCE_DATA_DIR}) to ${S2I_TARGET_DATA_DIR}..."
-      rsync -rl --out-format='%n' "${1}/${S2I_SOURCE_DATA_DIR}"/ "${S2I_TARGET_DATA_DIR}"
+      rsync --archive --out-format='%n' "${1}/${S2I_SOURCE_DATA_DIR}"/ "${S2I_TARGET_DATA_DIR}"
       # s2i used to be more forgiving, but the build will fail if this call
       # fails.  emit a warning and allow the build to succeed
       chmod -R g+rwX "${S2I_TARGET_DATA_DIR}" || log_warning "Errors occurred while adding read/write permissions to S2I_TARGET_DATA_DIR ($S2I_TARGET_DATA_DIR)."

--- a/tests/features/java/java_s2i.feature
+++ b/tests/features/java/java_s2i.feature
@@ -179,3 +179,9 @@ Feature: Openshift OpenJDK S2I tests
        | S2I_SOURCE_DATA_DIR | ./           |
        | S2I_TARGET_DATA_DIR | /deployments |
       Then container log should contain INFO exec -a "someUniqueString" java
+
+  Scenario: Ensure mtime is preserved for build artifacts (OPENJDK-2408)
+      Given s2i build https://github.com/jboss-container-images/openjdk-test-applications from OPENJDK-2408-bin-custom-s2i-assemble with env
+       | variable          | value |
+       | S2I_DELETE_SOURCE | false |
+    Then run find /deployments/spring-boot-sample-simple-1.5.0.BUILD-SNAPSHOT.jar ! -newer /tmp/src/spring-boot-sample-simple-1.5.0.BUILD-SNAPSHOT.jar in container and check its output for spring-boot-sample-simple-1.5.0.BUILD-SNAPSHOT.jar


### PR DESCRIPTION
Switch from '-rl' to '--archive' which attempts to preserve as much metadata from the source files as possible, including timestamps, the motivation behind OPENJDK-2408.

https://issues.redhat.com/browse/OPENJDK-2408

I haven't written a test yet, I'm just mooting the approach.