### PR TITLE
[OPENJDK-1165] install tar in the runtime images

### DIFF
--- a/modules/tar/module.yaml
+++ b/modules/tar/module.yaml
@@ -1,0 +1,8 @@
+schema_version: 1
+name: jboss.container.tar
+version: '1.0'
+description: Installs the Tar RPM to enable `oc cp` and `oc rsync`
+
+packages:
+  install:
+  - tar

--- a/tests/features/java/openjdk.feature
+++ b/tests/features/java/openjdk.feature
@@ -82,3 +82,10 @@ Feature: Miscellaneous OpenJDK-related unit tests
     | arg     | value                                  |
     | command | bash -c "$JAVA_HOME/bin/java -XshowSettings:properties -version" |
     Then available container log should contain file.encoding = UTF-8
+
+  @ubi9
+  Scenario: Ensure tar is installed (OPENJDK-1165)
+    When container is started with args
+    | arg     | value |
+    | command | tar   |
+    Then available container log should not contain command not found

--- a/ubi9-openjdk-11-runtime.yaml
+++ b/ubi9-openjdk-11-runtime.yaml
@@ -46,6 +46,7 @@ modules:
   - path: modules
   install:
   - name: jboss.container.util.pkg-update
+  - name: jboss.container.tar
   - name: jboss.container.openjdk.jre
     version: "11"
   - name:  jboss.container.java.jre.run

--- a/ubi9-openjdk-17-runtime.yaml
+++ b/ubi9-openjdk-17-runtime.yaml
@@ -46,6 +46,7 @@ modules:
   - path: modules
   install:
   - name: jboss.container.util.pkg-update
+  - name: jboss.container.tar
   - name: jboss.container.openjdk.jre
     version: "17"
   - name:  jboss.container.java.jre.run

--- a/ubi9-openjdk-21-runtime.yaml
+++ b/ubi9-openjdk-21-runtime.yaml
@@ -44,6 +44,7 @@ modules:
   - path: modules
   install:
   - name: jboss.container.util.pkg-update
+  - name: jboss.container.tar
   - name: jboss.container.openjdk.jre
     version: "21"
   - name: jboss.container.java.jre.run


### PR DESCRIPTION
`oc rsync` requires either `tar` or `rsync` to be present in the container images. `oc cp` requires `tar`. Install `tar` in the runtime images so that both `oc` commands function. This results in a negligible (+0.6MiB) increase in container size.

https://issues.redhat.com/browse/OPENJDK-1165

`tar` and `rsync` are already present in the builder images.