### PR TITLE
[OPENJDK-2903] [jlink] Ensure created objects are uniquely named

### DIFF
--- a/templates/jlink/README.md
+++ b/templates/jlink/README.md
@@ -56,12 +56,14 @@ Some suitable test values for the parameters are
  * APP_URI: https://github.com/jboss-container-images/openjdk-test-applications
  * REF: master
  * CONTEXT_DIR: quarkus-quickstarts/getting-started-3.9.2-uberjar
+ * APPNAME: quarkus-quickstart
 
         oc process \
             -p JDK_VERSION=17 \
             -p APP_URI=https://github.com/jboss-container-images/openjdk-test-applications \
             -p REF=master \
             -p CONTEXT_DIR=quarkus-quickstarts/getting-started-3.9.2-uberjar \
+            -p APPNAME=quarkus-quickstart \
             templates/jlink-app-template \
             | oc create -f -
 

--- a/templates/jlink/jlinked-app.yaml
+++ b/templates/jlink/jlinked-app.yaml
@@ -199,7 +199,7 @@ objects:
       dockerStrategy:
         from:
           kind: ImageStreamTag
-          name: ubimicro:latest
+          name: ${APPNAME}-ubimicro:latest
     output:
       to:
         kind: ImageStreamTag
@@ -215,4 +215,4 @@ objects:
         imageChange:
           from:
             kind: ImageStreamTag
-            name: ubimicro:latest  # ImageStreamTag for registry.access.redhat.com/ubi9/ubi-micro
+            name: ${APPNAME}-ubimicro:latest  # ImageStreamTag for registry.access.redhat.com/ubi9/ubi-micro

--- a/templates/jlink/jlinked-app.yaml
+++ b/templates/jlink/jlinked-app.yaml
@@ -12,6 +12,9 @@ parameters:
   name: JDK_VERSION
   value: "11"
   required: true
+- description: A name for the application used to ensure created resources are uniquely named
+  name: APPNAME
+  required: true
 - description: Application to run the jlink workflow on
   name: APP_URI
   required: true
@@ -35,7 +38,7 @@ objects:
 - apiVersion: image.openshift.io/v1
   kind: ImageStream
   metadata:
-    name: ubi9-openjdk-${JDK_VERSION}-jlink
+    name: ${APPNAME}-ubi9-openjdk-${JDK_VERSION}-jlink
   spec:
     lookupPolicy:
       local: false
@@ -44,9 +47,9 @@ objects:
 - apiVersion: build.openshift.io/v1
   kind: BuildConfig
   metadata: 
-    name: jlink-builder-jdk-${JDK_VERSION}
+    name: ${APPNAME}-jlink-builder-jdk-${JDK_VERSION}
     labels:
-      app: jlink-builder-jdk-${JDK_VERSION}
+      app: ${APPNAME}-jlink-builder-jdk-${JDK_VERSION}
   spec:
     source:
       dockerfile: |
@@ -72,7 +75,7 @@ objects:
     output:
       to:
         kind: ImageStreamTag
-        name: ubi9-openjdk-${JDK_VERSION}-jlink:latest
+        name: ${APPNAME}-ubi9-openjdk-${JDK_VERSION}-jlink:latest
     triggers:
       - type: ConfigChange
       - type: ImageChange
@@ -85,7 +88,7 @@ objects:
 - apiVersion: image.openshift.io/v1
   kind: ImageStream
   metadata:
-    name: intermediate
+    name: ${APPNAME}-intermediate
   spec:
     lookupPolicy:
       local: false
@@ -94,9 +97,9 @@ objects:
 - apiVersion: build.openshift.io/v1
   kind: BuildConfig
   metadata:
-    name: jlink-s2i-jdk-${JDK_VERSION}
+    name: ${APPNAME}-jlink-s2i-jdk-${JDK_VERSION}
     labels:
-      app: jlink-s2i-jdk-${JDK_VERSION}
+      app: ${APPNAME}-jlink-s2i-jdk-${JDK_VERSION}
   spec:
     source:
       type: Git
@@ -108,7 +111,7 @@ objects:
       sourceStrategy:
         from:
           kind: ImageStreamTag
-          name: ubi9-openjdk-${JDK_VERSION}-jlink:latest # Output Imagestream from stage-1
+          name: ${APPNAME}-ubi9-openjdk-${JDK_VERSION}-jlink:latest # Output Imagestream from stage-1
           pullPolicy: Always
         env:
           - name: S2I_ENABLE_JLINK
@@ -118,14 +121,14 @@ objects:
     output:
       to:
         kind: ImageStreamTag
-        name: intermediate:latest
+        name: ${APPNAME}-intermediate:latest
     triggers:
       - type: ConfigChange
       - type: ImageChange
         imageChange:
           from:
             kind: ImageStreamTag
-            name: ubi9-openjdk-${JDK_VERSION}-jlink:latest  # Output of stage-1 which serves as input to stage-2
+            name: ${APPNAME}-ubi9-openjdk-${JDK_VERSION}-jlink:latest  # Output of stage-1 which serves as input to stage-2
       - type: GitHub
         github:
           secret: ${GITHUB_WEBHOOK_SECRET}
@@ -135,7 +138,7 @@ objects:
 - apiVersion: image.openshift.io/v1
   kind: ImageStream
   metadata:
-    name: ubimicro
+    name: ${APPNAME}-ubimicro
   spec:
     lookupPolicy:
       local: true
@@ -151,7 +154,7 @@ objects:
 - apiVersion: image.openshift.io/v1
   kind: ImageStream
   metadata:
-    name: lightweight-image
+    name: ${APPNAME}-lightweight-image
   spec:
     lookupPolicy:
       local: false
@@ -160,13 +163,13 @@ objects:
 - apiVersion: build.openshift.io/v1
   kind: BuildConfig
   metadata: 
-    name: multistage-buildconfig
+    name: ${APPNAME}-multistage-buildconfig
   spec:
     source:
       images:
       - from:
           kind: ImageStreamTag
-          name: intermediate:latest
+          name: ${APPNAME}-intermediate:latest
         paths:
         - sourcePath:     /mnt/jrootfs
           destinationDir: jrootfs
@@ -200,14 +203,14 @@ objects:
     output:
       to:
         kind: ImageStreamTag
-        name: lightweight-image:latest  # Tag for the final output image
+        name: ${APPNAME}-lightweight-image:latest  # Tag for the final output image
     triggers:
       - type: ConfigChange
       - type: ImageChange
         imageChange:
           from:
             kind: ImageStreamTag
-            name: intermediate:latest  # output of stage-2
+            name: ${APPNAME}-intermediate:latest  # output of stage-2
       - type: ImageChange
         imageChange:
           from:


### PR DESCRIPTION
Hi,

This PR fixes OPENJDK-2903, adding a mandatory template parameter (APPNAME) that ensures all created resources are uniquely named.

https://issues.redhat.com/browse/OPENJDK-2903
