### PR TITLE
refresh GHA runners for UBI8 tests

### DIFF
--- a/.github/workflows/image-workflow-template.yml
+++ b/.github/workflows/image-workflow-template.yml
@@ -42,4 +42,4 @@ jobs:
       - name: Behave Tests
         run: |
           echo /home/runner/work/_temp/openshift-bin >> $GITHUB_PATH
-          cekit -v --descriptor ${{ inputs.image }}.yaml test behave
+          cekit -v --descriptor ${{ inputs.image }}.yaml test behave --steps-url https://github.com/jmtd/behave-test-steps

--- a/.github/workflows/image-workflow-template.yml
+++ b/.github/workflows/image-workflow-template.yml
@@ -1,0 +1,38 @@
+name: UBI8 OpenJDK S2I Image CI template
+on:
+  workflow_call:
+    inputs:
+      image:
+        required: true
+        type: string
+env:
+  LANG: en_US.UTF-8
+jobs:
+  openjdkci:
+    name: OpenJDK S2I Build and Test
+    runs-on: ubuntu-20.04
+    strategy:
+      fail-fast: false
+    steps:
+      - uses: actions/checkout@v2
+      - name: Verify latest UBI image is present
+        run:  docker pull registry.access.redhat.com/ubi8/ubi-minimal:latest
+
+      - name: Install CEKit
+        uses: cekit/actions-setup-cekit@v1.1.5
+
+      - name: Build
+        run: |
+          cekit -v --descriptor ${{ inputs.image }}.yaml build docker
+
+      - name: Install and cache S2I CLI tool from GitHub
+        uses: redhat-actions/openshift-tools-installer@v1
+        with:
+          source: "github"
+          github_pat: ${{ github.token }}
+          s2i: "1.3.4"
+
+      - name: Behave Tests
+        run: |
+          echo /home/runner/work/_temp/openshift-bin >> $GITHUB_PATH
+          cekit -v --descriptor ${{ inputs.image }}.yaml test behave

--- a/.github/workflows/image-workflow-template.yml
+++ b/.github/workflows/image-workflow-template.yml
@@ -23,7 +23,7 @@ jobs:
 
       - name: Build
         run: |
-          cekit -v --descriptor ${{ inputs.image }}.yaml build docker
+          cekit -v --descriptor ${{ inputs.image }}.yaml build docker --no-squash
 
       - name: Install and cache S2I CLI tool from GitHub
         uses: redhat-actions/openshift-tools-installer@v1

--- a/.github/workflows/image-workflow-template.yml
+++ b/.github/workflows/image-workflow-template.yml
@@ -33,6 +33,12 @@ jobs:
           github_pat: ${{ github.token }}
           s2i: "1.3.4"
 
+      # s2i misbehaves if registry credentials are present: tries and fails to query
+      # image metadata from docker.io before each build, etc. See:
+      # https://github.com/openshift/source-to-image/issues/1134
+      - name: clear docker credentials
+        run: docker logout
+
       - name: Behave Tests
         run: |
           echo /home/runner/work/_temp/openshift-bin >> $GITHUB_PATH

--- a/.github/workflows/image-workflow-template.yml
+++ b/.github/workflows/image-workflow-template.yml
@@ -10,6 +10,7 @@ env:
 jobs:
   openjdkci:
     name: OpenJDK S2I Build and Test
+    timeout-minutes: 60
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false

--- a/.github/workflows/image-workflow-template.yml
+++ b/.github/workflows/image-workflow-template.yml
@@ -10,7 +10,7 @@ env:
 jobs:
   openjdkci:
     name: OpenJDK S2I Build and Test
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
     steps:

--- a/.github/workflows/ubi8-openjdk-11-runtime.yml
+++ b/.github/workflows/ubi8-openjdk-11-runtime.yml
@@ -1,50 +1,10 @@
-name: OpenJDK 11 Runtime Image CI
+name: UBI8 OpenJDK 11 Runtime Image CI
 on: [push, pull_request]
 env:
   LANG: en_US.UTF-8
-  CEKIT_VERSION: 4.6.0
-  S2I_URI: https://github.com/openshift/source-to-image/releases/download/v1.3.1/source-to-image-v1.3.1-a5a77147-linux-amd64.tar.gz
+  IMAGE: ubi8-openjdk-11-runtime
 jobs:
-  openjdkci:
-    name: OpenJDK Runtime Build and Test
-    runs-on: ubuntu-20.04
-    strategy:
-      fail-fast: false
-    steps:
-      - uses: actions/checkout@v2
-      - name: Verify latest UBI image is present
-        run: |
-          docker pull registry.access.redhat.com/ubi8/ubi-minimal:latest
-          docker image ls | grep ubi8
-      - name: Setup required system packages
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y virtualenv libkrb5-dev
-      - name: Setup virtualenv and install cekit and required packages
-        run: |
-          mkdir ~/cekit${{ env.CEKIT_VERSION }}
-          virtualenv -p python3 ~/cekit${{ env.CEKIT_VERSION }}
-          . ~/cekit${{ env.CEKIT_VERSION }}/bin/activate
-          pip3 install cekit==${{ env.CEKIT_VERSION }} docker docker-squash odcs behave lxml
-      - name: Build
-        run: |
-          . ~/cekit${{ env.CEKIT_VERSION }}/bin/activate
-          cekit -v --descriptor ubi8-openjdk-11-runtime.yaml build docker
-          docker image ls
-
-# even though we don't run any S2I tests for the runtime images, the test suite
-# will fail to start if the s2i binary is not present.
-      - name: install s2i binary
-        run: |
-          echo ===== Installing s2i from ${{ env.S2I_URL }} =====
-          mkdir /tmp/s2i/ && cd /tmp/s2i/
-          wget ${{ env.S2I_URI }}
-          tar xvf source-to-image*.gz
-          sudo mv s2i /usr/bin
-          which s2i
-          s2i version
-
-      - name: Behave Tests
-        run: |
-          . ~/cekit${{ env.CEKIT_VERSION }}/bin/activate
-          cekit -v --descriptor ubi8-openjdk-11-runtime.yaml test behave
+  call-openjdkci:
+    uses: ./.github/workflows/image-workflow-template.yml
+    with:
+      image: ubi8-openjdk-11-runtime

--- a/.github/workflows/ubi8-openjdk-11.yml
+++ b/.github/workflows/ubi8-openjdk-11.yml
@@ -1,46 +1,10 @@
-name: OpenJDK 11 S2I Image CI
+name: UBI8 OpenJDK 11 S2I Image CI
 on: [push, pull_request]
 env:
   LANG: en_US.UTF-8
-  CEKIT_VERSION: 4.6.0
-  S2I_URI: https://github.com/openshift/source-to-image/releases/download/v1.3.1/source-to-image-v1.3.1-a5a77147-linux-amd64.tar.gz
+  IMAGE: ubi8-openjdk-11
 jobs:
-  openjdkci:
-    name: OpenJDK S2I Build and Test
-    runs-on: ubuntu-20.04
-    strategy:
-      fail-fast: false
-    steps:
-      - uses: actions/checkout@v2
-      - name: Verify latest UBI image is present
-        run: |
-          docker pull registry.access.redhat.com/ubi8/ubi-minimal:latest
-          docker image ls | grep ubi8
-      - name: Setup required system packages
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y virtualenv libkrb5-dev
-      - name: Setup virtualenv and install cekit and required packages
-        run: |
-          mkdir ~/cekit${{ env.CEKIT_VERSION }}
-          virtualenv -p python3 ~/cekit${{ env.CEKIT_VERSION }}
-          . ~/cekit${{ env.CEKIT_VERSION }}/bin/activate
-          pip3 install cekit==${{ env.CEKIT_VERSION }} docker docker-squash odcs behave lxml
-      - name: Build
-        run: |
-          . ~/cekit${{ env.CEKIT_VERSION }}/bin/activate
-          cekit -v --descriptor ubi8-openjdk-11.yaml build docker
-          docker image ls
-      - name: install s2i binary
-        run: |
-          echo ===== Installing s2i from ${{ env.S2I_URL }} =====
-          mkdir /tmp/s2i/ && cd /tmp/s2i/
-          wget ${{ env.S2I_URI }}
-          tar xvf source-to-image*.gz
-          sudo mv s2i /usr/bin
-          which s2i
-          s2i version
-      - name: Behave Tests
-        run: |
-          . ~/cekit${{ env.CEKIT_VERSION }}/bin/activate
-          cekit -v --descriptor ubi8-openjdk-11.yaml test behave
+  call-openjdkci:
+    uses: ./.github/workflows/image-workflow-template.yml
+    with:
+      image: ubi8-openjdk-11

--- a/.github/workflows/ubi8-openjdk-17-runtime.yml
+++ b/.github/workflows/ubi8-openjdk-17-runtime.yml
@@ -1,50 +1,10 @@
-name: OpenJDK 17 Runtime Image CI
+name: UBI8 OpenJDK 17 Runtime Image CI
 on: [push, pull_request]
 env:
   LANG: en_US.UTF-8
-  CEKIT_VERSION: 4.6.0
-  S2I_URI: https://github.com/openshift/source-to-image/releases/download/v1.3.1/source-to-image-v1.3.1-a5a77147-linux-amd64.tar.gz
+  IMAGE: ubi8-openjdk-17-runtime
 jobs:
-  openjdkci:
-    name: OpenJDK Runtime Build and Test
-    runs-on: ubuntu-20.04
-    strategy:
-      fail-fast: false
-    steps:
-      - uses: actions/checkout@v2
-      - name: Verify latest UBI image is present
-        run: |
-          docker pull registry.access.redhat.com/ubi8/ubi-minimal:latest
-          docker image ls | grep ubi8
-      - name: Setup required system packages
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y virtualenv libkrb5-dev
-      - name: Setup virtualenv and install cekit and required packages
-        run: |
-          mkdir ~/cekit${{ env.CEKIT_VERSION }}
-          virtualenv -p python3 ~/cekit${{ env.CEKIT_VERSION }}
-          . ~/cekit${{ env.CEKIT_VERSION }}/bin/activate
-          pip3 install cekit==${{ env.CEKIT_VERSION }} docker docker-squash odcs behave lxml
-      - name: Build
-        run: |
-          . ~/cekit${{ env.CEKIT_VERSION }}/bin/activate
-          cekit -v --descriptor ubi8-openjdk-17-runtime.yaml build docker
-          docker image ls
-
-# even though we don't run any S2I tests for the runtime images, the test suite
-# will fail to start if the s2i binary is not present.
-      - name: install s2i binary
-        run: |
-          echo ===== Installing s2i from ${{ env.S2I_URL }} =====
-          mkdir /tmp/s2i/ && cd /tmp/s2i/
-          wget ${{ env.S2I_URI }}
-          tar xvf source-to-image*.gz
-          sudo mv s2i /usr/bin
-          which s2i
-          s2i version
-
-      - name: Behave Tests
-        run: |
-          . ~/cekit${{ env.CEKIT_VERSION }}/bin/activate
-          cekit -v --descriptor ubi8-openjdk-17-runtime.yaml test behave
+  call-openjdkci:
+    uses: ./.github/workflows/image-workflow-template.yml
+    with:
+      image: ubi8-openjdk-17-runtime

--- a/.github/workflows/ubi8-openjdk-17.yml
+++ b/.github/workflows/ubi8-openjdk-17.yml
@@ -1,46 +1,10 @@
-name: OpenJDK 17 S2I Image CI
+name: UBI8 OpenJDK 17 S2I Image CI
 on: [push, pull_request]
 env:
   LANG: en_US.UTF-8
-  CEKIT_VERSION: 4.6.0
-  S2I_URI: https://github.com/openshift/source-to-image/releases/download/v1.3.1/source-to-image-v1.3.1-a5a77147-linux-amd64.tar.gz
+  IMAGE: ubi8-openjdk-17
 jobs:
-  openjdkci:
-    name: OpenJDK S2I Build and Test
-    runs-on: ubuntu-20.04
-    strategy:
-      fail-fast: false
-    steps:
-      - uses: actions/checkout@v2
-      - name: Verify latest UBI image is present
-        run: |
-          docker pull registry.access.redhat.com/ubi8/ubi-minimal:latest
-          docker image ls | grep ubi8
-      - name: Setup required system packages
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y virtualenv libkrb5-dev
-      - name: Setup virtualenv and install cekit and required packages
-        run: |
-          mkdir ~/cekit${{ env.CEKIT_VERSION }}
-          virtualenv -p python3 ~/cekit${{ env.CEKIT_VERSION }}
-          . ~/cekit${{ env.CEKIT_VERSION }}/bin/activate
-          pip3 install cekit==${{ env.CEKIT_VERSION }} docker docker-squash odcs behave lxml
-      - name: Build
-        run: |
-          . ~/cekit${{ env.CEKIT_VERSION }}/bin/activate
-          cekit -v --descriptor ubi8-openjdk-17.yaml build docker
-          docker image ls
-      - name: install s2i binary
-        run: |
-          echo ===== Installing s2i from ${{ env.S2I_URL }} =====
-          mkdir /tmp/s2i/ && cd /tmp/s2i/
-          wget ${{ env.S2I_URI }}
-          tar xvf source-to-image*.gz
-          sudo mv s2i /usr/bin
-          which s2i
-          s2i version
-      - name: Behave Tests
-        run: |
-          . ~/cekit${{ env.CEKIT_VERSION }}/bin/activate
-          cekit -v --descriptor ubi8-openjdk-17.yaml test behave
+  call-openjdkci:
+    uses: ./.github/workflows/image-workflow-template.yml
+    with:
+      image: ubi8-openjdk-17

--- a/.github/workflows/ubi8-openjdk-21-runtime.yml
+++ b/.github/workflows/ubi8-openjdk-21-runtime.yml
@@ -1,4 +1,4 @@
-name: UBI8 OpenJDK 21 Runtime S2I Image CI
+name: UBI8 OpenJDK 21 Runtime Image CI
 on: [push, pull_request]
 env:
   LANG: en_US.UTF-8

--- a/.github/workflows/ubi8-openjdk-8-runtime.yml
+++ b/.github/workflows/ubi8-openjdk-8-runtime.yml
@@ -1,50 +1,10 @@
-name: OpenJDK 8 Runtime Image CI
+name: UBI8 OpenJDK 8 Runtime Image CI
 on: [push, pull_request]
 env:
   LANG: en_US.UTF-8
-  CEKIT_VERSION: 4.6.0
-  S2I_URI: https://github.com/openshift/source-to-image/releases/download/v1.3.1/source-to-image-v1.3.1-a5a77147-linux-amd64.tar.gz
+  IMAGE: ubi8-openjdk-8-runtime
 jobs:
-  openjdkci:
-    name: OpenJDK Runtime Build and Test
-    runs-on: ubuntu-20.04
-    strategy:
-      fail-fast: false
-    steps:
-      - uses: actions/checkout@v2
-      - name: Verify latest UBI image is present
-        run: |
-          docker pull registry.access.redhat.com/ubi8/ubi-minimal:latest
-          docker image ls | grep ubi8
-      - name: Setup required system packages
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y virtualenv libkrb5-dev
-      - name: Setup virtualenv and install cekit and required packages
-        run: |
-          mkdir ~/cekit${{ env.CEKIT_VERSION }}
-          virtualenv -p python3 ~/cekit${{ env.CEKIT_VERSION }}
-          . ~/cekit${{ env.CEKIT_VERSION }}/bin/activate
-          pip3 install cekit==${{ env.CEKIT_VERSION }} docker docker-squash odcs behave lxml
-      - name: Build
-        run: |
-          . ~/cekit${{ env.CEKIT_VERSION }}/bin/activate
-          cekit -v --descriptor ubi8-openjdk-8-runtime.yaml build docker
-          docker image ls
-
-# even though we don't run any S2I tests for the runtime images, the test suite
-# will fail to start if the s2i binary is not present.
-      - name: install s2i binary
-        run: |
-          echo ===== Installing s2i from ${{ env.S2I_URL }} =====
-          mkdir /tmp/s2i/ && cd /tmp/s2i/
-          wget ${{ env.S2I_URI }}
-          tar xvf source-to-image*.gz
-          sudo mv s2i /usr/bin
-          which s2i
-          s2i version
-
-      - name: Behave Tests
-        run: |
-          . ~/cekit${{ env.CEKIT_VERSION }}/bin/activate
-          cekit -v --descriptor ubi8-openjdk-8-runtime.yaml test behave
+  call-openjdkci:
+    uses: ./.github/workflows/image-workflow-template.yml
+    with:
+      image: ubi8-openjdk-8-runtime

--- a/.github/workflows/ubi8-openjdk-8.yml
+++ b/.github/workflows/ubi8-openjdk-8.yml
@@ -1,46 +1,10 @@
-name: OpenJDK 8 S2I Image CI
+name: UBI8 OpenJDK 8 S2I Image CI
 on: [push, pull_request]
 env:
   LANG: en_US.UTF-8
-  CEKIT_VERSION: 4.6.0
-  S2I_URI: https://github.com/openshift/source-to-image/releases/download/v1.3.1/source-to-image-v1.3.1-a5a77147-linux-amd64.tar.gz
+  IMAGE: ubi8-openjdk-8
 jobs:
-  openjdkci:
-    name: OpenJDK S2I Build and Test
-    runs-on: ubuntu-20.04
-    strategy:
-      fail-fast: false
-    steps:
-      - uses: actions/checkout@v2
-      - name: Verify latest UBI image is present
-        run: |
-          docker pull registry.access.redhat.com/ubi8/ubi-minimal:latest
-          docker image ls | grep ubi8
-      - name: Setup required system packages
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y virtualenv libkrb5-dev
-      - name: Setup virtualenv and install cekit and required packages
-        run: |
-          mkdir ~/cekit${{ env.CEKIT_VERSION }}
-          virtualenv -p python3 ~/cekit${{ env.CEKIT_VERSION }}
-          . ~/cekit${{ env.CEKIT_VERSION }}/bin/activate
-          pip3 install cekit==${{ env.CEKIT_VERSION }} docker docker-squash odcs behave lxml
-      - name: Build
-        run: |
-          . ~/cekit${{ env.CEKIT_VERSION }}/bin/activate
-          cekit -v --descriptor ubi8-openjdk-8.yaml build docker
-          docker image ls
-      - name: install s2i binary
-        run: |
-          echo ===== Installing s2i from ${{ env.S2I_URL }} =====
-          mkdir /tmp/s2i/ && cd /tmp/s2i/
-          wget ${{ env.S2I_URI }}
-          tar xvf source-to-image*.gz
-          sudo mv s2i /usr/bin
-          which s2i
-          s2i version
-      - name: Behave Tests
-        run: |
-          . ~/cekit${{ env.CEKIT_VERSION }}/bin/activate
-          cekit -v --descriptor ubi8-openjdk-8.yaml test behave
+  call-openjdkci:
+    uses: ./.github/workflows/image-workflow-template.yml
+    with:
+      image: ubi8-openjdk-8

--- a/tests/features/java/java_s2i.feature
+++ b/tests/features/java/java_s2i.feature
@@ -328,10 +328,3 @@ Feature: Openshift OpenJDK S2I tests
       Given s2i build https://github.com/jboss-container-images/openjdk-test-applications from OPENJDK-1549 with env
        | variable           | value    |
        | MAVEN_ARGS         | validate |
-
-  Scenario: Ensure that run-env.sh placed in the JAVA_APP_DIR is sourced in the run script before launching java
-      Given s2i build https://github.com/jboss-container-images/openjdk-test-applications from quarkus-quickstarts/getting-started-3.0.1.Final-nos2i
-       | variable            | value        |
-       | S2I_SOURCE_DATA_DIR | ./           |
-       | S2I_TARGET_DATA_DIR | /deployments |
-      Then container log should contain INFO exec -a "someUniqueString" java

--- a/tests/features/java/java_s2i.feature
+++ b/tests/features/java/java_s2i.feature
@@ -1,3 +1,6 @@
+# temporarily marking 'ignore' so these tests are skipped on GHA
+# See: https://issues.redhat.com/browse/OPENJDK-2602
+@ignore
 @ubi8/openjdk-8
 @ubi8/openjdk-11
 @ubi8/openjdk-17

--- a/tests/features/java/java_s2i_quarkus.feature
+++ b/tests/features/java/java_s2i_quarkus.feature
@@ -1,0 +1,10 @@
+@ubi8/openjdk-11
+@ubi8/openjdk-17
+@ubi8/openjdk-21
+Feature: Openshift OpenJDK S2I tests (Quarkus-based)
+  Scenario: Ensure that run-env.sh placed in the JAVA_APP_DIR is sourced in the run script before launching java
+      Given s2i build https://github.com/jboss-container-images/openjdk-test-applications from quarkus-quickstarts/getting-started-3.0.1.Final-nos2i
+       | variable            | value        |
+       | S2I_SOURCE_DATA_DIR | ./           |
+       | S2I_TARGET_DATA_DIR | /deployments |
+      Then container log should contain INFO exec -a "someUniqueString" java

--- a/tests/features/java/openjdk_s2i.feature
+++ b/tests/features/java/openjdk_s2i.feature
@@ -5,6 +5,9 @@
 Feature: Openshift OpenJDK-only S2I tests
 
   @ubi8/openjdk-8
+  # temporarily marking 'ignore' so these tests are skipped on GHA
+  # See: https://issues.redhat.com/browse/OPENJDK-2602
+  @ignore
   Scenario: Check java perf dir owned by jboss (CLOUD-2070)
     Given s2i build https://github.com/jboss-container-images/openjdk-test-applications from undertow-servlet
     Then run jstat -gc 1 1000 1 in container and check its output for S0C

--- a/ubi8-openjdk-11-runtime.yaml
+++ b/ubi8-openjdk-11-runtime.yaml
@@ -24,6 +24,10 @@ labels:
   value: "https://www.redhat.com/en/about/red-hat-end-user-license-agreements#UBI"
 - name: "org.opencontainers.image.documentation"
   value: *docs
+- name: "name"
+  value: *name
+- name: "version"
+  value: *version
 
 envs:
 - name: "JBOSS_IMAGE_NAME"

--- a/ubi8-openjdk-11.yaml
+++ b/ubi8-openjdk-11.yaml
@@ -24,6 +24,10 @@ labels:
   value: "https://www.redhat.com/en/about/red-hat-end-user-license-agreements#UBI"
 - name: "org.opencontainers.image.documentation"
   value: *docs
+- name: "name"
+  value: *name
+- name: "version"
+  value: *version
 
 envs:
 - name: PATH

--- a/ubi8-openjdk-17-runtime.yaml
+++ b/ubi8-openjdk-17-runtime.yaml
@@ -24,6 +24,10 @@ labels:
   value: "https://www.redhat.com/en/about/red-hat-end-user-license-agreements#UBI"
 - name: "org.opencontainers.image.documentation"
   value: *docs
+- name: "name"
+  value: *name
+- name: "version"
+  value: *version
 
 envs:
 - name: "JBOSS_IMAGE_NAME"

--- a/ubi8-openjdk-17.yaml
+++ b/ubi8-openjdk-17.yaml
@@ -24,6 +24,10 @@ labels:
   value: "https://www.redhat.com/en/about/red-hat-end-user-license-agreements#UBI"
 - name: "org.opencontainers.image.documentation"
   value: *docs
+- name: "name"
+  value: *name
+- name: "version"
+  value: *version
 
 envs:
 - name: PATH

--- a/ubi8-openjdk-21-runtime.yaml
+++ b/ubi8-openjdk-21-runtime.yaml
@@ -24,6 +24,10 @@ labels:
   value: "https://www.redhat.com/en/about/red-hat-end-user-license-agreements#UBI"
 - name: "org.opencontainers.image.documentation"
   value: *docs
+- name: "name"
+  value: *name
+- name: "version"
+  value: *version
 
 envs:
 - name: "JBOSS_IMAGE_NAME"

--- a/ubi8-openjdk-21.yaml
+++ b/ubi8-openjdk-21.yaml
@@ -24,6 +24,10 @@ labels:
   value: "https://www.redhat.com/en/about/red-hat-end-user-license-agreements#UBI"
 - name: "org.opencontainers.image.documentation"
   value: *docs
+- name: "name"
+  value: *name
+- name: "version"
+  value: *version
 
 envs:
 - name: PATH

--- a/ubi8-openjdk-8-runtime.yaml
+++ b/ubi8-openjdk-8-runtime.yaml
@@ -24,6 +24,10 @@ labels:
   value: "https://www.redhat.com/en/about/red-hat-end-user-license-agreements#UBI"
 - name: "org.opencontainers.image.documentation"
   value: *docs
+- name: "name"
+  value: *name
+- name: "version"
+  value: *version
 
 envs:
 - name: "JBOSS_IMAGE_NAME"

--- a/ubi8-openjdk-8.yaml
+++ b/ubi8-openjdk-8.yaml
@@ -24,6 +24,10 @@ labels:
   value: "https://www.redhat.com/en/about/red-hat-end-user-license-agreements#UBI"
 - name: "org.opencontainers.image.documentation"
   value: *docs
+- name: "name"
+  value: *name
+- name: "version"
+  value: *version
 
 envs:
 - name: PATH


### PR DESCRIPTION
This is intended to be the UBI8 equivalent of #418 

It rolls up a fix for https://issues.redhat.com/browse/OPENJDK-2438 (commit references the UBI9 variant of that bug, OPENJDK-2414)