### PR TITLE
[OPENJDK-3009] mask passwords from java arguments in logs (UBI8)

### DIFF
--- a/modules/run/artifacts/opt/jboss/container/java/run/run-java.sh
+++ b/modules/run/artifacts/opt/jboss/container/java/run/run-java.sh
@@ -264,9 +264,9 @@ startup() {
 
   local procname="${JAVA_APP_NAME-java}"
 
-  local masked_args=$(mask_passwords "${args}")
+  local masked_opts=$(mask_passwords "$(get_java_options)")
 
-  log_info "exec -a \"${procname}\" java $(get_java_options) -cp \"$(get_classpath)\" ${masked_args} $*"
+  log_info "exec -a \"${procname}\" java ${masked_opts} -cp \"$(get_classpath)\" ${args} $*"
   log_info "running in $PWD"
   exec -a "${procname}" java $(get_java_options) -cp "$(get_classpath)" ${args} $*
 }

--- a/modules/run/artifacts/opt/jboss/container/java/run/run-java.sh
+++ b/modules/run/artifacts/opt/jboss/container/java/run/run-java.sh
@@ -225,6 +225,26 @@ function configure_passwd() {
   if [ -w "$HOME/passwd" ]; then
     sed "/^jboss/s/[^:]*/$(id -u)/3" /etc/passwd > "$HOME/passwd"
   fi
+
+# Mask secrets before printing
+mask_passwords() {
+    local content="$1"
+    local result=""
+
+    IFS=' ' read -r -a key_value_pairs <<< "$content"
+
+    for pair in "${key_value_pairs[@]}"; do
+        key=$(echo "$pair" | cut -d '=' -f 1)
+        value=$(echo "$pair" | cut -d '=' -f 2-)
+
+        if [[ $key =~ [Pp][Aa][Ss][Ss][Ww][Oo][Rr][Dd] ]]; then
+            result+="$key=***** "
+        else
+            result+="$pair "
+        fi
+    done
+
+    echo "${result% }"
 }
 
 # Start JVM
@@ -242,9 +262,11 @@ startup() {
      args="-jar ${JAVA_APP_JAR}"
   fi
 
-  procname="${JAVA_APP_NAME-java}"
+  local procname="${JAVA_APP_NAME-java}"
 
-  log_info "exec -a \"${procname}\" java $(get_java_options) -cp \"$(get_classpath)\" ${args} $*"
+  local masked_args=$(mask_passwords "${args}")
+
+  log_info "exec -a \"${procname}\" java $(get_java_options) -cp \"$(get_classpath)\" ${masked_args} $*"
   log_info "running in $PWD"
   exec -a "${procname}" java $(get_java_options) -cp "$(get_classpath)" ${args} $*
 }

--- a/modules/run/tests/features/run.feature
+++ b/modules/run/tests/features/run.feature
@@ -1,0 +1,8 @@
+@ubi8
+Feature: OpenJDK run script tests
+  Scenario: OPENJDK-3009: Ensure command-line options containing 'password' are masked in logs
+    Given container is started with env
+      | variable         | value                                              |
+      | JAVA_OPTS_APPEND | -Djavax.net.ssl.trustStorePassword=sensitiveString |
+    Then container log should not contain sensitiveString
+


### PR DESCRIPTION
https://issues.redhat.com/browse/OPENJDK-3009

Backport of #466 