### PR TITLE
OPENJDK-2736 and OPENJDK-2737: gate Jlink code, fail early if jmods unavailable

### DIFF
--- a/modules/jlink/artifacts/opt/jboss/container/java/jlink/preflight.sh
+++ b/modules/jlink/artifacts/opt/jboss/container/java/jlink/preflight.sh
@@ -4,9 +4,11 @@ jlink_preflight_check()
     if [ "$JAVA_VERSION" -lt 11 ]; then
       echo "Jlink integration not available for JDK${JAVA_VERSION}!"
       echo "Jlink integration is only supported for JDK versions 11 and newer."
+      exit 1
     fi
     if [ ! -d /usr/lib/jvm/java/jmods ]; then
       echo "Jlink integration requires the jmods RPM to be installed in the builder image, e.g."
       echo "        microdnf install -y java-${JAVA_VERSION}-openjdk-jmods"
+      exit 1
     fi
 }

--- a/modules/jlink/artifacts/opt/jboss/container/java/jlink/preflight.sh
+++ b/modules/jlink/artifacts/opt/jboss/container/java/jlink/preflight.sh
@@ -1,0 +1,12 @@
+jlink_preflight_check()
+{
+    # preflight check: do we have what we need?
+    if [ "$JAVA_VERSION" -lt 11 ]; then
+      echo "Jlink integration not available for JDK${JAVA_VERSION}!"
+      echo "Jlink integration is only supported for JDK versions 11 and newer."
+    fi
+    if [ ! -d /usr/lib/jvm/java/jmods ]; then
+      echo "Jlink integration requires the jmods RPM to be installed in the builder image, e.g."
+      echo "        microdnf install -y java-${JAVA_VERSION}-openjdk-jmods"
+    fi
+}

--- a/modules/s2i/bash/artifacts/usr/local/s2i/assemble
+++ b/modules/s2i/bash/artifacts/usr/local/s2i/assemble
@@ -19,18 +19,22 @@ source "${JBOSS_CONTAINER_UTIL_PATHFINDER_MODULE}/pathfinder.sh"
 setup_java_app_and_lib
 
 # include our jlink scripts
-source "${JBOSS_CONTAINER_JAVA_JLINK_MODULE}/mkdeps.sh"
-echo "Invoking mkdeps"
-generate_deps
+if [ "$S2I_ENABLE_JLINK" = "true" ]; then
 
-source "${JBOSS_CONTAINER_JAVA_JLINK_MODULE}/mkstrippeddeps.sh"
-echo "Stripping dependencies"
-mkstrippeddeps
+    source "${JBOSS_CONTAINER_JAVA_JLINK_MODULE}/mkdeps.sh"
+    echo "Invoking mkdeps"
+    generate_deps
 
-source "${JBOSS_CONTAINER_JAVA_JLINK_MODULE}/generatejdkdeps.sh"
-echo "Generating JDK dependencies"
-generatejdkdeps
+    source "${JBOSS_CONTAINER_JAVA_JLINK_MODULE}/mkstrippeddeps.sh"
+    echo "Stripping dependencies"
+    mkstrippeddeps
 
-source "${JBOSS_CONTAINER_JAVA_JLINK_MODULE}/mkjreimage.sh"
-echo "Linking jre"
-generate_jre_image
+    source "${JBOSS_CONTAINER_JAVA_JLINK_MODULE}/generatejdkdeps.sh"
+    echo "Generating JDK dependencies"
+    generatejdkdeps
+
+    source "${JBOSS_CONTAINER_JAVA_JLINK_MODULE}/mkjreimage.sh"
+    echo "Linking jre"
+    generate_jre_image
+
+fi

--- a/modules/s2i/bash/artifacts/usr/local/s2i/assemble
+++ b/modules/s2i/bash/artifacts/usr/local/s2i/assemble
@@ -21,6 +21,9 @@ setup_java_app_and_lib
 # include our jlink scripts
 if [ "$S2I_ENABLE_JLINK" = "true" ]; then
 
+    source "${JBOSS_CONTAINER_JAVA_JLINK_MODULE}/preflight.sh"
+    jlink_preflight_check
+
     source "${JBOSS_CONTAINER_JAVA_JLINK_MODULE}/mkdeps.sh"
     echo "Invoking mkdeps"
     generate_deps

--- a/modules/s2i/bash/artifacts/usr/local/s2i/assemble
+++ b/modules/s2i/bash/artifacts/usr/local/s2i/assemble
@@ -16,7 +16,6 @@ maven_s2i_build
 
 # run the pathfinder scripts to define JAVA_APP_JAR and JAVA_LIB_DIR
 source "${JBOSS_CONTAINER_UTIL_PATHFINDER_MODULE}/pathfinder.sh"
-echo "Setting up java app and lib variables"
 setup_java_app_and_lib
 
 # include our jlink scripts


### PR DESCRIPTION
 * https://issues.redhat.com/browse/OPENJDK-2736
 * https://issues.redhat.com/browse/OPENJDK-2737

