### PR TITLE
label images with opencontainers 'source' label

### DIFF
--- a/ubi9-openjdk-17-runtime.yaml
+++ b/ubi9-openjdk-17-runtime.yaml
@@ -30,6 +30,8 @@ labels:
   value: *version
 - name: "org.opencontainers.image.source"
   value: "https://github.com/rh-openjdk/redhat-openjdk-containers"
+- name: "org.opencontainers.image.revision"
+  value: "ubi9"
 
 envs:
 - name: "JBOSS_IMAGE_NAME"

--- a/ubi9-openjdk-17-runtime.yaml
+++ b/ubi9-openjdk-17-runtime.yaml
@@ -28,6 +28,8 @@ labels:
   value: *name
 - name: "version"
   value: *version
+- name: "org.opencontainers.image.source"
+  value: "https://github.com/rh-openjdk/redhat-openjdk-containers"
 
 envs:
 - name: "JBOSS_IMAGE_NAME"

--- a/ubi9-openjdk-17.yaml
+++ b/ubi9-openjdk-17.yaml
@@ -30,6 +30,8 @@ labels:
   value: *version
 - name: "org.opencontainers.image.source"
   value: "https://github.com/rh-openjdk/redhat-openjdk-containers"
+- name: "org.opencontainers.image.revision"
+  value: "ubi9"
 
 envs:
 - name: PATH

--- a/ubi9-openjdk-17.yaml
+++ b/ubi9-openjdk-17.yaml
@@ -28,6 +28,8 @@ labels:
   value: *name
 - name: "version"
   value: *version
+- name: "org.opencontainers.image.source"
+  value: "https://github.com/rh-openjdk/redhat-openjdk-containers"
 
 envs:
 - name: PATH

--- a/ubi9-openjdk-21-runtime.yaml
+++ b/ubi9-openjdk-21-runtime.yaml
@@ -30,6 +30,8 @@ labels:
   value: *version
 - name: "org.opencontainers.image.source"
   value: "https://github.com/rh-openjdk/redhat-openjdk-containers"
+- name: "org.opencontainers.image.revision"
+  value: "ubi9"
 
 envs:
 - name: "JBOSS_IMAGE_NAME"

--- a/ubi9-openjdk-21-runtime.yaml
+++ b/ubi9-openjdk-21-runtime.yaml
@@ -28,6 +28,8 @@ labels:
   value: *name
 - name: "version"
   value: *version
+- name: "org.opencontainers.image.source"
+  value: "https://github.com/rh-openjdk/redhat-openjdk-containers"
 
 envs:
 - name: "JBOSS_IMAGE_NAME"

--- a/ubi9-openjdk-21.yaml
+++ b/ubi9-openjdk-21.yaml
@@ -30,6 +30,8 @@ labels:
   value: *version
 - name: "org.opencontainers.image.source"
   value: "https://github.com/rh-openjdk/redhat-openjdk-containers"
+- name: "org.opencontainers.image.revision"
+  value: "ubi9"
 
 envs:
 - name: PATH

--- a/ubi9-openjdk-21.yaml
+++ b/ubi9-openjdk-21.yaml
@@ -28,6 +28,8 @@ labels:
   value: *name
 - name: "version"
   value: *version
+- name: "org.opencontainers.image.source"
+  value: "https://github.com/rh-openjdk/redhat-openjdk-containers"
 
 envs:
 - name: PATH


### PR DESCRIPTION
Amongst other things, this allows GitHub to provide links back from Container Images to the source repository that built them (if we publish Container Images to GHCR.) See
<https://github.com/opencontainers/image-spec/blob/main/annotations.md#pre-defined-annotation-keys>

https://issues.redhat.com/browse/OPENJDK-4003