### PR TITLE
[OPENJDK-2428] Test coverage for user-provided run-env.sh and Update test URI to refer new application source repo

### DIFF
--- a/tests/features/java.security.feature
+++ b/tests/features/java.security.feature
@@ -4,5 +4,5 @@
 @ubi8/openjdk-21
 Feature: Openshift S2I tests
   Scenario: Check networkaddress.cache.negative.ttl has been set correctly
-    Given s2i build https://github.com/jboss-openshift/openshift-examples/ from binary-cli-security-property
+    Given s2i build https://github.com/jboss-container-images/openjdk-test-applications from binary-cli-security-property
     Then s2i build log should contain networkaddress.cache.negative.ttl=0

--- a/tests/features/java/java_s2i.feature
+++ b/tests/features/java/java_s2i.feature
@@ -9,7 +9,7 @@ Feature: Openshift OpenJDK S2I tests
 
   # handles mirror/repository configuration; proxy configuration
   Scenario: run the s2i and check the maven mirror and proxy have been initialised in the default settings.xml, uses http_proxy
-    Given s2i build https://github.com/jboss-openshift/openshift-examples from spring-boot-sample-simple
+    Given s2i build https://github.com/jboss-container-images/openjdk-test-applications from spring-boot-sample-simple
        | variable           | value                                            |
        | MAVEN_ARGS         | -v                                               |
        | MAVEN_MIRROR_URL   | http://127.0.0.1:8080/repository/internal/       |
@@ -22,7 +22,7 @@ Feature: Openshift OpenJDK S2I tests
 
   # proxy auth configuration (success case) + nonProxyHosts
   Scenario: run the s2i and check the maven mirror, proxy (including username and password) and non proxy have been initialised in the default settings.xml, uses http_proxy
-    Given s2i build https://github.com/jboss-openshift/openshift-examples from spring-boot-sample-simple
+    Given s2i build https://github.com/jboss-container-images/openjdk-test-applications from spring-boot-sample-simple
        | variable           | value                                            |
        | MAVEN_ARGS         | -v                                               |
        | http_proxy         | myuser:mypass@127.0.0.1:8080                     |
@@ -34,7 +34,7 @@ Feature: Openshift OpenJDK S2I tests
 
   # proxy auth configuration (fail case: no password supplied)
   Scenario: run the s2i and check the maven mirror, proxy (including username) and non proxy have been initialised in the default settings.xml, uses http_proxy
-    Given s2i build https://github.com/jboss-openshift/openshift-examples from spring-boot-sample-simple
+    Given s2i build https://github.com/jboss-container-images/openjdk-test-applications from spring-boot-sample-simple
        | variable           | value                                            |
        | MAVEN_ARGS         | -v                                               |
        | http_proxy         | myuser@127.0.0.1:8080                            |
@@ -45,7 +45,7 @@ Feature: Openshift OpenJDK S2I tests
 
   # handles mirror/repository configuration; proxy configuration
   Scenario: run the s2i and check the maven mirror and proxy have been initialised in the default settings.xml, uses HTTP_PROXY
-    Given s2i build https://github.com/jboss-openshift/openshift-examples from spring-boot-sample-simple
+    Given s2i build https://github.com/jboss-container-images/openjdk-test-applications from spring-boot-sample-simple
        | variable           | value                                            |
        | MAVEN_ARGS         | -v                                               |
        | MAVEN_MIRROR_URL   | http://127.0.0.1:8080/repository/internal/       |
@@ -58,7 +58,7 @@ Feature: Openshift OpenJDK S2I tests
 
   # proxy auth configuration (success case) + nonProxyHosts
   Scenario: run the s2i and check the maven mirror, proxy (including username and password) and non proxy have been initialised in the default settings.xml, uses HTTP_PROXY
-    Given s2i build https://github.com/jboss-openshift/openshift-examples from spring-boot-sample-simple
+    Given s2i build https://github.com/jboss-container-images/openjdk-test-applications from spring-boot-sample-simple
        | variable           | value                                            |
        | MAVEN_ARGS         | -v                                               |
        | HTTP_PROXY         | myuser:mypass@127.0.0.1:8080                     |
@@ -70,7 +70,7 @@ Feature: Openshift OpenJDK S2I tests
 
   # proxy auth configuration (fail case: no password supplied)
   Scenario: run the s2i and check the maven mirror, proxy (including username) and non proxy have been initialised in the default settings.xml, uses HTTP_PROXY
-    Given s2i build https://github.com/jboss-openshift/openshift-examples from spring-boot-sample-simple
+    Given s2i build https://github.com/jboss-container-images/openjdk-test-applications from spring-boot-sample-simple
        | variable           | value                                            |
        | MAVEN_ARGS         | -v                                               |
        | HTTP_PROXY         | myuser@127.0.0.1:8080                            |
@@ -81,7 +81,7 @@ Feature: Openshift OpenJDK S2I tests
 
   # handles mirror/repository configuration; proxy configuration
   Scenario: run the s2i and check the maven mirror and proxy have been initialised in the default settings.xml, uses http_proxy and HTTP_PROXY
-    Given s2i build https://github.com/jboss-openshift/openshift-examples from spring-boot-sample-simple
+    Given s2i build https://github.com/jboss-container-images/openjdk-test-applications from spring-boot-sample-simple
        | variable           | value                                            |
        | MAVEN_ARGS         | -v                                               |
        | MAVEN_MIRROR_URL   | http://127.0.0.1:8080/repository/internal/       |
@@ -95,7 +95,7 @@ Feature: Openshift OpenJDK S2I tests
 
   # proxy auth configuration (success case) + nonProxyHosts
   Scenario: run the s2i and check the maven mirror, proxy (including username and password) and non proxy have been initialised in the default settings.xml, uses http_proxy and HTTP_PROXY
-    Given s2i build https://github.com/jboss-openshift/openshift-examples from spring-boot-sample-simple
+    Given s2i build https://github.com/jboss-container-images/openjdk-test-applications from spring-boot-sample-simple
        | variable           | value                                            |
        | MAVEN_ARGS         | -v                                               |
        | http_proxy         | user2:pass2@127.0.0.2:9090                       |
@@ -108,7 +108,7 @@ Feature: Openshift OpenJDK S2I tests
 
   # proxy auth configuration (fail case: no password supplied)
   Scenario: run the s2i and check the maven mirror, proxy (including username) and non proxy have been initialised in the default settings.xml, uses http_proxy and HTTP_PROXY
-    Given s2i build https://github.com/jboss-openshift/openshift-examples from spring-boot-sample-simple
+    Given s2i build https://github.com/jboss-container-images/openjdk-test-applications from spring-boot-sample-simple
        | variable           | value                                            |
        | MAVEN_ARGS         | -v                                               |
        | http_proxy         | user2@127.0.0.2:9090                             |
@@ -120,7 +120,7 @@ Feature: Openshift OpenJDK S2I tests
 
   # handles mirror/repository configuration; proxy configuration
   Scenario: run the s2i and check the maven mirror and proxy have been initialised in the default settings.xml, uses https_proxy
-    Given s2i build https://github.com/jboss-openshift/openshift-examples from spring-boot-sample-simple
+    Given s2i build https://github.com/jboss-container-images/openjdk-test-applications from spring-boot-sample-simple
        | variable           | value                                            |
        | MAVEN_ARGS         | -v                                               |
        | MAVEN_MIRROR_URL   | http://127.0.0.1:8080/repository/internal/       |
@@ -133,7 +133,7 @@ Feature: Openshift OpenJDK S2I tests
 
   # proxy auth configuration (success case) + nonProxyHosts
   Scenario: run the s2i and check the maven mirror, proxy (including username and password) and non proxy have been initialised in the default settings.xml, uses https_proxy
-    Given s2i build https://github.com/jboss-openshift/openshift-examples from spring-boot-sample-simple
+    Given s2i build https://github.com/jboss-container-images/openjdk-test-applications from spring-boot-sample-simple
        | variable           | value                                            |
        | MAVEN_ARGS         | -v                                               |
        | https_proxy        | myuser:mypass@127.0.0.1:8080                     |
@@ -145,7 +145,7 @@ Feature: Openshift OpenJDK S2I tests
 
   # proxy auth configuration (fail case: no password supplied)
   Scenario: run the s2i and check the maven mirror, proxy (including username) and non proxy have been initialised in the default settings.xml, uses https_proxy
-    Given s2i build https://github.com/jboss-openshift/openshift-examples from spring-boot-sample-simple
+    Given s2i build https://github.com/jboss-container-images/openjdk-test-applications from spring-boot-sample-simple
        | variable           | value                                            |
        | MAVEN_ARGS         | -v                                               |
        | https_proxy        | myuser@127.0.0.1:8080                            |
@@ -156,7 +156,7 @@ Feature: Openshift OpenJDK S2I tests
 
   # handles mirror/repository configuration; proxy configuration
   Scenario: run the s2i and check the maven mirror and proxy have been initialised in the default settings.xml, uses HTTPS_PROXY
-    Given s2i build https://github.com/jboss-openshift/openshift-examples from spring-boot-sample-simple
+    Given s2i build https://github.com/jboss-container-images/openjdk-test-applications from spring-boot-sample-simple
        | variable           | value                                            |
        | MAVEN_ARGS         | -v                                               |
        | MAVEN_MIRROR_URL   | http://127.0.0.1:8080/repository/internal/       |
@@ -169,7 +169,7 @@ Feature: Openshift OpenJDK S2I tests
 
   # proxy auth configuration (success case) + nonProxyHosts
   Scenario: run the s2i and check the maven mirror, proxy (including username and password) and non proxy have been initialised in the default settings.xml, uses HTTPS_PROXY
-    Given s2i build https://github.com/jboss-openshift/openshift-examples from spring-boot-sample-simple
+    Given s2i build https://github.com/jboss-container-images/openjdk-test-applications from spring-boot-sample-simple
        | variable           | value                                            |
        | MAVEN_ARGS         | -v                                               |
        | HTTPS_PROXY        | myuser:mypass@127.0.0.1:8080                     |
@@ -181,7 +181,7 @@ Feature: Openshift OpenJDK S2I tests
 
   # proxy auth configuration (fail case: no password supplied)
   Scenario: run the s2i and check the maven mirror, proxy (including username) and non proxy have been initialised in the default settings.xml, uses HTTPS_PROXY
-    Given s2i build https://github.com/jboss-openshift/openshift-examples from spring-boot-sample-simple
+    Given s2i build https://github.com/jboss-container-images/openjdk-test-applications from spring-boot-sample-simple
        | variable           | value                                            |
        | MAVEN_ARGS         | -v                                               |
        | HTTPS_PROXY        | myuser@127.0.0.1:8080                            |
@@ -192,7 +192,7 @@ Feature: Openshift OpenJDK S2I tests
 
   # handles mirror/repository configuration; proxy configuration
   Scenario: run the s2i and check the maven mirror and proxy have been initialised in the default settings.xml, uses https_proxy and HTTPS_PROXY
-    Given s2i build https://github.com/jboss-openshift/openshift-examples from spring-boot-sample-simple
+    Given s2i build https://github.com/jboss-container-images/openjdk-test-applications from spring-boot-sample-simple
        | variable           | value                                            |
        | MAVEN_ARGS         | -v                                               |
        | MAVEN_MIRROR_URL   | http://127.0.0.1:8080/repository/internal/       |
@@ -206,7 +206,7 @@ Feature: Openshift OpenJDK S2I tests
 
   # proxy auth configuration (success case) + nonProxyHosts
   Scenario: run the s2i and check the maven mirror, proxy (including username and password) and non proxy have been initialised in the default settings.xml, uses https_proxy and HTTPS_PROXY
-    Given s2i build https://github.com/jboss-openshift/openshift-examples from spring-boot-sample-simple
+    Given s2i build https://github.com/jboss-container-images/openjdk-test-applications from spring-boot-sample-simple
        | variable           | value                                            |
        | MAVEN_ARGS         | -v                                               |
        | https_proxy        | user2:pass2@127.0.0.2:9090                       |
@@ -219,7 +219,7 @@ Feature: Openshift OpenJDK S2I tests
 
   # proxy auth configuration (fail case: no password supplied)
   Scenario: run the s2i and check the maven mirror, proxy (including username) and non proxy have been initialised in the default settings.xml, uses https_proxy and HTTPS_PROXY
-    Given s2i build https://github.com/jboss-openshift/openshift-examples from spring-boot-sample-simple
+    Given s2i build https://github.com/jboss-container-images/openjdk-test-applications from spring-boot-sample-simple
        | variable           | value                                            |
        | MAVEN_ARGS         | -v                                               |
        | https_proxy        | user2@127.0.0.2:9090                             |
@@ -231,7 +231,7 @@ Feature: Openshift OpenJDK S2I tests
 
   # proxy auth configuration (success case) + nonProxyHosts
   Scenario: run the s2i and check the maven mirror, proxy (including username and password) and non proxy have been initialised in the default settings.xml, uses https_proxy and HTTPS_PROXY
-    Given s2i build https://github.com/jboss-openshift/openshift-examples from spring-boot-sample-simple
+    Given s2i build https://github.com/jboss-container-images/openjdk-test-applications from spring-boot-sample-simple
        | variable           | value                                            |
        | MAVEN_ARGS         | -v                                               |
        | https_proxy        | user3:pass3@127.0.0.3:7070                       |
@@ -244,7 +244,7 @@ Feature: Openshift OpenJDK S2I tests
     Then XML file /tmp/artifacts/configuration/settings.xml should have 1 elements on XPath //ns:proxy[ns:id='genproxy'][ns:active='true'][ns:protocol='https'][ns:host='127.0.0.3'][ns:port='7070'][ns:username='user3'][ns:password='pass3'][ns:nonProxyHosts='*.example.com']
 
   Scenario: run s2i assemble and check HTTP_PROXY_NONPROXYHOSTS is honoured
-    Given s2i build https://github.com/jboss-openshift/openshift-examples from spring-boot-sample-simple
+    Given s2i build https://github.com/jboss-container-images/openjdk-test-applications from spring-boot-sample-simple
        | variable           | value                                            |
        | MAVEN_ARGS         | -v                                               |
        | MAVEN_MIRROR_URL   | http://127.0.0.1:8080/repository/internal/       |
@@ -256,7 +256,7 @@ Feature: Openshift OpenJDK S2I tests
     Then XML file /tmp/artifacts/configuration/settings.xml should have 1 elements on XPath //ns:proxy[ns:id='genproxy'][ns:active='true'][ns:protocol='http'][ns:host='127.0.0.1'][ns:port='8080'][ns:nonProxyHosts='*.example.com']
 
   Scenario: run s2i assemble and check HTTP_PROXY_NONPROXYHOSTS is honoured with multiple entries
-    Given s2i build https://github.com/jboss-openshift/openshift-examples from spring-boot-sample-simple
+    Given s2i build https://github.com/jboss-container-images/openjdk-test-applications from spring-boot-sample-simple
        | variable           | value                                            |
        | MAVEN_ARGS         | -v                                               |
        | MAVEN_MIRROR_URL   | http://127.0.0.1:8080/repository/internal/       |
@@ -268,7 +268,7 @@ Feature: Openshift OpenJDK S2I tests
     Then XML file /tmp/artifacts/configuration/settings.xml should have 1 elements on XPath //ns:proxy[ns:id='genproxy'][ns:active='true'][ns:protocol='http'][ns:host='127.0.0.1'][ns:port='8080'][ns:nonProxyHosts='foo.example.com|bar.example.com']
 
   Scenario: run an S2I build that depends on com.redhat.xpaas.repo.redhatga being defined
-    Given s2i build https://github.com/jboss-openshift/openshift-examples from spring-boot-sample-simple
+    Given s2i build https://github.com/jboss-container-images/openjdk-test-applications from spring-boot-sample-simple
 
   Scenario: run an S2I that should fail as MAVEN_ARGS does not define com.redhat.xpaas.repo.redhatga
     Given failing s2i build https://github.com/jboss-openshift/openshift-examples from spring-boot-sample-simple using openjdk-enforce-profile
@@ -276,7 +276,7 @@ Feature: Openshift OpenJDK S2I tests
        | MAVEN_ARGS         | -e package                                       |
 
   Scenario: Ensure legacy ARTIFACT_COPY_ARGS works as it used to
-    Given s2i build https://github.com/jboss-openshift/openshift-quickstarts from undertow-servlet
+    Given s2i build https://github.com/jboss-container-images/openjdk-test-applications from undertow-servlet
        | variable             | value                |
        | ARTIFACT_COPY_ARGS   | undertow-servlet.jar |
        | JAVA_ARGS            | Hello from CTF test  |
@@ -284,20 +284,20 @@ Feature: Openshift OpenJDK S2I tests
 
   # CLOUD-579
   Scenario: Test that maven is executed in batch mode
-    Given s2i build https://github.com/jboss-openshift/openshift-examples from spring-boot-sample-simple
+    Given s2i build https://github.com/jboss-container-images/openjdk-test-applications from spring-boot-sample-simple
     Then s2i build log should contain --batch-mode
     And s2i build log should not contain \r
 
   # CLOUD-3095 - context dir should be recursively copied into the image
   # "/target" suffix is important here; it triggers a different code-path (no source build)
   Scenario: Ensure binary-only mode copies binaries into the target image
-    Given s2i build https://github.com/jboss-openshift/openshift-examples from spring-boot-sample-simple/target
+    Given s2i build https://github.com/jboss-container-images/openjdk-test-applications from spring-boot-sample-simple/target
     Then s2i build log should not contain skipping directory .
     And  run find /deployments in container and check its output for spring-boot-sample-simple-1.5.0.BUILD-SNAPSHOT.jar
 
   # OPENJDK-2069 - MAVEN_REPOS
   Scenario: run the s2i and check the maven mirror and proxy have been initialised in the default settings.xml, uses http_proxy
-    Given s2i build https://github.com/jboss-openshift/openshift-examples from spring-boot-sample-simple/target
+    Given s2i build https://github.com/jboss-container-images/openjdk-test-applications from spring-boot-sample-simple/target
        | variable                | value                                |
        | MAVEN_REPOS             | TESTREPO,ANOTHER                     |
        | TESTREPO_MAVEN_REPO_URL | http://repo.example.com:8080/maven2/ |
@@ -314,7 +314,7 @@ Feature: Openshift OpenJDK S2I tests
 
   # OPENJDK-2068: MAVEN_REPO_URL and MAVEN_REPO_ID
   Scenario: Check MAVEN_REPO_URL generates Maven settings and profile configuration
-    Given s2i build https://github.com/jboss-openshift/openshift-examples from spring-boot-sample-simple/target
+    Given s2i build https://github.com/jboss-container-images/openjdk-test-applications from spring-boot-sample-simple/target
        | variable       | value                                |
        | MAVEN_REPO_URL | http://repo.example.com:8080/maven2/ |
        | MAVEN_REPO_ID  | myrepo                               |
@@ -325,12 +325,12 @@ Feature: Openshift OpenJDK S2I tests
     Then XML file /tmp/artifacts/configuration/settings.xml should have 1 elements on XPath //ns:profile[ns:id='myrepo-profile']/ns:repositories/ns:repository[ns:url='http://repo.example.com:8080/maven2/']
 
   Scenario: Ensure the environment is cleaned when executing mvn (OPENJDK-1548)
-      Given s2i build https://github.com/jmtd/openjdk from tests/OPENJDK-1548 with env using OPENJDK-1548-maven-args
+      Given s2i build https://github.com/jboss-container-images/openjdk-test-applications from OPENJDK-1549 with env
        | variable           | value    |
        | MAVEN_ARGS         | validate |
 
   Scenario: Ensure that run-env.sh placed in the JAVA_APP_DIR is sourced in the run script before launching java
-      Given s2i build https://github.com/jboss-container-images/openjdk-test-applications from quarkus-quickstarts/getting-started-3.0.1.Final-nos2i using main
+      Given s2i build https://github.com/jboss-container-images/openjdk-test-applications from quarkus-quickstarts/getting-started-3.0.1.Final-nos2i
        | variable            | value        |
        | S2I_SOURCE_DATA_DIR | ./           |
        | S2I_TARGET_DATA_DIR | /deployments |

--- a/tests/features/java/java_s2i.feature
+++ b/tests/features/java/java_s2i.feature
@@ -271,7 +271,7 @@ Feature: Openshift OpenJDK S2I tests
     Given s2i build https://github.com/jboss-container-images/openjdk-test-applications from spring-boot-sample-simple
 
   Scenario: run an S2I that should fail as MAVEN_ARGS does not define com.redhat.xpaas.repo.redhatga
-    Given failing s2i build https://github.com/jboss-openshift/openshift-examples from spring-boot-sample-simple using openjdk-enforce-profile
+    Given failing s2i build https://github.com/jboss-container-images/openjdk-test-applications from spring-boot-sample-simple using openjdk-enforce-profile
        | variable           | value                                            |
        | MAVEN_ARGS         | -e package                                       |
 

--- a/tests/features/java/java_s2i.feature
+++ b/tests/features/java/java_s2i.feature
@@ -328,3 +328,10 @@ Feature: Openshift OpenJDK S2I tests
       Given s2i build https://github.com/jmtd/openjdk from tests/OPENJDK-1548 with env using OPENJDK-1548-maven-args
        | variable           | value    |
        | MAVEN_ARGS         | validate |
+
+  Scenario: Ensure that run-env.sh placed in the JAVA_APP_DIR is sourced in the run script before launching java
+      Given s2i build https://github.com/jboss-container-images/openjdk-test-applications from quarkus-quickstarts/getting-started-3.0.1.Final-nos2i using main
+       | variable            | value        |
+       | S2I_SOURCE_DATA_DIR | ./           |
+       | S2I_TARGET_DATA_DIR | /deployments |
+      Then container log should contain INFO exec -a "someUniqueString" java

--- a/tests/features/java/java_s2i_inc.feature
+++ b/tests/features/java/java_s2i_inc.feature
@@ -6,12 +6,12 @@ Feature: Openshift OpenJDK S2I tests
 
   # test incremental builds
   Scenario: Check incremental builds cache .m2
-    Given s2i build https://github.com/jboss-openshift/openshift-quickstarts from undertow-servlet
+    Given s2i build https://github.com/jboss-container-images/openjdk-test-applications from undertow-servlet
         | variable    | value               |
         | JAVA_ARGS   | Hello from CTF test |
     Then container log should contain /deployments/undertow-servlet.jar Hello from CTF test
      And s2i build log should contain Downloading from central:
-    Given s2i build https://github.com/jboss-openshift/openshift-quickstarts from undertow-servlet with env and incremental
+    Given s2i build https://github.com/jboss-container-images/openjdk-test-applications from undertow-servlet with env and incremental
         | variable    | value               |
         | JAVA_ARGS   | Hello from CTF test |
     Then container log should contain /deployments/undertow-servlet.jar Hello from CTF test

--- a/tests/features/java/memory.feature
+++ b/tests/features/java/memory.feature
@@ -62,5 +62,5 @@ Feature: OPENJDK-559 JVM Memory tests
   @ubi8/openjdk-17
   @ubi8/openjdk-21
   Scenario: Ensure Maven doesn't use MaxRAMPercentage=80
-    Given s2i build https://github.com/jboss-openshift/openshift-examples from spring-boot-sample-simple
+    Given s2i build https://github.com/jboss-container-images/openjdk-test-applications from spring-boot-sample-simple
     Then s2i build log should match regex INFO Using MAVEN_OPTS.*-XX:MaxRAMPercentage=25.0$

--- a/tests/features/java/openjdk_s2i.feature
+++ b/tests/features/java/openjdk_s2i.feature
@@ -6,16 +6,16 @@ Feature: Openshift OpenJDK-only S2I tests
 
   @ubi8/openjdk-8
   Scenario: Check java perf dir owned by jboss (CLOUD-2070)
-    Given s2i build https://github.com/jboss-openshift/openshift-quickstarts from undertow-servlet
+    Given s2i build https://github.com/jboss-container-images/openjdk-test-applications from undertow-servlet
     Then run jstat -gc 1 1000 1 in container and check its output for S0C
     And run stat --printf="%U %G" /tmp/hsperfdata_jboss/ in container and check its output for jboss root
 
   Scenario: Ensure Quarkus CDS doesn't fail due to timestamp mismatch (OPENDJK-1673)
-    Given s2i build https://github.com/jerboaa/quarkus-quickstarts from getting-started using quickstart-2.16-s2i-cds
+    Given s2i build https://github.com/jboss-container-images/openjdk-test-applications from getting-started
     Then container log should not contain A jar file is not the one used while building the shared archive file
 
   Scenario: quarkus fast-jar layout works out-of-the-box (OPENJDK-1957)
-    Given s2i build https://github.com/jmtd/openshift-quickstarts from quarkus-quickstarts/getting-started-3.0.1.Final-nos2i using OPENJDK-631-quarkus-fast-jar
+    Given s2i build https://github.com/jboss-container-images/openjdk-test-applications from quarkus-quickstarts/getting-started-3.0.1.Final-nos2i
     Then container log should contain INFO quarkus fast-jar package type detected
     And  container log should contain -jar /deployments/quarkus-app/quarkus-run.jar
     And  container log should contain (main) getting-started 1.0.0-SNAPSHOT on JVM (powered by Quarkus
@@ -24,7 +24,7 @@ Feature: Openshift OpenJDK-only S2I tests
     And  container log should not contain no main manifest attribute
 
   Scenario: quarkus uber-jar layout works out-of-the-box (OPENJDK-1957)
-    Given s2i build https://github.com/jmtd/openshift-quickstarts from quarkus-quickstarts/getting-started-3.0.1.Final-nos2i with env using OPENJDK-631-quarkus-fast-jar
+    Given s2i build https://github.com/jboss-container-images/openjdk-test-applications from quarkus-quickstarts/getting-started-3.0.1.Final-nos2i with env
        | variable             | value    |
        | QUARKUS_PACKAGE_TYPE | uber-jar |
     Then container log should not contain INFO quarkus fast-jar package type detected

--- a/tests/features/java/ports.feature
+++ b/tests/features/java/ports.feature
@@ -3,9 +3,8 @@
 @ubi8/openjdk-17
 @ubi8/openjdk-21
 Feature: Openshift OpenJDK port tests
-
   Scenario: Check ports are available
-    Given s2i build https://github.com/jboss-openshift/openshift-quickstarts from undertow-servlet
+    Given s2i build https://github.com/jboss-container-images/openjdk-test-applications from undertow-servlet
     Then check that port 8080 is open
     Then check that port 8443 is open
     Then inspect container

--- a/tests/features/java/runtime.feature
+++ b/tests/features/java/runtime.feature
@@ -3,19 +3,18 @@
 @ubi8/openjdk-17
 @ubi8/openjdk-21
 Feature: Openshift OpenJDK Runtime tests
-
   Scenario: Ensure JVM_ARGS is no longer present in the run script
-    Given s2i build https://github.com/jboss-openshift/openshift-quickstarts from undertow-servlet
+    Given s2i build https://github.com/jboss-container-images/openjdk-test-applications from undertow-servlet
     Then file /usr/local/s2i/run should not contain JVM_ARGS
 
   Scenario: Ensure JAVA_ARGS are passed through to the running java application
-    Given s2i build https://github.com/jboss-openshift/openshift-quickstarts from undertow-servlet
+    Given s2i build https://github.com/jboss-container-images/openjdk-test-applications from undertow-servlet
        | variable    | value               |
        | JAVA_ARGS   | Hello from CTF test |
     Then container log should contain /deployments/undertow-servlet.jar Hello from CTF test
 
   Scenario: Ensure diagnostic options work correctly
-    Given s2i build https://github.com/jboss-openshift/openshift-quickstarts from undertow-servlet
+    Given s2i build https://github.com/jboss-container-images/openjdk-test-applications from undertow-servlet
        | variable         | value               |
        | JAVA_ARGS        | Hello from CTF test |
        | JAVA_DIAGNOSTICS | true                |

--- a/tests/features/jolokia.feature
+++ b/tests/features/jolokia.feature
@@ -2,13 +2,13 @@
 Feature: Openshift OpenJDK Jolokia tests
 
   Scenario: Check Environment variable is correct
-    Given s2i build https://github.com/jboss-openshift/openshift-quickstarts from undertow-servlet
+    Given s2i build https://github.com/jboss-container-images/openjdk-test-applications from undertow-servlet
     Then run sh -c 'unzip -q -p /usr/share/java/jolokia-jvm-agent/jolokia-jvm.jar META-INF/maven/org.jolokia/jolokia-jvm/pom.properties | grep -F ${JOLOKIA_VERSION}' in container and check its output for version=
 
   @ubi8/openjdk-8
   @ubi8/openjdk-11
   Scenario: Check jolokia port is available
-    Given s2i build https://github.com/jboss-openshift/openshift-quickstarts from undertow-servlet
+    Given s2i build https://github.com/jboss-container-images/openjdk-test-applications from undertow-servlet
     Then check that port 8778 is open
     And  inspect container
        | path                    | value       |
@@ -17,7 +17,7 @@ Feature: Openshift OpenJDK Jolokia tests
   @ubi8/openjdk-8
   @ubi8/openjdk-11
   Scenario: Ensure Jolokia diagnostic options work correctly
-    Given s2i build https://github.com/jboss-openshift/openshift-quickstarts from undertow-servlet
+    Given s2i build https://github.com/jboss-container-images/openjdk-test-applications from undertow-servlet
        | variable         | value               |
        | JAVA_ARGS        | Hello from CTF test |
        | JAVA_DIAGNOSTICS | true                |

--- a/tests/features/s2i-core.feature
+++ b/tests/features/s2i-core.feature
@@ -5,5 +5,5 @@
 Feature: Openshift S2I tests
   # OPENJDK-84 - /tmp/src should not be present after build
   Scenario: run an s2i build and check that /tmp/src has been removed afterwards
-    Given s2i build https://github.com/jboss-openshift/openshift-examples from spring-boot-sample-simple
+    Given s2i build https://github.com/jboss-container-images/openjdk-test-applications from spring-boot-sample-simple
     Then run stat /tmp/src in container and immediately check its output does not contain File:


### PR DESCRIPTION
JIRA tracker: https://issues.redhat.com/browse/OPENJDK-2428

This PR includes test coverage for user-provided run-env.sh and Update test URI to refer new application source repository which are already been merged to ubi9.

I have tested the changes locally and they passed.

```
$ cekit --descriptor ubi8-openjdk-17.yaml test behave --wip
.
.
.
.
  @ubi8 @wip
  Scenario: Check non-existent path JAVA_APP_DIR (OPENJDK-2033)                                   # features/image/java/runtime.feature:91
    Given container is started with env                                                           # steps/container_steps.py:72 10.510s
      | variable     | value |
      | JAVA_APP_DIR | /nope |
    Then available container log should contain ERROR No directory /nope found for auto detection # steps/container_steps.py:50
    Then available container log should contain ERROR No directory /nope found for auto detection # steps/container_steps.py:50 0.006she logs
2023-11-23 14:48:30,936 container.py:100        INFO  Removing container 'c588934f1c7f62626d23bcc9a5047c0e94382638275e38cd1b69710c11fb3f26', 1 try...
2023-11-23 14:48:30,961 container.py:103        INFO  Container 'c588934f1c7f62626d23bcc9a5047c0e94382638275e38cd1b69710c11fb3f26' removed

8 features passed, 0 failed, 7 skipped
58 scenarios passed, 0 failed, 48 skipped
168 steps passed, 0 failed, 144 skipped, 0 undefined
Took 72m2.960s
2023-11-23 14:48:30,965 cli.py:503        INFO  Finished!
```