### PR TITLE
[OPENJDK-3418] Bump GH Pages Actions to recent versions

### DIFF
--- a/.github/workflows/gendocs.yml
+++ b/.github/workflows/gendocs.yml
@@ -41,13 +41,13 @@ jobs:
           ./gendocs.sh
 
       - name: Setup Pages
-        uses: actions/configure-pages@v3
+        uses: actions/configure-pages@v5
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v1
+        uses: actions/upload-pages-artifact@v3
         with:
           path: 'docs'
 
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v2
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
https://issues.redhat.com/browse/OPENJDK-3418

actions/upload-pages-artifact@v1 uses Artifact actions v3 which will be deprecated on 2024-12-05.

Updating upload-pages-artifact to v3 requires updating deploy-pages to v4.

Take the opportunity to update configure-pages@v5 as well.

(JIRA issue forthcoming)