### PR TITLE
[OPENJDK-3009] syntax fix for run-java.sh

### DIFF
--- a/modules/run/artifacts/opt/jboss/container/java/run/run-java.sh
+++ b/modules/run/artifacts/opt/jboss/container/java/run/run-java.sh
@@ -225,6 +225,7 @@ function configure_passwd() {
   if [ -w "$HOME/passwd" ]; then
     sed "/^jboss/s/[^:]*/$(id -u)/3" /etc/passwd > "$HOME/passwd"
   fi
+}
 
 # Mask secrets before printing
 mask_passwords() {


### PR DESCRIPTION
The backporting of mask_passwords to UBI8 had a syntax error, we borrowed the closing parenthesis from mask_passwords(), breaking the run-java.sh script.

https://issues.redhat.com/browse/OPENJDK-3009

I think I introduced this when undoing my attempt to remove `configure_passwd` first time around :(