### PR TITLE
[OPENJDK-2833] Possible fix for OpenJDK image should scrub passwords from logs

### DIFF
--- a/modules/run/artifacts/opt/jboss/container/java/run/run-java.sh
+++ b/modules/run/artifacts/opt/jboss/container/java/run/run-java.sh
@@ -235,9 +235,9 @@ startup() {
 
   local procname="${JAVA_APP_NAME-java}"
 
-  local masked_args=$(mask_passwords "${args}")
+  local masked_opts=$(mask_passwords "$(get_java_options)")
 
-  log_info "exec -a \"${procname}\" java $(get_java_options) -cp \"$(get_classpath)\" ${masked_args} $*"
+  log_info "exec -a \"${procname}\" java ${masked_opts} -cp \"$(get_classpath)\" ${args} $*"
   log_info "running in $PWD"
   exec -a "${procname}" java $(get_java_options) -cp "$(get_classpath)" ${args} $*
 }

--- a/modules/run/artifacts/opt/jboss/container/java/run/run-java.sh
+++ b/modules/run/artifacts/opt/jboss/container/java/run/run-java.sh
@@ -199,6 +199,27 @@ get_classpath() {
   echo "${cp_path}"
 }
 
+# Mask secrets before printing
+mask_passwords() {
+    local content="$1"
+    local result=""
+
+    IFS=' ' read -r -a key_value_pairs <<< "$content"
+
+    for pair in "${key_value_pairs[@]}"; do
+        key=$(echo "$pair" | cut -d '=' -f 1)
+        value=$(echo "$pair" | cut -d '=' -f 2-)
+
+        if [[ $key =~ [Pp][Aa][Ss][Ss][Ww][Oo][Rr][Dd] ]]; then
+            result+="$key=***** "
+        else
+            result+="$pair "
+        fi
+    done
+
+    echo "${result% }"
+}
+
 # Start JVM
 startup() {
   # Initialize environment
@@ -212,9 +233,11 @@ startup() {
      args="-jar ${JAVA_APP_JAR}"
   fi
 
-  procname="${JAVA_APP_NAME-java}"
+  local procname="${JAVA_APP_NAME-java}"
 
-  log_info "exec -a \"${procname}\" java $(get_java_options) -cp \"$(get_classpath)\" ${args} $*"
+  local masked_args=$(mask_passwords "${args}")
+
+  log_info "exec -a \"${procname}\" java $(get_java_options) -cp \"$(get_classpath)\" ${masked_args} $*"
   log_info "running in $PWD"
   exec -a "${procname}" java $(get_java_options) -cp "$(get_classpath)" ${args} $*
 }

--- a/modules/run/tests/features/run.feature
+++ b/modules/run/tests/features/run.feature
@@ -1,0 +1,8 @@
+@ubi9
+Feature: OpenJDK run script tests
+  Scenario: Ensure command-line options containing 'password' are masked in logs
+    Given container is started with env
+      | variable         | value                                              |
+      | JAVA_OPTS_APPEND | -Djavax.net.ssl.trustStorePassword=sensitiveString |
+    Then container log should not contain sensitiveString
+


### PR DESCRIPTION
https://issues.redhat.com/browse/OPENJDK-2833

----

This PR masks password provided via Java parameters on a command line. This is a possible fix for https://issues.redhat.com/browse/CSB-3783.

Thanks for submitting your Pull Request!

Please make sure your PR meets the following requirements:

- [x] A JIRA issue must exist in the OPENJDK project at issues.redhat.com
- [x] Pull Request title should be prefixed with the JIRA issue: `[OPENJDK-XYZ] Subject`
- [x] Pull Request contains hyperlink to the JIRA issue
- [x] Pull Request contains description of the issue
- [x] Pull Request does not include fixes for issues other than the main ticket
- [x] Attached commits represent units of work and are properly formatted
- [x] You have read and agreed to the Developer Certificate of Origin (DCO) (see `CONTRIBUTING.md`)
- [x] Every commit contains `Signed-off-by: Your Name <yourname@example.com>` - use `git commit -s`
