### PR TITLE
[OPENJDK-2200] Test coverage for user-provided run-env.sh

### DIFF
--- a/tests/features/java/java_s2i.feature
+++ b/tests/features/java/java_s2i.feature
@@ -173,7 +173,7 @@ Feature: Openshift OpenJDK S2I tests
        | MAVEN_ARGS         | validate |
 
   Scenario: Ensure that run-env.sh placed in the JAVA_APP_DIR is sourced in the run script before launching java
-      Given s2i build https://github.com/jboss-container-images/openjdk-test-applications from quarkus-quickstarts/getting-started-3.0.1.Final-nos2i using main
+      Given s2i build https://github.com/jboss-container-images/openjdk-test-applications from quarkus-quickstarts/getting-started-3.0.1.Final-nos2i
        | variable            | value        |
        | S2I_SOURCE_DATA_DIR | ./           |
        | S2I_TARGET_DATA_DIR | /deployments |

--- a/tests/features/java/java_s2i.feature
+++ b/tests/features/java/java_s2i.feature
@@ -171,3 +171,10 @@ Feature: Openshift OpenJDK S2I tests
       Given s2i build https://github.com/jboss-container-images/openjdk from tests/OPENJDK-1549 with env using ubi9
        | variable           | value    |
        | MAVEN_ARGS         | validate |
+
+  Scenario: Ensure that run-env.sh placed in the JAVA_APP_DIR is sourced in the run script before launching java
+      Given s2i build https://github.com/jboss-container-images/openjdk-test-applications from quarkus-quickstarts/getting-started-3.0.1.Final-nos2i using main
+       | variable            | value        |
+       | S2I_SOURCE_DATA_DIR | ./           |
+       | S2I_TARGET_DATA_DIR | /deployments |
+      Then container log should contain INFO exec -a "someUniqueString" java


### PR DESCRIPTION
JIRA issue: https://issues.redhat.com/browse/OPENJDK-2200
GH issue: https://github.com/jboss-container-images/openjdk/issues/399
The referenced application source is included in the PR : https://github.com/jboss-container-images/openjdk-test-applications/pull/3
