### PR TITLE
[OPENJDK-2735] Move grep and gawk installation to phase-1

### DIFF
--- a/templates/jlink/jlink-builder/jlink-builder-template.yaml
+++ b/templates/jlink/jlink-builder/jlink-builder-template.yaml
@@ -29,6 +29,7 @@ objects:
       dockerfile: |
         FROM -
         USER 0
+        RUN microdnf --setopt=install_weak_deps=0 --setopt=tsflags=nodocs install -y java-${JDK_VERSION}-openjdk-jmods
         RUN mkdir -p /mnt/jrootfs
         RUN microdnf install --installroot /mnt/jrootfs --releasever 9 --setopt install_weak_deps=0 --nodocs -y java-${JDK_VERSION}-openjdk-jmods \
         --config=/etc/dnf/dnf.conf \

--- a/templates/jlink/jlink-builder/jlink-builder-template.yaml
+++ b/templates/jlink/jlink-builder/jlink-builder-template.yaml
@@ -31,7 +31,7 @@ objects:
         USER 0
         RUN microdnf --setopt=install_weak_deps=0 --setopt=tsflags=nodocs install -y java-${JDK_VERSION}-openjdk-jmods
         RUN mkdir -p /mnt/jrootfs
-        RUN microdnf install --installroot /mnt/jrootfs --releasever 9 --setopt install_weak_deps=0 --nodocs -y java-${JDK_VERSION}-openjdk-jmods \
+        RUN microdnf install --installroot /mnt/jrootfs --releasever 9 --setopt install_weak_deps=0 --nodocs -y \
         --config=/etc/dnf/dnf.conf \
         --noplugins \
         --setopt=cachedir=/var/cache \

--- a/templates/jlink/jlink-builder/jlink-builder-template.yaml
+++ b/templates/jlink/jlink-builder/jlink-builder-template.yaml
@@ -29,7 +29,15 @@ objects:
       dockerfile: |
         FROM -
         USER 0
-        RUN microdnf --setopt=install_weak_deps=0 --setopt=tsflags=nodocs install -y java-${JDK_VERSION}-openjdk-jmods
+        RUN mkdir -p /mnt/jrootfs
+        RUN microdnf install --installroot /mnt/jrootfs --releasever 9 --setopt install_weak_deps=0 --nodocs -y java-${JDK_VERSION}-openjdk-jmods \
+        --config=/etc/dnf/dnf.conf \
+        --noplugins \
+        --setopt=cachedir=/var/cache \
+        --setopt=reposdir=/etc/yum.repos.d \
+        --setopt=varsdir=/etc/dnf/vars \
+        grep gawk
+        RUN rm -rf /mnt/jrootfs/var/cache/* /mnt/jrootfs/var/lib/rpm /mnt/jrootfs/var/lib/dnf
         USER 185
     strategy:
       dockerStrategy:


### PR DESCRIPTION
As suggested I have made an attempt to move `grep` and `gawk` installation to phase-1.
But with or without this change my builds are coming out with 
```
unable to retrieve container logs for cri-o:.........
```

 When I tried to check on web console as `adminstrator` I see that it is some ephemeral-storage issue.
```
Generated from kubelet on crc-vlf7c-master-0
The node was low on resource: ephemeral-storage. Threshold quantity: 4902142351, available: 4730208Ki. Container docker-build was using 4Ki, request is 0, has larger consumption of ephemeral-storage
```

I deleted all builds/pods/imagestreams but there is  no effect :)
Yesterday I was trying to create a deployment which was continuously failing and creating successive pods after every failure. I guessed that might have consumed all the memory and deleted all pods in that project. Now on local CRC I don't have any builds. Even then builds are failing with that `cri-o error`.