### PR TITLE
[Openjdk 3029] no singleton jdk - maven module edition

### DIFF
--- a/modules/maven/21/configure.sh
+++ b/modules/maven/21/configure.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+set -e
+
+# This file is shipped by a Maven package and sets JAVA_HOME to
+# an OpenJDK-specific path. This causes problems for OpenJ9 containers
+# as the path is not correct for them.  We don't need this in any of
+# the containers because we set JAVA_HOME in the container metadata.
+# Blank the file rather than removing it, to avoid a warning message
+# from /usr/bin/mvn.
+if [ -f /etc/java/maven.conf ]; then
+  :> /etc/java/maven.conf
+fi

--- a/modules/maven/21/module.yaml
+++ b/modules/maven/21/module.yaml
@@ -1,0 +1,25 @@
+schema_version: 1
+name: jboss.container.maven
+version: '3.8.21'
+description: Provides Maven v3.8 capabilities to an image.
+
+labels:
+- name: io.fabric8.s2i.version.maven
+  value: "3.8"
+
+envs:
+- name: JBOSS_CONTAINER_MAVEN_38_MODULE
+  value: /opt/jboss/container/maven/38/
+- name: MAVEN_VERSION
+  value: '3.8'
+
+modules:
+  install:
+  - name: jboss.container.maven.module
+
+packages:
+  install:
+  - maven-openjdk21
+
+execute:
+- script: configure.sh

--- a/ubi8-openjdk-21.yaml
+++ b/ubi8-openjdk-21.yaml
@@ -51,7 +51,7 @@ modules:
   - name: jboss.container.openjdk.jdk
     version: "21"
   - name: jboss.container.maven
-    version: "3.8.17"
+    version: "3.8.21"
   - name: jboss.container.util.tzdata
   - name: jboss.container.java.s2i.bash
 


### PR DESCRIPTION
Removing singleton-jdk from the JDK21 builder image is not sufficient, we also need to install `maven-openjdk21` instead of `maven-openjdk17`. Thanks @sefroberg for catching this.

Test coverage: the JDK21 tests in `modules/jdk/tests/features/openjdk.feature` catch this (pass for this PR, fail for branch ubi8)

https://issues.redhat.com/browse/OPENJDK-3029