### PR TITLE
Openjdk 2427 rsync preserve ubi8

### DIFF
--- a/modules/s2i/bash/artifacts/opt/jboss/container/java/s2i/maven-s2i-overrides
+++ b/modules/s2i/bash/artifacts/opt/jboss/container/java/s2i/maven-s2i-overrides
@@ -28,7 +28,7 @@ function maven_s2i_custom_binary_build() {
     binary_dir="${S2I_SOURCE_DIR}"
   fi
   log_info "Copying binaries from ${binary_dir} to ${S2I_TARGET_DEPLOYMENTS_DIR} ..."
-  rsync -rl --out-format='%n' "${binary_dir}"/ "${S2I_TARGET_DEPLOYMENTS_DIR}"
+  rsync --archive --out-format='%n' "${binary_dir}"/ "${S2I_TARGET_DEPLOYMENTS_DIR}"
 }
 
 function maven_s2i_deploy_artifacts_override() {

--- a/modules/s2i/core/bash/artifacts/opt/jboss/container/s2i/core/s2i-core
+++ b/modules/s2i/core/bash/artifacts/opt/jboss/container/s2i/core/s2i-core
@@ -64,7 +64,7 @@ function s2i_core_copy_configuration() {
         mkdir -pm 775 "${S2I_TARGET_CONFIGURATION_DIR}"
       fi
       log_info "Copying configuration from $(realpath --relative-to ${S2I_SOURCE_DIR} ${1}/${S2I_SOURCE_CONFIGURATION_DIR}) to ${S2I_TARGET_CONFIGURATION_DIR}..."
-      rsync -rl --out-format='%n' "${1}/${S2I_SOURCE_CONFIGURATION_DIR}"/ "${S2I_TARGET_CONFIGURATION_DIR}"
+      rsync --archive --out-format='%n' "${1}/${S2I_SOURCE_CONFIGURATION_DIR}"/ "${S2I_TARGET_CONFIGURATION_DIR}"
     fi
   fi 
 }
@@ -81,7 +81,7 @@ function s2i_core_copy_data() {
         mkdir -pm 775 "${S2I_TARGET_DATA_DIR}"
       fi
       log_info "Copying app data from $(realpath --relative-to ${S2I_SOURCE_DIR} ${1}/${S2I_SOURCE_DATA_DIR}) to ${S2I_TARGET_DATA_DIR}..."
-      rsync -rl --out-format='%n' "${1}/${S2I_SOURCE_DATA_DIR}"/ "${S2I_TARGET_DATA_DIR}"
+      rsync --archive --out-format='%n' "${1}/${S2I_SOURCE_DATA_DIR}"/ "${S2I_TARGET_DATA_DIR}"
       # s2i used to be more forgiving, but the build will fail if this call
       # fails.  emit a warning and allow the build to succeed
       chmod -R g+rwX "${S2I_TARGET_DATA_DIR}" || log_warning "Errors occurred while adding read/write permissions to S2I_TARGET_DATA_DIR ($S2I_TARGET_DATA_DIR)."

--- a/tests/features/java/java_s2i.feature
+++ b/tests/features/java/java_s2i.feature
@@ -331,3 +331,9 @@ Feature: Openshift OpenJDK S2I tests
       Given s2i build https://github.com/jboss-container-images/openjdk-test-applications from OPENJDK-1549 with env
        | variable           | value    |
        | MAVEN_ARGS         | validate |
+
+  Scenario: Ensure mtime is preserved for build artifacts (OPENJDK-2427)
+      Given s2i build https://github.com/jboss-container-images/openjdk-test-applications from OPENJDK-2408-bin-custom-s2i-assemble with env
+       | variable          | value |
+       | S2I_DELETE_SOURCE | false |
+    Then run find /deployments/spring-boot-sample-simple-1.5.0.BUILD-SNAPSHOT.jar ! -newer /tmp/src/spring-boot-sample-simple-1.5.0.BUILD-SNAPSHOT.jar in container and check its output for spring-boot-sample-simple-1.5.0.BUILD-SNAPSHOT.jar


### PR DESCRIPTION
https://issues.redhat.com/browse/OPENJDK-2427

This is the UBI8 port of #411.

 * <s>It is based upon #443 which I needed to build JDK17.</s> _no longer_
 * <s>In the UBI9 version, the test was in `tests/features/java/java_s2i.feature` but we have subsequently marked the whole file `@ignore` due to GHA issues; for that reason, I've put the test into the not-ignored `tests/features/java/java_s2i_inc.feature` here. We'll see if it passes on GHA. It does locally.</s> _no longer_