### PR TITLE
[OPENJDK-3391] Update GitHub Pages URI

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -17,7 +17,7 @@ link:https://www.redhat.com/en/about/red-hat-end-user-license-agreements#UBI[UBI
 link:https://access.redhat.com/documentation/en-us/openjdk/17[Red Hat provide
 Product documentation for customers]. Tables of environment variables used for
 image configuration are published to
-<https://jboss-container-images.github.io/openjdk/>. These tables are automatically
+<https://rh-openjdk.github.io/redhat-openjdk-containers/>. These tables are automatically
 updated for every tagged release, and every commit to the development branches.
 
 Older RHEL7 and RHEL8-based image sources are in the `rhel7` and `ubi8` branches respectively.

--- a/ubi9-openjdk-11-runtime.yaml
+++ b/ubi9-openjdk-11-runtime.yaml
@@ -19,7 +19,7 @@ labels:
 - name: "com.redhat.component"
   value: "openjdk-11-runtime-ubi9-container"
 - name: "usage"
-  value: &docs "https://jboss-container-images.github.io/openjdk/"
+  value: &docs "https://rh-openjdk.github.io/redhat-openjdk-containers/"
 - name: "com.redhat.license_terms"
   value: "https://www.redhat.com/en/about/red-hat-end-user-license-agreements#UBI"
 - name: "org.opencontainers.image.documentation"

--- a/ubi9-openjdk-11.yaml
+++ b/ubi9-openjdk-11.yaml
@@ -19,7 +19,7 @@ labels:
 - name: "com.redhat.component"
   value: "openjdk-11-ubi9-container"
 - name: "usage"
-  value: &docs "https://jboss-container-images.github.io/openjdk/"
+  value: &docs "https://rh-openjdk.github.io/redhat-openjdk-containers/"
 - name: "com.redhat.license_terms"
   value: "https://www.redhat.com/en/about/red-hat-end-user-license-agreements#UBI"
 - name: "org.opencontainers.image.documentation"

--- a/ubi9-openjdk-17-runtime.yaml
+++ b/ubi9-openjdk-17-runtime.yaml
@@ -19,7 +19,7 @@ labels:
 - name: "com.redhat.component"
   value: "openjdk-17-runtime-ubi9-container"
 - name: "usage"
-  value: &docs "https://jboss-container-images.github.io/openjdk/"
+  value: &docs "https://rh-openjdk.github.io/redhat-openjdk-containers/"
 - name: "com.redhat.license_terms"
   value: "https://www.redhat.com/en/about/red-hat-end-user-license-agreements#UBI"
 - name: "org.opencontainers.image.documentation"

--- a/ubi9-openjdk-17.yaml
+++ b/ubi9-openjdk-17.yaml
@@ -19,7 +19,7 @@ labels:
 - name: "com.redhat.component"
   value: "openjdk-17-ubi9-container"
 - name: "usage"
-  value: &docs "https://jboss-container-images.github.io/openjdk/"
+  value: &docs "https://rh-openjdk.github.io/redhat-openjdk-containers/"
 - name: "com.redhat.license_terms"
   value: "https://www.redhat.com/en/about/red-hat-end-user-license-agreements#UBI"
 - name: "org.opencontainers.image.documentation"

--- a/ubi9-openjdk-21-runtime.yaml
+++ b/ubi9-openjdk-21-runtime.yaml
@@ -19,7 +19,7 @@ labels:
 - name: "com.redhat.component"
   value: "openjdk-21-runtime-ubi9-container"
 - name: "usage"
-  value: &docs "https://jboss-container-images.github.io/openjdk/"
+  value: &docs "https://rh-openjdk.github.io/redhat-openjdk-containers/"
 - name: "com.redhat.license_terms"
   value: "https://www.redhat.com/en/about/red-hat-end-user-license-agreements#UBI"
 - name: "org.opencontainers.image.documentation"

--- a/ubi9-openjdk-21.yaml
+++ b/ubi9-openjdk-21.yaml
@@ -19,7 +19,7 @@ labels:
 - name: "com.redhat.component"
   value: "openjdk-21-ubi9-container"
 - name: "usage"
-  value: &docs "https://jboss-container-images.github.io/openjdk/"
+  value: &docs "https://rh-openjdk.github.io/redhat-openjdk-containers/"
 - name: "com.redhat.license_terms"
   value: "https://www.redhat.com/en/about/red-hat-end-user-license-agreements#UBI"
 - name: "org.opencontainers.image.documentation"


### PR DESCRIPTION
Update GitHub Pages URI to reflect new GitHub Organisation and repository names.

<https://issues.redhat.com/browse/OPENJDK-3391>

NOTE: we can't merge this until https://issues.redhat.com/browse/OPENJDK-3389 is completed.