### PR TITLE
Openjdk 3033 singleton ubi9 m21

### DIFF
--- a/modules/maven/21/configure.sh
+++ b/modules/maven/21/configure.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+set -e
+
+# This file is shipped by a Maven package and sets JAVA_HOME to
+# an OpenJDK-specific path. This causes problems for OpenJ9 containers
+# as the path is not correct for them.  We don't need this in any of
+# the containers because we set JAVA_HOME in the container metadata.
+# Blank the file rather than removing it, to avoid a warning message
+# from /usr/bin/mvn.
+if [ -f /etc/java/maven.conf ]; then
+  :> /etc/java/maven.conf
+fi

--- a/modules/maven/21/module.yaml
+++ b/modules/maven/21/module.yaml
@@ -1,0 +1,21 @@
+schema_version: 1
+name: jboss.container.maven
+version: '3.8.21'
+description: Provides Maven v3.8 capabilities to an image.
+
+envs:
+- name: JBOSS_CONTAINER_MAVEN_38_MODULE
+  value: /opt/jboss/container/maven/38/
+- name: MAVEN_VERSION
+  value: '3.8'
+
+modules:
+  install:
+  - name: jboss.container.maven.module
+
+packages:
+  install:
+  - maven-openjdk21
+
+execute:
+- script: configure.sh

--- a/ubi9-openjdk-21.yaml
+++ b/ubi9-openjdk-21.yaml
@@ -54,7 +54,6 @@ modules:
     version: "3.8.17"
   - name: jboss.container.java.s2i.bash
   - name: jboss.container.util.tzdata
-  - name: jboss.container.java.singleton-jdk
 
 help:
   add: true

--- a/ubi9-openjdk-21.yaml
+++ b/ubi9-openjdk-21.yaml
@@ -51,7 +51,8 @@ modules:
   - name: jboss.container.openjdk.jdk
     version: "21"
   - name: jboss.container.maven
-    version: "3.8.17"
+    version: "3.8.21"
+  - name: jboss.container.util.tzdata
   - name: jboss.container.java.s2i.bash
   - name: jboss.container.util.tzdata
 


### PR DESCRIPTION
https://issues.redhat.com/browse/OPENJDK-3029

use maven-openjdk21 for jdk21 builder image and stop using singleton-jdk module to clean up JDKs.