### PR TITLE
auto-generated Docs:  add ToC, re-order sections

### DIFF
--- a/docs/README.adoc
+++ b/docs/README.adoc
@@ -1,4 +1,5 @@
-# Red Hat UBI OpenJDK container images
+= Red Hat UBI OpenJDK container images
+:toc: right
 
 This is auto-generated documentation for the
 link:https://www.redhat.com/en/blog/introducing-red-hat-universal-base-image[Red

--- a/gendocs.sh
+++ b/gendocs.sh
@@ -68,16 +68,16 @@ cp ./gendocs.py "$workdir/gendocs.py"
 cp ./docs/README.adoc "$workdir/README.adoc"
 
 # documentation for development branches
-addToIndex "\n== Development branches ==\n"
+addToIndex "\n== Development branches\n"
 for branch in ubi8 ubi9; do
-    addToIndex "\n=== $branch ===\n"
+    addToIndex "\n=== $branch\n"
     handleRef "$branch" "$branch"
 done
 
 # documentation for tagged releases
-addToIndex "\n== Released images =="
+addToIndex "\n== Released images"
 for tag in $(git tag -l 'ubi?-openjdk-containers*' | sort -r); do
-    addToIndex "\n=== $tag ===\n"
+    addToIndex "\n=== $tag\n"
     handleRef "$tag"
 done
 

--- a/gendocs.sh
+++ b/gendocs.sh
@@ -67,18 +67,16 @@ workdir="$(mktemp -td gendocs.XXXXXX)"
 cp ./gendocs.py "$workdir/gendocs.py"
 cp ./docs/README.adoc "$workdir/README.adoc"
 
-# documentation for development branches
-addToIndex "\n== Development branches\n"
-for branch in ubi8 ubi9; do
-    addToIndex "\n=== $branch\n"
-    handleRef "$branch" "$branch"
-done
-
-# documentation for tagged releases
-addToIndex "\n== Released images"
-for tag in $(git tag -l 'ubi?-openjdk-containers*' | sort -r); do
-    addToIndex "\n=== $tag\n"
-    handleRef "$tag"
+for ubi in ubi9 ubi8; do
+    UBI=${ubi^^}
+    addToIndex "\n== $UBI\n"
+    addToIndex "\n=== development\n"
+    handleRef "$ubi"
+    for tag in $(git tag -l "${ubi}-openjdk-containers*" | sort -r); do
+        version=${tag/${ubi}-openjdk-containers-/}
+        addToIndex "\n=== $version\n"
+        handleRef "$tag"
+    done
 done
 
 asciidoctor "$workdir/README.adoc" -o docs/index.html


### PR DESCRIPTION
This re-orders the auto-generated documentation somewhat. It adds a Table of Contents to the index page, and adjusts the order and labelling of the sections, so that the top-most headers are the UBI versions in reverse order (UBI9 first); the first second-level header is development, followed by the versions (abridged to e.g. `1.19`) in reverse numerical order.

E.g.

    UBI9
        development
        1.18
        1.17
        1.16
        1.15
        1.13
    UBI8
        development
        1.19
        1.18
        1.17
        1.16
        1.15
        1.14

 I think this improves legibility of https://jboss-container-images.github.io/openjdk/
