### PR TITLE
[OPENJDK-2199] Update old URI to new one in the tests

### DIFF
--- a/tests/features/java/java_s2i.feature
+++ b/tests/features/java/java_s2i.feature
@@ -118,11 +118,11 @@ Feature: Openshift OpenJDK S2I tests
 
   # deprecated?
   Scenario: run an S2I build that depends on com.redhat.xpaas.repo.redhatga being defined
-    Given s2i build https://github.com/jboss-openshift/openshift-examples from spring-boot-sample-simple
+    Given s2i build https://github.com/jboss-container-images/openjdk-test-applications from spring-boot-sample-simple
 
   # deprecated?
   Scenario: run an S2I that should fail as MAVEN_ARGS does not define com.redhat.xpaas.repo.redhatga
-    Given failing s2i build https://github.com/jboss-openshift/openshift-examples from spring-boot-sample-simple using openjdk-enforce-profile
+    Given failing s2i build https://github.com/jboss-container-images/openjdk-test-applications from spring-boot-sample-simple using openjdk-enforce-profile
        | variable           | value                                            |
        | MAVEN_ARGS         | -e package                                       |
 


### PR DESCRIPTION
JIRA tracker : https://issues.redhat.com/browse/OPENJDK-2199

Updated old URI to new one. As these two tests were marked as 'deprecated?' I was not sure whether to update to new URI or not. In https://github.com/jboss-container-images/openjdk/pull/420 you suggested to update these tests to new URI (in ubi8 these tests are not marked as 'deprecated?') so I thought of updating the same to ubi9 as well.

Could you please take a look?
