### PR TITLE
[OPENJDK-2915] refactor run-env.sh into run-java.sh, clean up run script

### DIFF
--- a/modules/run/artifacts/opt/jboss/container/java/run/run-env.sh
+++ b/modules/run/artifacts/opt/jboss/container/java/run/run-env.sh
@@ -1,6 +1,0 @@
-#!/bin/sh
-
-# Default the application dir to the S2I deployment dir
-if [ -z "$JAVA_APP_DIR" ]
-then JAVA_APP_DIR=/deployments
-fi

--- a/modules/run/artifacts/opt/jboss/container/java/run/run-java.sh
+++ b/modules/run/artifacts/opt/jboss/container/java/run/run-java.sh
@@ -4,8 +4,8 @@
 set -eo pipefail
 
 #These are defined explicitly here to avoid defining them in templates/jlink/Dockerfile
-export JBOSS_CONTAINER_UTIL_LOGGING_MODULE="/opt/jboss/container/util/logging"
-export JBOSS_CONTAINER_JAVA_RUN_MODULE="/opt/jboss/container/java/run"
+export JBOSS_CONTAINER_UTIL_LOGGING_MODULE="${JBOSS_CONTAINER_UTIL_LOGGING_MODULE-/opt/jboss/container/util/logging}"
+export JBOSS_CONTAINER_JAVA_RUN_MODULE="${JBOSS_CONTAINER_JAVA_RUN_MODULE-/opt/jboss/container/java/run}"
 
 #This is moved here after deleting run-env.sh
 # Default the application dir to the S2I deployment dir

--- a/modules/run/artifacts/opt/jboss/container/java/run/run-java.sh
+++ b/modules/run/artifacts/opt/jboss/container/java/run/run-java.sh
@@ -3,6 +3,13 @@
 # Fail on a single failed command
 set -eo pipefail
 
+#These are defined explicitly here to avoid defining them in templates/jlink/Dockerfile
+export JBOSS_CONTAINER_UTIL_LOGGING_MODULE="/opt/jboss/container/util/logging"
+export JBOSS_CONTAINER_JAVA_RUN_MODULE="/opt/jboss/container/java/run"
+
+#This is moved here after deleting run-env.sh
+export JAVA_APP_DIR=/deployments
+
 source "$JBOSS_CONTAINER_UTIL_LOGGING_MODULE/logging.sh"
 
 # ==========================================================
@@ -96,13 +103,8 @@ load_env() {
   if [ -z "${JAVA_APP_DIR}" ]; then
     # XXX: is this correct?  This is defaulted above to /deployments.  Should we
     # define a default to the old /opt/java-run?
-    JAVA_APP_DIR="${JBOSS_CONTAINER_JAVA_RUN_MODULE}"
-  else
-    if [ -f "${JAVA_APP_DIR}/${run_env_sh}" ]; then
-      source "${JAVA_APP_DIR}/${run_env_sh}"
-    fi
+    export JAVA_APP_DIR="${JBOSS_CONTAINER_JAVA_RUN_MODULE}"
   fi
-  export JAVA_APP_DIR
 
   # JAVA_LIB_DIR defaults to JAVA_APP_DIR
   export JAVA_LIB_DIR="${JAVA_LIB_DIR:-${JAVA_APP_DIR}}"

--- a/modules/run/artifacts/opt/jboss/container/java/run/run-java.sh
+++ b/modules/run/artifacts/opt/jboss/container/java/run/run-java.sh
@@ -3,14 +3,12 @@
 # Fail on a single failed command
 set -eo pipefail
 
-#These are defined explicitly here to avoid defining them in templates/jlink/Dockerfile
 export JBOSS_CONTAINER_UTIL_LOGGING_MODULE="${JBOSS_CONTAINER_UTIL_LOGGING_MODULE-/opt/jboss/container/util/logging}"
 export JBOSS_CONTAINER_JAVA_RUN_MODULE="${JBOSS_CONTAINER_JAVA_RUN_MODULE-/opt/jboss/container/java/run}"
 
-#This is moved here after deleting run-env.sh
 # Default the application dir to the S2I deployment dir
 if [ -z "$JAVA_APP_DIR" ]
-then JAVA_APP_DIR=/deployments
+  then JAVA_APP_DIR=/deployments
 fi
 
 source "$JBOSS_CONTAINER_UTIL_LOGGING_MODULE/logging.sh"

--- a/modules/run/artifacts/opt/jboss/container/java/run/run-java.sh
+++ b/modules/run/artifacts/opt/jboss/container/java/run/run-java.sh
@@ -8,7 +8,10 @@ export JBOSS_CONTAINER_UTIL_LOGGING_MODULE="/opt/jboss/container/util/logging"
 export JBOSS_CONTAINER_JAVA_RUN_MODULE="/opt/jboss/container/java/run"
 
 #This is moved here after deleting run-env.sh
-export JAVA_APP_DIR=/deployments
+# Default the application dir to the S2I deployment dir
+if [ -z "$JAVA_APP_DIR" ]
+then JAVA_APP_DIR=/deployments
+fi
 
 source "$JBOSS_CONTAINER_UTIL_LOGGING_MODULE/logging.sh"
 
@@ -100,11 +103,11 @@ load_env() {
 
   # Check also $JAVA_APP_DIR. Overrides other defaults
   # It's valid to set the app dir in the default script
-  if [ -z "${JAVA_APP_DIR}" ]; then
-    # XXX: is this correct?  This is defaulted above to /deployments.  Should we
-    # define a default to the old /opt/java-run?
-    export JAVA_APP_DIR="${JBOSS_CONTAINER_JAVA_RUN_MODULE}"
+  if [ -f "${JAVA_APP_DIR}/${run_env_sh}" ]; then
+      source "${JAVA_APP_DIR}/${run_env_sh}"
   fi
+
+  export JAVA_APP_DIR
 
   # JAVA_LIB_DIR defaults to JAVA_APP_DIR
   export JAVA_LIB_DIR="${JAVA_LIB_DIR:-${JAVA_APP_DIR}}"


### PR DESCRIPTION
<https://issues.redhat.com/browse/OPENJDK-2915>

This is some clean-up work that was needed prior to implementing the
jlink integration scripts.

The file `run-env.sh` is shipped alongside `run-java.sh` in the containers.
All it did was to set a default value for JAVA_APP_DIR, if it was not
already set.

There is a related feature of the run script: if a run-env.sh script
is present within the application dir (JAVA_APP_DIR), then it is
evaluated. Therefore an application source can extend the run behaviour
with extra shell script.

This clean-up removes the `run-env.sh` that is shipped alongside `run-java.sh`,
moving what it directly into `run-java.sh` instead. Via separate PRs, we have
added unit test coverage for the behaviours listed above:

1. [Ensure that run-env.sh placed in the JAVA_APP_DIR is sourced in the run script before launching java](https://github.com/jboss-container-images/openjdk/blob/ubi9/modules/maven/s2i/tests/features/java_s2i.feature#L178)
2. [test coverage for setting values of JAVA_APP_DIR](https://github.com/jboss-container-images/openjdk/blob/ubi9/modules/jvm/tests/features/runtime.feature)

----

This is a port of https://github.com/jboss-container-images/openjdk/pull/397 for the ubi9 branch. I hope to merge this (and another piece) prior to looking at `jlink-dev`, to reduce the size of the jlink delta and make review easier.

This is @jhuttana 's work.