### PR TITLE
Correct the link to the Cekit instllation docs

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -24,7 +24,7 @@ Older RHEL7 and RHEL8-based image sources are in the `rhel7` and `ubi8` branches
 
 ## How to build the images
 
-You need to https://cekit.readthedocs.io/en/develop/installation.html[install Cekit] to build these images.
+You need to https://docs.cekit.io/en/latest/handbook/installation/index.html[install Cekit] to build these images.
 
 These sources are prepared and tested for Cekit 4.1.1.
 


### PR DESCRIPTION
The link in the README.adoc for 'intall Cekit' is out of date and returns a 404. This PR corrects the link url.

Please make sure your PR meets the following requirements:

- [ ] A JIRA issue must exist in the OPENJDK project at issues.redhat.com
- [ ] Pull Request title should be prefixed with the JIRA issue: `[OPENJDK-XYZ] Subject`
- [ ] Pull Request contains hyperlink to the JIRA issue
- [ ] Pull Request contains description of the issue
- [ ] Pull Request does not include fixes for issues other than the main ticket
- [ ] Attached commits represent units of work and are properly formatted
- [x] You have read and agreed to the Developer Certificate of Origin (DCO) (see `CONTRIBUTING.md`)
- [ ] Every commit contains `Signed-off-by: Your Name <yourname@example.com>` - use `git commit -s`
