### PR TITLE
[OPENJDK-2824] assemble: binary: Don't set times on directories (UBI8)

### DIFF
--- a/modules/s2i/bash/artifacts/opt/jboss/container/java/s2i/maven-s2i-overrides
+++ b/modules/s2i/bash/artifacts/opt/jboss/container/java/s2i/maven-s2i-overrides
@@ -28,7 +28,12 @@ function maven_s2i_custom_binary_build() {
     binary_dir="${S2I_SOURCE_DIR}"
   fi
   log_info "Copying binaries from ${binary_dir} to ${S2I_TARGET_DEPLOYMENTS_DIR} ..."
-  rsync --archive --out-format='%n' "${binary_dir}"/ "${S2I_TARGET_DEPLOYMENTS_DIR}"
+
+  ( # OPENJDK-2850: use glob (dotglob to match hidden files) to stop rsync altering
+    # timestamps of S2I_TARGET_DEPLOYMENTS_DIR. Don't alter parent shell's dotglob.
+    shopt -s dotglob
+    rsync --archive --out-format='%n' "${binary_dir}"/* "${S2I_TARGET_DEPLOYMENTS_DIR}"
+  )
 }
 
 function maven_s2i_deploy_artifacts_override() {

--- a/modules/s2i/core/api/tests/features/s2i-core.feature
+++ b/modules/s2i/core/api/tests/features/s2i-core.feature
@@ -7,3 +7,14 @@ Feature: Openshift S2I tests
   Scenario: run an s2i build and check that /tmp/src has been removed afterwards
     Given s2i build https://github.com/jboss-container-images/openjdk-test-applications from spring-boot-sample-simple
     Then run stat /tmp/src in container and immediately check its output does not contain File:
+
+  # OPENJDK-2824 - ensure binary-only s2i doesn't try to change timestamps of
+  # S2I_TARGET_DEPLOYMENTS_DIR. Use /var/tmp as a directory where attempting to
+  # will fail. This simulates the s2i process running as a random UID, which can't
+  # change timestamps on the default directory, /deployments.
+  Scenario: Ensure binary-only build doesn't fail trying to set timestamp of S2I_TARGET_DEPLOYMENTS_DIR (OPENJDK-2850)
+      Given s2i build https://github.com/jboss-container-images/openjdk-test-applications from OPENJDK-2408-bin-custom-s2i-assemble with env
+       | variable                   | value |
+       | S2I_TARGET_DEPLOYMENTS_DIR | /var/tmp  |
+     Then s2i build log should not contain rsync: [generator] failed to set permissions on "/var/tmp/.": Operation not permitted
+     And  run stat /var/tmp/spring-boot-sample-simple-1.5.0.BUILD-SNAPSHOT.jar in container and check its output for Access:


### PR DESCRIPTION
If the S2I build runs as a user other than 185 (such as s2i's default
of 1001), attempting to set the timestamp of /deployments will fail,
causing the build to fail.

https://issues.redhat.com/browse/OPENJDK-2824

See also
https://issues.redhat.com/browse/OPENJDK-2408

Backport of #470 