### PR TITLE
Rhel7 bump prometheus artifact to a newer build

### DIFF
--- a/modules/prometheus/7/module.yaml
+++ b/modules/prometheus/7/module.yaml
@@ -25,6 +25,6 @@ execute:
 
 artifacts:
 - name: jmx_prometheus_javaagent
-  pnc_build_id: '72393'
-  pnc_artifact_id: '5037842'
-  target: jmx_prometheus_javaagent-0.3.2.redhat-00003.jar
+  pnc_build_id: 'AY2WMDUUTRQAA'
+  pnc_artifact_id: '10355398'
+  target: jmx_prometheus_javaagent-0.3.2.redhat-00005.jar

--- a/openjdk-11-rhel7.yaml
+++ b/openjdk-11-rhel7.yaml
@@ -4,7 +4,7 @@ schema_version: 1
 
 from: "registry.redhat.io/rhel7/rhel"
 name: &name "openjdk/openjdk-11-rhel7"
-version: &version "1.16"
+version: &version "1.17"
 description: "Source To Image (S2I) image for Red Hat OpenShift providing OpenJDK 11"
 
 labels:

--- a/openjdk18-openshift.yaml
+++ b/openjdk18-openshift.yaml
@@ -4,7 +4,7 @@ schema_version: 1
 
 from: "registry.redhat.io/rhel7/rhel"
 name: &name "redhat-openjdk-18/openjdk18-openshift"
-version: &version "1.16"
+version: &version "1.17"
 description: "Source To Image (S2I) image for Red Hat OpenShift providing OpenJDK 8"
 
 labels:

--- a/tests/features/prometheus.feature
+++ b/tests/features/prometheus.feature
@@ -34,4 +34,4 @@ Feature: Prometheus agent tests
     When container is started with args
     | arg     | value                                                                            |
     | command | bash -c "md5sum $JBOSS_CONTAINER_PROMETHEUS_MODULE/jmx_prometheus_javaagent.jar" |
-    Then available container log should contain 8b3af39995b113baf35e53468bad7aae
+    Then available container log should contain 2cd8f7055b99fff305a74b0581e8ecd3


### PR DESCRIPTION
(Waiting on a JIRA tracker to be created by another team)

Move to a newer build of the prometheus agent JAR for the rhel7 images.