### PR TITLE
[Openjdk-2969] runtime images and JAVA_ARGS, JAVA_OPTIONS handling (ubi8)

### DIFF
--- a/modules/maven/default/backward_compatibility.sh
+++ b/modules/maven/default/backward_compatibility.sh
@@ -4,7 +4,5 @@ set -e
 
 # For backward compatibility
 mkdir -p /usr/local/s2i
-ln -s /opt/jboss/container/maven/default/scl-enable-maven /usr/local/s2i/scl-enable-maven
-chown -h jboss:root /usr/local/s2i/scl-enable-maven
 ln -s /opt/jboss/container/maven/default/maven.sh /usr/local/s2i/common.sh
 chown -h jboss:root /usr/local/s2i/common.sh

--- a/modules/maven/s2i/artifacts/opt/jboss/container/maven/s2i/maven-s2i
+++ b/modules/maven/s2i/artifacts/opt/jboss/container/maven/s2i/maven-s2i
@@ -36,10 +36,6 @@ function maven_s2i_init() {
   # Location of archived local Maven repository.  Used with incremental builds.
   _MAVEN_S2I_ARCHIVED_REPO="${S2I_ARTIFACTS_DIR}/m2"
 
-  # include maven scripts
-  if test -r "${JBOSS_CONTAINER_MAVEN_DEFAULT_MODULE}"/scl-enable-maven; then
-	  source "${JBOSS_CONTAINER_MAVEN_DEFAULT_MODULE}"/scl-enable-maven
-  fi
   source "${JBOSS_CONTAINER_MAVEN_DEFAULT_MODULE}"/maven.sh
 
   # Overrides for use with maven s2i

--- a/modules/run/artifacts/opt/jboss/container/java/run/run-java.sh
+++ b/modules/run/artifacts/opt/jboss/container/java/run/run-java.sh
@@ -227,6 +227,16 @@ function configure_passwd() {
   fi
 }
 
+handle_java_options() {
+  # JAVA_OPTIONS is a deprecated name for JAVA_OPTS. It is not supported
+  # in the images from UBI9 onwards.
+  if [ -z "${JAVA_OPTS+isunset}" ] && [ -n "${JAVA_OPTIONS+isset}" ]; then
+    JAVA_OPTS="$JAVA_OPTIONS"
+  fi
+  export JAVA_OPTS
+  export JAVA_OPTIONS="$JAVA_OPTS"
+}
+
 # Start JVM
 startup() {
   # Initialize environment
@@ -251,4 +261,13 @@ startup() {
 
 # =============================================================================
 # Fire up
-startup $*
+
+handle_java_options
+
+if [ -f "${S2I_TARGET_DEPLOYMENTS_DIR}/bin/run.sh" ]; then
+    echo "Starting the application using the bundled ${S2I_TARGET_DEPLOYMENTS_DIR}/bin/run.sh ..."
+    exec ${DEPLOYMENTS_DIR}/bin/run.sh $* ${JAVA_ARGS}
+else
+    echo "Starting the Java application using ${JBOSS_CONTAINER_JAVA_RUN_MODULE}/run-java.sh $*..."
+    startup $* ${JAVA_ARGS}
+fi

--- a/modules/run/tests/features/java.runtime.feature
+++ b/modules/run/tests/features/java.runtime.feature
@@ -45,6 +45,14 @@ Feature: Openshift OpenJDK Runtime tests
        | JAVA_ARGS   | Hello from CTF test |
     Then container log should contain /deployments/undertow-servlet.jar Hello from CTF test
 
+  @ubi8
+  # alternative to previous test which can run against runtimes
+  Scenario: OPENJDK-2968 Ensure JAVA_ARGS is passed to the running Java application
+    Given container is started with env
+       | variable    | value                 |
+       | JAVA_ARGS   | Hello from Cekit test |
+    Then container log should match regex ^INFO exec -a "java" java.*Hello from Cekit test$
+
   Scenario: Ensure diagnostic options work correctly
     Given s2i build https://github.com/jboss-container-images/openjdk-test-applications from undertow-servlet
        | variable         | value               |

--- a/modules/run/tests/features/options.feature
+++ b/modules/run/tests/features/options.feature
@@ -1,12 +1,9 @@
-@ubi8/openjdk-8
-@ubi8/openjdk-11
-@ubi8/openjdk-17
-@ubi8/openjdk-21
-Feature: OpenJDK JAVA s2i Runtime tests
+@ubi8
+Feature: OpenJDK run script option handling
 
   Scenario: JAVA_OPTIONS sets JAVA_OPTS and overrides defaults (OPENJDK-2009)
     Given container is started with env
     | variable     | value          |
     | JAVA_OPTIONS | --show-version |
     Then container log should not contain -XX:MaxRAMPercentage
-    And  container log should contain --show-version
+    And  container log should match regex ^INFO exec.*java --show-version

--- a/modules/s2i/bash/artifacts/usr/local/s2i/run
+++ b/modules/s2i/bash/artifacts/usr/local/s2i/run
@@ -11,12 +11,6 @@ source "${JBOSS_CONTAINER_JAVA_S2I_MODULE}/s2i-core-hooks"
 # Global S2I variable setup
 s2i_core_env_init
 
-# CLOUD-3387: RHEL7-based images enable maven in the runtime environment. This
-# is not needed for RHEL8-based images.
-if test -r "${JBOSS_CONTAINER_MAVEN_DEFAULT_MODULE}/scl-enable-maven"; then
-    source "${JBOSS_CONTAINER_MAVEN_DEFAULT_MODULE}/scl-enable-maven"
-fi
-
 if [ -z "${JAVA_OPTS+isunset}" ] && [ -n "${JAVA_OPTIONS+isset}" ]; then
     JAVA_OPTS="$JAVA_OPTIONS"
 fi

--- a/modules/s2i/bash/artifacts/usr/local/s2i/run
+++ b/modules/s2i/bash/artifacts/usr/local/s2i/run
@@ -11,10 +11,6 @@ source "${JBOSS_CONTAINER_JAVA_S2I_MODULE}/s2i-core-hooks"
 # Global S2I variable setup
 s2i_core_env_init
 
-if [ -z "${JAVA_OPTS+isunset}" ] && [ -n "${JAVA_OPTIONS+isset}" ]; then
-    JAVA_OPTS="$JAVA_OPTIONS"
-fi
-
 if [ -f "${JBOSS_CONTAINER_JOLOKIA_MODULE}/jolokia-opts" ]; then
     # Always include jolokia-opts, which can be empty if switched off via env
     S2I_RUN_OPTS="${S2I_RUN_OPTS} $(${JBOSS_CONTAINER_JOLOKIA_MODULE}/jolokia-opts)"
@@ -24,13 +20,10 @@ if [ -f "${JBOSS_CONTAINER_PROMETHEUS_MODULE}/prometheus-opts" ]; then
 fi
 
 export S2I_RUN_OPTS
-export JAVA_OPTS
-export JAVA_OPTIONS="$JAVA_OPTS"
 
-if [ -f "${S2I_TARGET_DEPLOYMENTS_DIR}/bin/run.sh" ]; then
-    echo "Starting the application using the bundled ${S2I_TARGET_DEPLOYMENTS_DIR}/bin/run.sh ..."
-    exec ${DEPLOYMENTS_DIR}/bin/run.sh $args ${JAVA_ARGS}
-else
-    echo "Starting the Java application using ${JBOSS_CONTAINER_JAVA_RUN_MODULE}/run-java.sh $args..."
-    exec "${JBOSS_CONTAINER_JAVA_RUN_MODULE}/run-java.sh" $args ${JAVA_ARGS}
-fi
+# XXX this is needed to support a user-provided alternative run script but we
+# should probably export all relevant S2I variables, possibly by moving the
+# above `source` statements into run-java.sh
+export S2I_TARGET_DEPLOYMENTS_DIR
+
+exec "${JBOSS_CONTAINER_JAVA_RUN_MODULE}/run-java.sh" $args

--- a/modules/s2i/bash/artifacts/usr/local/s2i/s2i-setup
+++ b/modules/s2i/bash/artifacts/usr/local/s2i/s2i-setup
@@ -9,5 +9,3 @@ source "${JBOSS_CONTAINER_JAVA_S2I_MODULE}/s2i-core-hooks"
 log_warning "s2i-setup script has been deprecated and will be removed in a future release."
 
 s2i_core_init
-
-source "${JBOSS_CONTAINER_MAVEN_DEFAULT_MODULE}/scl-enable-maven"

--- a/modules/s2i/bash/tests/features/run.feature
+++ b/modules/s2i/bash/tests/features/run.feature
@@ -1,0 +1,15 @@
+@ubi8/openjdk-8
+@ubi8/openjdk-11
+@ubi8/openjdk-17
+@ubi8/openjdk-21
+Feature: S2I run script tests
+ 
+  Scenario: OPENJDK-2968 application run script is invoked instead of image run script
+      Given s2i build https://github.com/jmtd/openjdk-test-applications from OPENJDK-2968-bin-custom-run with env using OPENJDK-2968-custom-run
+       | variable     | value      |
+       | JAVA_OPTIONS | deprecated |
+       | JAVA_ARGS    | percolated |
+      Then container log should not contain Starting the Java application using /opt/jboss/container/java/run/run-java.sh
+      And  container log should contain hello world
+      And  container log should contain JAVA_OPTS=deprecated
+      And  container log should contain args=percolated


### PR DESCRIPTION
Some of the run logic is implemented in bin/s2i which means it is not applied in the runtime images.

https://issues.redhat.com/browse/OPENJDK-2969