### PR TITLE
[OPENJDK-2519] Add tzdata module to reinstall tzdata

### DIFF
--- a/modules/util/tzdata/execute.sh
+++ b/modules/util/tzdata/execute.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+set -euo pipefail
+
+for candidate in yum dnf microdnf; do
+    if command -v "$candidate"; then
+        mgr="$(command -v "$candidate")"
+        "$mgr" reinstall tzdata -y && \
+            "$mgr" -y clean all
+        exit
+    fi
+done
+
+echo "cannot find a package manager" >&2
+exit 1

--- a/modules/util/tzdata/module.yaml
+++ b/modules/util/tzdata/module.yaml
@@ -1,0 +1,7 @@
+schema_version: 1
+name: jboss.container.util.tzdata
+version: '1.0'
+description: Reinstall the tzdata package, to ensure zoneinfo is present
+
+execute:
+- script: execute.sh

--- a/tests/features/java/openjdk.feature
+++ b/tests/features/java/openjdk.feature
@@ -89,3 +89,10 @@ Feature: Miscellaneous OpenJDK-related unit tests
     | arg     | value |
     | command | tar   |
     Then available container log should not contain command not found
+
+  @ubi9
+  Scenario: Ensure tzdata RPM is properly installed (OPENJDK-2519)
+    When container is started with args
+    | arg     | value         |
+    | command | rpm -V tzdata |
+    Then available container log should not contain missing

--- a/ubi9-openjdk-11-runtime.yaml
+++ b/ubi9-openjdk-11-runtime.yaml
@@ -49,7 +49,8 @@ modules:
   - name: jboss.container.tar
   - name: jboss.container.openjdk.jre
     version: "11"
-  - name:  jboss.container.java.jre.run
+  - name: jboss.container.util.tzdata
+  - name: jboss.container.java.jre.run
 
 help:
   add: true

--- a/ubi9-openjdk-11.yaml
+++ b/ubi9-openjdk-11.yaml
@@ -52,6 +52,7 @@ modules:
     version: "11"
   - name: jboss.container.maven
     version: "3.8.11"
+  - name: jboss.container.util.tzdata
   - name: jboss.container.java.s2i.bash
 
 help:

--- a/ubi9-openjdk-17-runtime.yaml
+++ b/ubi9-openjdk-17-runtime.yaml
@@ -49,7 +49,8 @@ modules:
   - name: jboss.container.tar
   - name: jboss.container.openjdk.jre
     version: "17"
-  - name:  jboss.container.java.jre.run
+  - name: jboss.container.util.tzdata
+  - name: jboss.container.java.jre.run
 
 help:
   add: true

--- a/ubi9-openjdk-17.yaml
+++ b/ubi9-openjdk-17.yaml
@@ -52,6 +52,7 @@ modules:
     version: "17"
   - name: jboss.container.maven
     version: "3.8.17"
+  - name: jboss.container.util.tzdata
   - name: jboss.container.java.s2i.bash
 
 help:

--- a/ubi9-openjdk-21-runtime.yaml
+++ b/ubi9-openjdk-21-runtime.yaml
@@ -47,6 +47,7 @@ modules:
   - name: jboss.container.tar
   - name: jboss.container.openjdk.jre
     version: "21"
+  - name: jboss.container.util.tzdata
   - name: jboss.container.java.jre.run
 
 help:

--- a/ubi9-openjdk-21.yaml
+++ b/ubi9-openjdk-21.yaml
@@ -51,6 +51,7 @@ modules:
   - name: jboss.container.maven
     version: "3.8.17"
   - name: jboss.container.java.s2i.bash
+  - name: jboss.container.util.tzdata
   - name: jboss.container.java.singleton-jdk
 
 help:


### PR DESCRIPTION
tzdata is deliberately broken in ubi-minimal images (presumably for disk space reasons). The fix is to reinstall the tzdata package:

    <https://access.redhat.com/solutions/5616681>

This appears to add a neglibible amount to our image sizes (<1%) but resolves TZ issues for Java applications.

https://issues.redhat.com/browse/OPENJDK-2519
