### PR TITLE
[Openjdk 3029] no singleton jdk required for openjdk-21

### DIFF
--- a/ubi8-openjdk-21.yaml
+++ b/ubi8-openjdk-21.yaml
@@ -54,7 +54,6 @@ modules:
     version: "3.8.17"
   - name: jboss.container.util.tzdata
   - name: jboss.container.java.s2i.bash
-  - name: jboss.container.java.singleton-jdk
 
 help:
   add: true


### PR DESCRIPTION
This used to be required to remove the system JDK, as pulled in by Maven, prior to the introduction of the maven-openjdk21 package.

Test coverage exists in modules/jdk/tests/features/openjdk.feature

https://issues.redhat.com/browse/OPENJDK-3029