### PR TITLE
[OPENJDK-2519] tzdata module depend upon pkg-update

### DIFF
--- a/modules/util/tzdata/module.yaml
+++ b/modules/util/tzdata/module.yaml
@@ -1,7 +1,14 @@
 schema_version: 1
 name: jboss.container.util.tzdata
 version: '1.0'
-description: Reinstall the tzdata package, to ensure zoneinfo is present
+description: Reinstall the tzdata package, to ensure zoneinfo is present.
+
+# if the base image tzdata version is not available on the RPM mirrors (such as
+# when it has been updated), the reinstall action will fail. To prevent this,
+# run pkg-update first.
+modules:
+  install:
+  - name: jboss.container.util.pkg-update
 
 execute:
 - script: execute.sh


### PR DESCRIPTION
This is the top-up commit from #443 (UBI8), to add a documentation-dependency between the tzdata and pkg-update modules. It is a no-op for these images (at the moment)

https://issues.redhat.com/browse/OPENJDK-2519