### PR TITLE
[OPENJDK-2806] Remove value for S2I_ENABLE_JLINK

### DIFF
--- a/modules/s2i/core/module.yaml
+++ b/modules/s2i/core/module.yaml
@@ -116,7 +116,6 @@ envs:
   description: ^
     Enables the Jdeps/JLink workflow to minimize JRE size
   example: "false"
-  value: "false"
 
 run:
   cmd:


### PR DESCRIPTION
S2I_ENABLE_JLINK is a configuration environment variable, not an informational one, and so the default should be unset, rather than "false".

https://issues.redhat.com/browse/OPENJDK-2806