### PR TITLE
Set GHA job timeout down to 1 hour (from 6)

### DIFF
--- a/.github/workflows/image-workflow-template.yml
+++ b/.github/workflows/image-workflow-template.yml
@@ -10,6 +10,7 @@ env:
 jobs:
   openjdkci:
     name: OpenJDK S2I Build and Test
+    timeout-minutes: 60
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false


### PR DESCRIPTION
A successful run of the jobs should take on the order of 20-30 minutes, so this timeout gives about twice that for headroom. This should cause stuck jobs to fail faster than the default of 6 hours.