### PR TITLE
update Openshift templates for post-2023 01 CPU

### DIFF
--- a/templates/community-image-streams.json
+++ b/templates/community-image-streams.json
@@ -191,6 +191,25 @@
                             "kind": "DockerImage",
                             "name": "registry.access.redhat.com/ubi8/openjdk-8:1.17"
                         }
+                    },
+                    {
+                        "name": "1.18",
+                        "annotations": {
+                            "openshift.io/display-name": "Red Hat OpenJDK 8 (UBI8)",
+                            "description": "Build and run Java applications using Maven and OpenJDK 8 upon UBI8.",
+                            "iconClass": "icon-rh-openjdk",
+                            "tags": "builder,java,openjdk,ubi8",
+                            "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts",
+                            "sampleContextDir": "undertow-servlet",
+                            "version": "1.18"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
+                        },
+                        "from": {
+                            "kind": "DockerImage",
+                            "name": "registry.access.redhat.com/ubi8/openjdk-8:1.18"
+                        }
                     }
                 ]
             }
@@ -377,6 +396,25 @@
                             "kind": "DockerImage",
                             "name": "registry.access.redhat.com/ubi8/openjdk-11:1.17"
                         }
+                    },
+                    {
+                        "name": "1.18",
+                        "annotations": {
+                            "openshift.io/display-name": "Red Hat OpenJDK 11 (UBI8)",
+                            "description": "Build and run Java applications using Maven and OpenJDK 11 upon UBI8.",
+                            "iconClass": "icon-rh-openjdk",
+                            "tags": "builder,java,openjdk,ubi8",
+                            "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts",
+                            "sampleContextDir": "undertow-servlet",
+                            "version": "1.18"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
+                        },
+                        "from": {
+                            "kind": "DockerImage",
+                            "name": "registry.access.redhat.com/ubi8/openjdk-11:1.18"
+                        }
                     }
                 ]
             }
@@ -524,6 +562,25 @@
                         "from": {
                             "kind": "DockerImage",
                             "name": "registry.access.redhat.com/ubi8/openjdk-17:1.17"
+                        }
+                    },
+                    {
+                        "name": "1.18",
+                        "annotations": {
+                            "openshift.io/display-name": "Red Hat OpenJDK 17 (UBI8)",
+                            "description": "Build and run Java applications using Maven and OpenJDK 17 upon UBI8.",
+                            "iconClass": "icon-rh-openjdk",
+                            "tags": "builder,java,openjdk,ubi8",
+                            "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts",
+                            "sampleContextDir": "undertow-servlet",
+                            "version": "1.18"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
+                        },
+                        "from": {
+                            "kind": "DockerImage",
+                            "name": "registry.access.redhat.com/ubi8/openjdk-17:1.18"
                         }
                     }
                 ]

--- a/templates/data.yaml
+++ b/templates/data.yaml
@@ -8,7 +8,7 @@ rhel7:
   # for the rhel7 images, the default range of versions is 1.0-1.12
   # (these keys are numeric as the script uses them as inputs for range())
   from: 0
-  to: 15
+  to: 17
   builder:
     8:
       name: "redhat-openjdk-18/openjdk18-openshift"
@@ -24,7 +24,7 @@ rhel7:
       not: [ 2, 3, 4, 5, 6, 7, 8, 9, 13 ]
 ubi8:
   from: 3
-  to: 17
+  to: 18
   not: [ 4, 5, 6, 7, 8, 9 ]
   builder: # "ubi8/openjdk-X"
     8:  {}
@@ -41,8 +41,11 @@ ubi8:
     17:
       name: "ubi8/openjdk-17-runtime"
       from: 11
+
+# ubi9 is not yet being used in any templates
 ubi9:
   from: 13
+  to: 17
   builder:
     11: {}
     17: {}

--- a/templates/image-streams-aarch64.json
+++ b/templates/image-streams-aarch64.json
@@ -191,6 +191,25 @@
                             "kind": "DockerImage",
                             "name": "registry.access.redhat.com/ubi8/openjdk-8:1.17"
                         }
+                    },
+                    {
+                        "name": "1.18",
+                        "annotations": {
+                            "openshift.io/display-name": "Red Hat OpenJDK 8 (UBI8)",
+                            "description": "Build and run Java applications using Maven and OpenJDK 8 upon UBI8.",
+                            "iconClass": "icon-rh-openjdk",
+                            "tags": "builder,java,openjdk,ubi8,hidden",
+                            "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts",
+                            "sampleContextDir": "undertow-servlet",
+                            "version": "1.18"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
+                        },
+                        "from": {
+                            "kind": "DockerImage",
+                            "name": "registry.access.redhat.com/ubi8/openjdk-8:1.18"
+                        }
                     }
                 ]
             }
@@ -377,6 +396,25 @@
                             "kind": "DockerImage",
                             "name": "registry.access.redhat.com/ubi8/openjdk-11:1.17"
                         }
+                    },
+                    {
+                        "name": "1.18",
+                        "annotations": {
+                            "openshift.io/display-name": "Red Hat OpenJDK 11 (UBI8)",
+                            "description": "Build and run Java applications using Maven and OpenJDK 11 upon UBI8.",
+                            "iconClass": "icon-rh-openjdk",
+                            "tags": "builder,java,openjdk,ubi8,hidden",
+                            "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts",
+                            "sampleContextDir": "undertow-servlet",
+                            "version": "1.18"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
+                        },
+                        "from": {
+                            "kind": "DockerImage",
+                            "name": "registry.access.redhat.com/ubi8/openjdk-11:1.18"
+                        }
                     }
                 ]
             }
@@ -524,6 +562,25 @@
                         "from": {
                             "kind": "DockerImage",
                             "name": "registry.access.redhat.com/ubi8/openjdk-17:1.17"
+                        }
+                    },
+                    {
+                        "name": "1.18",
+                        "annotations": {
+                            "openshift.io/display-name": "Red Hat OpenJDK 17 (UBI8)",
+                            "description": "Build and run Java applications using Maven and OpenJDK 17 upon UBI8.",
+                            "iconClass": "icon-rh-openjdk",
+                            "tags": "builder,java,openjdk,ubi8,hidden",
+                            "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts",
+                            "sampleContextDir": "undertow-servlet",
+                            "version": "1.18"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
+                        },
+                        "from": {
+                            "kind": "DockerImage",
+                            "name": "registry.access.redhat.com/ubi8/openjdk-17:1.18"
                         }
                     }
                 ]

--- a/templates/image-streams-ppc64le.json
+++ b/templates/image-streams-ppc64le.json
@@ -200,6 +200,46 @@
                             "kind": "DockerImage",
                             "name": "registry.access.redhat.com/redhat-openjdk-18/openjdk18-openshift:1.15"
                         }
+                    },
+                    {
+                        "name": "1.16",
+                        "annotations": {
+                            "openshift.io/display-name": "Red Hat OpenJDK 8 (RHEL7)",
+                            "description": "Build and run Java applications using Maven and OpenJDK 8 upon RHEL7.",
+                            "iconClass": "icon-rh-openjdk",
+                            "tags": "builder,java,openjdk,hidden",
+                            "supports": "java:8",
+                            "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts",
+                            "sampleContextDir": "undertow-servlet",
+                            "version": "1.16"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
+                        },
+                        "from": {
+                            "kind": "DockerImage",
+                            "name": "registry.access.redhat.com/redhat-openjdk-18/openjdk18-openshift:1.16"
+                        }
+                    },
+                    {
+                        "name": "1.17",
+                        "annotations": {
+                            "openshift.io/display-name": "Red Hat OpenJDK 8 (RHEL7)",
+                            "description": "Build and run Java applications using Maven and OpenJDK 8 upon RHEL7.",
+                            "iconClass": "icon-rh-openjdk",
+                            "tags": "builder,java,openjdk,hidden",
+                            "supports": "java:8",
+                            "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts",
+                            "sampleContextDir": "undertow-servlet",
+                            "version": "1.17"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
+                        },
+                        "from": {
+                            "kind": "DockerImage",
+                            "name": "registry.access.redhat.com/redhat-openjdk-18/openjdk18-openshift:1.17"
+                        }
                     }
                 ]
             }
@@ -353,6 +393,46 @@
                         "from": {
                             "kind": "DockerImage",
                             "name": "registry.access.redhat.com/openjdk/openjdk-11-rhel7:1.15"
+                        }
+                    },
+                    {
+                        "name": "1.16",
+                        "annotations": {
+                            "openshift.io/display-name": "Red Hat OpenJDK 11 (RHEL7)",
+                            "description": "Build and run Java applications using Maven and OpenJDK 11 upon RHEL7.",
+                            "iconClass": "icon-rh-openjdk",
+                            "tags": "builder,java,openjdk,hidden",
+                            "supports": "java:11",
+                            "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts",
+                            "sampleContextDir": "undertow-servlet",
+                            "version": "1.16"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
+                        },
+                        "from": {
+                            "kind": "DockerImage",
+                            "name": "registry.access.redhat.com/openjdk/openjdk-11-rhel7:1.16"
+                        }
+                    },
+                    {
+                        "name": "1.17",
+                        "annotations": {
+                            "openshift.io/display-name": "Red Hat OpenJDK 11 (RHEL7)",
+                            "description": "Build and run Java applications using Maven and OpenJDK 11 upon RHEL7.",
+                            "iconClass": "icon-rh-openjdk",
+                            "tags": "builder,java,openjdk,hidden",
+                            "supports": "java:11",
+                            "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts",
+                            "sampleContextDir": "undertow-servlet",
+                            "version": "1.17"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
+                        },
+                        "from": {
+                            "kind": "DockerImage",
+                            "name": "registry.access.redhat.com/openjdk/openjdk-11-rhel7:1.17"
                         }
                     }
                 ]
@@ -538,6 +618,25 @@
                         "from": {
                             "kind": "DockerImage",
                             "name": "registry.access.redhat.com/ubi8/openjdk-8:1.17"
+                        }
+                    },
+                    {
+                        "name": "1.18",
+                        "annotations": {
+                            "openshift.io/display-name": "Red Hat OpenJDK 8 (UBI8)",
+                            "description": "Build and run Java applications using Maven and OpenJDK 8 upon UBI8.",
+                            "iconClass": "icon-rh-openjdk",
+                            "tags": "builder,java,openjdk,ubi8,hidden",
+                            "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts",
+                            "sampleContextDir": "undertow-servlet",
+                            "version": "1.18"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
+                        },
+                        "from": {
+                            "kind": "DockerImage",
+                            "name": "registry.access.redhat.com/ubi8/openjdk-8:1.18"
                         }
                     }
                 ]
@@ -725,6 +824,25 @@
                             "kind": "DockerImage",
                             "name": "registry.access.redhat.com/ubi8/openjdk-11:1.17"
                         }
+                    },
+                    {
+                        "name": "1.18",
+                        "annotations": {
+                            "openshift.io/display-name": "Red Hat OpenJDK 11 (UBI8)",
+                            "description": "Build and run Java applications using Maven and OpenJDK 11 upon UBI8.",
+                            "iconClass": "icon-rh-openjdk",
+                            "tags": "builder,java,openjdk,ubi8,hidden",
+                            "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts",
+                            "sampleContextDir": "undertow-servlet",
+                            "version": "1.18"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
+                        },
+                        "from": {
+                            "kind": "DockerImage",
+                            "name": "registry.access.redhat.com/ubi8/openjdk-11:1.18"
+                        }
                     }
                 ]
             }
@@ -872,6 +990,25 @@
                         "from": {
                             "kind": "DockerImage",
                             "name": "registry.access.redhat.com/ubi8/openjdk-17:1.17"
+                        }
+                    },
+                    {
+                        "name": "1.18",
+                        "annotations": {
+                            "openshift.io/display-name": "Red Hat OpenJDK 17 (UBI8)",
+                            "description": "Build and run Java applications using Maven and OpenJDK 17 upon UBI8.",
+                            "iconClass": "icon-rh-openjdk",
+                            "tags": "builder,java,openjdk,ubi8,hidden",
+                            "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts",
+                            "sampleContextDir": "undertow-servlet",
+                            "version": "1.18"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
+                        },
+                        "from": {
+                            "kind": "DockerImage",
+                            "name": "registry.access.redhat.com/ubi8/openjdk-17:1.18"
                         }
                     }
                 ]

--- a/templates/image-streams-s390x.json
+++ b/templates/image-streams-s390x.json
@@ -200,6 +200,46 @@
                             "kind": "DockerImage",
                             "name": "registry.access.redhat.com/redhat-openjdk-18/openjdk18-openshift:1.15"
                         }
+                    },
+                    {
+                        "name": "1.16",
+                        "annotations": {
+                            "openshift.io/display-name": "Red Hat OpenJDK 8 (RHEL7)",
+                            "description": "Build and run Java applications using Maven and OpenJDK 8 upon RHEL7.",
+                            "iconClass": "icon-rh-openjdk",
+                            "tags": "builder,java,openjdk,hidden",
+                            "supports": "java:8",
+                            "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts",
+                            "sampleContextDir": "undertow-servlet",
+                            "version": "1.16"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
+                        },
+                        "from": {
+                            "kind": "DockerImage",
+                            "name": "registry.access.redhat.com/redhat-openjdk-18/openjdk18-openshift:1.16"
+                        }
+                    },
+                    {
+                        "name": "1.17",
+                        "annotations": {
+                            "openshift.io/display-name": "Red Hat OpenJDK 8 (RHEL7)",
+                            "description": "Build and run Java applications using Maven and OpenJDK 8 upon RHEL7.",
+                            "iconClass": "icon-rh-openjdk",
+                            "tags": "builder,java,openjdk,hidden",
+                            "supports": "java:8",
+                            "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts",
+                            "sampleContextDir": "undertow-servlet",
+                            "version": "1.17"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
+                        },
+                        "from": {
+                            "kind": "DockerImage",
+                            "name": "registry.access.redhat.com/redhat-openjdk-18/openjdk18-openshift:1.17"
+                        }
                     }
                 ]
             }
@@ -353,6 +393,46 @@
                         "from": {
                             "kind": "DockerImage",
                             "name": "registry.access.redhat.com/openjdk/openjdk-11-rhel7:1.15"
+                        }
+                    },
+                    {
+                        "name": "1.16",
+                        "annotations": {
+                            "openshift.io/display-name": "Red Hat OpenJDK 11 (RHEL7)",
+                            "description": "Build and run Java applications using Maven and OpenJDK 11 upon RHEL7.",
+                            "iconClass": "icon-rh-openjdk",
+                            "tags": "builder,java,openjdk,hidden",
+                            "supports": "java:11",
+                            "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts",
+                            "sampleContextDir": "undertow-servlet",
+                            "version": "1.16"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
+                        },
+                        "from": {
+                            "kind": "DockerImage",
+                            "name": "registry.access.redhat.com/openjdk/openjdk-11-rhel7:1.16"
+                        }
+                    },
+                    {
+                        "name": "1.17",
+                        "annotations": {
+                            "openshift.io/display-name": "Red Hat OpenJDK 11 (RHEL7)",
+                            "description": "Build and run Java applications using Maven and OpenJDK 11 upon RHEL7.",
+                            "iconClass": "icon-rh-openjdk",
+                            "tags": "builder,java,openjdk,hidden",
+                            "supports": "java:11",
+                            "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts",
+                            "sampleContextDir": "undertow-servlet",
+                            "version": "1.17"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
+                        },
+                        "from": {
+                            "kind": "DockerImage",
+                            "name": "registry.access.redhat.com/openjdk/openjdk-11-rhel7:1.17"
                         }
                     }
                 ]
@@ -538,6 +618,25 @@
                         "from": {
                             "kind": "DockerImage",
                             "name": "registry.access.redhat.com/ubi8/openjdk-8:1.17"
+                        }
+                    },
+                    {
+                        "name": "1.18",
+                        "annotations": {
+                            "openshift.io/display-name": "Red Hat OpenJDK 8 (UBI8)",
+                            "description": "Build and run Java applications using Maven and OpenJDK 8 upon UBI8.",
+                            "iconClass": "icon-rh-openjdk",
+                            "tags": "builder,java,openjdk,ubi8,hidden",
+                            "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts",
+                            "sampleContextDir": "undertow-servlet",
+                            "version": "1.18"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
+                        },
+                        "from": {
+                            "kind": "DockerImage",
+                            "name": "registry.access.redhat.com/ubi8/openjdk-8:1.18"
                         }
                     }
                 ]
@@ -725,6 +824,25 @@
                             "kind": "DockerImage",
                             "name": "registry.access.redhat.com/ubi8/openjdk-11:1.17"
                         }
+                    },
+                    {
+                        "name": "1.18",
+                        "annotations": {
+                            "openshift.io/display-name": "Red Hat OpenJDK 11 (UBI8)",
+                            "description": "Build and run Java applications using Maven and OpenJDK 11 upon UBI8.",
+                            "iconClass": "icon-rh-openjdk",
+                            "tags": "builder,java,openjdk,ubi8,hidden",
+                            "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts",
+                            "sampleContextDir": "undertow-servlet",
+                            "version": "1.18"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
+                        },
+                        "from": {
+                            "kind": "DockerImage",
+                            "name": "registry.access.redhat.com/ubi8/openjdk-11:1.18"
+                        }
                     }
                 ]
             }
@@ -872,6 +990,25 @@
                         "from": {
                             "kind": "DockerImage",
                             "name": "registry.access.redhat.com/ubi8/openjdk-17:1.17"
+                        }
+                    },
+                    {
+                        "name": "1.18",
+                        "annotations": {
+                            "openshift.io/display-name": "Red Hat OpenJDK 17 (UBI8)",
+                            "description": "Build and run Java applications using Maven and OpenJDK 17 upon UBI8.",
+                            "iconClass": "icon-rh-openjdk",
+                            "tags": "builder,java,openjdk,ubi8,hidden",
+                            "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts",
+                            "sampleContextDir": "undertow-servlet",
+                            "version": "1.18"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
+                        },
+                        "from": {
+                            "kind": "DockerImage",
+                            "name": "registry.access.redhat.com/ubi8/openjdk-17:1.18"
                         }
                     }
                 ]

--- a/templates/image-streams.json
+++ b/templates/image-streams.json
@@ -240,6 +240,46 @@
                             "kind": "DockerImage",
                             "name": "registry.access.redhat.com/redhat-openjdk-18/openjdk18-openshift:1.15"
                         }
+                    },
+                    {
+                        "name": "1.16",
+                        "annotations": {
+                            "openshift.io/display-name": "Red Hat OpenJDK 8 (RHEL7)",
+                            "description": "Build and run Java applications using Maven and OpenJDK 8 upon RHEL7.",
+                            "iconClass": "icon-rh-openjdk",
+                            "tags": "builder,java,openjdk,hidden",
+                            "supports": "java:8",
+                            "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts",
+                            "sampleContextDir": "undertow-servlet",
+                            "version": "1.16"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
+                        },
+                        "from": {
+                            "kind": "DockerImage",
+                            "name": "registry.access.redhat.com/redhat-openjdk-18/openjdk18-openshift:1.16"
+                        }
+                    },
+                    {
+                        "name": "1.17",
+                        "annotations": {
+                            "openshift.io/display-name": "Red Hat OpenJDK 8 (RHEL7)",
+                            "description": "Build and run Java applications using Maven and OpenJDK 8 upon RHEL7.",
+                            "iconClass": "icon-rh-openjdk",
+                            "tags": "builder,java,openjdk,hidden",
+                            "supports": "java:8",
+                            "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts",
+                            "sampleContextDir": "undertow-servlet",
+                            "version": "1.17"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
+                        },
+                        "from": {
+                            "kind": "DockerImage",
+                            "name": "registry.access.redhat.com/redhat-openjdk-18/openjdk18-openshift:1.17"
+                        }
                     }
                 ]
             }
@@ -393,6 +433,46 @@
                         "from": {
                             "kind": "DockerImage",
                             "name": "registry.access.redhat.com/openjdk/openjdk-11-rhel7:1.15"
+                        }
+                    },
+                    {
+                        "name": "1.16",
+                        "annotations": {
+                            "openshift.io/display-name": "Red Hat OpenJDK 11 (RHEL7)",
+                            "description": "Build and run Java applications using Maven and OpenJDK 11 upon RHEL7.",
+                            "iconClass": "icon-rh-openjdk",
+                            "tags": "builder,java,openjdk,hidden",
+                            "supports": "java:11",
+                            "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts",
+                            "sampleContextDir": "undertow-servlet",
+                            "version": "1.16"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
+                        },
+                        "from": {
+                            "kind": "DockerImage",
+                            "name": "registry.access.redhat.com/openjdk/openjdk-11-rhel7:1.16"
+                        }
+                    },
+                    {
+                        "name": "1.17",
+                        "annotations": {
+                            "openshift.io/display-name": "Red Hat OpenJDK 11 (RHEL7)",
+                            "description": "Build and run Java applications using Maven and OpenJDK 11 upon RHEL7.",
+                            "iconClass": "icon-rh-openjdk",
+                            "tags": "builder,java,openjdk,hidden",
+                            "supports": "java:11",
+                            "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts",
+                            "sampleContextDir": "undertow-servlet",
+                            "version": "1.17"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
+                        },
+                        "from": {
+                            "kind": "DockerImage",
+                            "name": "registry.access.redhat.com/openjdk/openjdk-11-rhel7:1.17"
                         }
                     }
                 ]
@@ -578,6 +658,25 @@
                         "from": {
                             "kind": "DockerImage",
                             "name": "registry.access.redhat.com/ubi8/openjdk-8:1.17"
+                        }
+                    },
+                    {
+                        "name": "1.18",
+                        "annotations": {
+                            "openshift.io/display-name": "Red Hat OpenJDK 8 (UBI8)",
+                            "description": "Build and run Java applications using Maven and OpenJDK 8 upon UBI8.",
+                            "iconClass": "icon-rh-openjdk",
+                            "tags": "builder,java,openjdk,ubi8,hidden",
+                            "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts",
+                            "sampleContextDir": "undertow-servlet",
+                            "version": "1.18"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
+                        },
+                        "from": {
+                            "kind": "DockerImage",
+                            "name": "registry.access.redhat.com/ubi8/openjdk-8:1.18"
                         }
                     }
                 ]
@@ -765,6 +864,25 @@
                             "kind": "DockerImage",
                             "name": "registry.access.redhat.com/ubi8/openjdk-11:1.17"
                         }
+                    },
+                    {
+                        "name": "1.18",
+                        "annotations": {
+                            "openshift.io/display-name": "Red Hat OpenJDK 11 (UBI8)",
+                            "description": "Build and run Java applications using Maven and OpenJDK 11 upon UBI8.",
+                            "iconClass": "icon-rh-openjdk",
+                            "tags": "builder,java,openjdk,ubi8,hidden",
+                            "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts",
+                            "sampleContextDir": "undertow-servlet",
+                            "version": "1.18"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
+                        },
+                        "from": {
+                            "kind": "DockerImage",
+                            "name": "registry.access.redhat.com/ubi8/openjdk-11:1.18"
+                        }
                     }
                 ]
             }
@@ -912,6 +1030,25 @@
                         "from": {
                             "kind": "DockerImage",
                             "name": "registry.access.redhat.com/ubi8/openjdk-17:1.17"
+                        }
+                    },
+                    {
+                        "name": "1.18",
+                        "annotations": {
+                            "openshift.io/display-name": "Red Hat OpenJDK 17 (UBI8)",
+                            "description": "Build and run Java applications using Maven and OpenJDK 17 upon UBI8.",
+                            "iconClass": "icon-rh-openjdk",
+                            "tags": "builder,java,openjdk,ubi8,hidden",
+                            "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts",
+                            "sampleContextDir": "undertow-servlet",
+                            "version": "1.18"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
+                        },
+                        "from": {
+                            "kind": "DockerImage",
+                            "name": "registry.access.redhat.com/ubi8/openjdk-17:1.18"
                         }
                     }
                 ]

--- a/templates/runtime-image-streams.json
+++ b/templates/runtime-image-streams.json
@@ -182,6 +182,24 @@
                             "kind": "DockerImage",
                             "name": "registry.access.redhat.com/ubi8/openjdk-8-runtime:1.17"
                         }
+                    },
+                    {
+                        "name": "1.18",
+                        "annotations": {
+                            "openshift.io/display-name": "Red Hat OpenJDK 8 Runtime (UBI8)",
+                            "description": "Run Java applications using OpenJDK 8 upon UBI8.",
+                            "iconClass": "icon-rh-openjdk",
+                            "tags": "java,openjdk,ubi8",
+                            
+                            "version": "1.18"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
+                        },
+                        "from": {
+                            "kind": "DockerImage",
+                            "name": "registry.access.redhat.com/ubi8/openjdk-8-runtime:1.18"
+                        }
                     }
                 ]
             }
@@ -359,6 +377,24 @@
                             "kind": "DockerImage",
                             "name": "registry.access.redhat.com/ubi8/openjdk-11-runtime:1.17"
                         }
+                    },
+                    {
+                        "name": "1.18",
+                        "annotations": {
+                            "openshift.io/display-name": "Red Hat OpenJDK 11 Runtime (UBI8)",
+                            "description": "Run Java applications using OpenJDK 11 upon UBI8.",
+                            "iconClass": "icon-rh-openjdk",
+                            "tags": "java,openjdk,ubi8",
+                            
+                            "version": "1.18"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
+                        },
+                        "from": {
+                            "kind": "DockerImage",
+                            "name": "registry.access.redhat.com/ubi8/openjdk-11-runtime:1.18"
+                        }
                     }
                 ]
             }
@@ -499,6 +535,24 @@
                         "from": {
                             "kind": "DockerImage",
                             "name": "registry.access.redhat.com/ubi8/openjdk-17-runtime:1.17"
+                        }
+                    },
+                    {
+                        "name": "1.18",
+                        "annotations": {
+                            "openshift.io/display-name": "Red Hat OpenJDK 17 Runtime (UBI8)",
+                            "description": "Run Java applications using OpenJDK 17 upon UBI8.",
+                            "iconClass": "icon-rh-openjdk",
+                            "tags": "java,openjdk,ubi8",
+                            
+                            "version": "1.18"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
+                        },
+                        "from": {
+                            "kind": "DockerImage",
+                            "name": "registry.access.redhat.com/ubi8/openjdk-17-runtime:1.18"
                         }
                     }
                 ]


### PR DESCRIPTION
this updates the OpenShift templates to bump the versions to those which will be current after the January CPU.

Only the rhel7 images are going to change their versions in this CPU, but the templates are lagging behind for the current ubi8 image versions.

Not to be merged until after the CPU containers ship.

The first commit (data.yaml) is the manual change, the second the result of running `generateImageStreamTemplates.py`