### PR TITLE
[OPENJDK-3376] stop installing jmods in the builder images

### DIFF
--- a/modules/jdk/11/module.yaml
+++ b/modules/jdk/11/module.yaml
@@ -25,7 +25,6 @@ envs:
 packages:
   install:
   - java-11-openjdk-devel
-  - java-11-openjdk-jmods
   - tzdata-java
 
 modules:

--- a/modules/jdk/17/module.yaml
+++ b/modules/jdk/17/module.yaml
@@ -25,7 +25,6 @@ envs:
 packages:
   install:
   - java-17-openjdk-devel
-  - java-17-openjdk-jmods
 
 modules:
   install:

--- a/modules/jdk/21/module.yaml
+++ b/modules/jdk/21/module.yaml
@@ -25,7 +25,6 @@ envs:
 packages:
   install:
   - java-21-openjdk-devel
-  - java-21-openjdk-jmods
 
 modules:
   install:


### PR DESCRIPTION
Hi,

This PR removes the jmods rpms from the builder images now that we have stage 1 in place.