### PR TITLE
[Openjdk-2587] ensure pkg-update happens before reinstall tzdata (ubi8)

### DIFF
--- a/modules/util/tzdata/module.yaml
+++ b/modules/util/tzdata/module.yaml
@@ -1,7 +1,14 @@
 schema_version: 1
 name: jboss.container.util.tzdata
 version: '1.0'
-description: Reinstall the tzdata package, to ensure zoneinfo is present
+description: Reinstall the tzdata package, to ensure zoneinfo is present.
+
+# if the base image tzdata version is not available on the RPM mirrors (such as
+# when it has been updated), the reinstall action will fail. To prevent this,
+# run pkg-update first.
+modules:
+  install:
+  - name: jboss.container.util.pkg-update
 
 execute:
 - script: execute.sh

--- a/ubi8-openjdk-11.yaml
+++ b/ubi8-openjdk-11.yaml
@@ -47,6 +47,7 @@ modules:
   repositories:
   - path: modules
   install:
+  - name: jboss.container.util.pkg-update
   - name: jboss.container.openjdk.jdk
     version: "11"
   - name: jboss.container.prometheus
@@ -55,7 +56,6 @@ modules:
   - name: jboss.container.maven
     version: "3.8.11"
   - name: jboss.container.java.s2i.bash
-  - name: jboss.container.util.pkg-update
   - name: jboss.container.util.tzdata
   # required due to jolokia
   - name: jboss.container.java.singleton-jdk

--- a/ubi8-openjdk-17.yaml
+++ b/ubi8-openjdk-17.yaml
@@ -47,6 +47,7 @@ modules:
   repositories:
   - path: modules
   install:
+  - name: jboss.container.util.pkg-update
   - name: jboss.container.openjdk.jdk
     version: "17"
   - name: jboss.container.prometheus
@@ -55,7 +56,6 @@ modules:
     version: "3.8.17"
   - name: jboss.container.util.tzdata
   - name: jboss.container.java.s2i.bash
-  - name: jboss.container.util.pkg-update
 
 help:
   add: true

--- a/ubi8-openjdk-8-runtime.yaml
+++ b/ubi8-openjdk-8-runtime.yaml
@@ -45,11 +45,11 @@ modules:
   repositories:
   - path: modules
   install:
+  - name: jboss.container.util.pkg-update
   - name: jboss.container.openjdk.jre
     version: "8"
   - name:  jboss.container.java.jre.run
   - name: jboss.container.tar
-  - name: jboss.container.util.pkg-update
   - name: jboss.container.util.tzdata
 
 help:

--- a/ubi8-openjdk-8.yaml
+++ b/ubi8-openjdk-8.yaml
@@ -47,6 +47,7 @@ modules:
   repositories:
   - path: modules
   install:
+  - name: jboss.container.util.pkg-update
   - name: jboss.container.openjdk.jdk
     version: "8"
   - name: jboss.container.prometheus
@@ -55,7 +56,6 @@ modules:
   - name: jboss.container.maven
     version: "3.8.8"
   - name: jboss.container.java.s2i.bash
-  - name: jboss.container.util.pkg-update
   - name: jboss.container.util.tzdata
 
 help:


### PR DESCRIPTION
https://issues.redhat.com/browse/OPENJDK-2587

The tzdata module, which calls "microdnf reinstall tzdata", may fail if the base image has an installed tzdata RPM that is no longer available on the mirrors / is out-of-date. For example

    base image installed RPM: tzdata-2023d-1.el8.noarch
    attempt to build ubi8-openjdk-17 (where tzdata module is first)
    "Installed package tzdata-2023d-1.el8.noarch not available"

The fix is to move the pkg-update module to be earlier. Do this for all images, for consistency, place pkg-update first. (This matches the ubi9 images)

I have not included a unit test as I am not sure how to approach mocking older/newer RPM versions in a controllable way.