### PR TITLE
[OPENJDK-2992] Create DeploymentConfig and Route for jlink apps

### DIFF
--- a/templates/jlink/README.md
+++ b/templates/jlink/README.md
@@ -57,6 +57,8 @@ Some suitable test values for the parameters are
  * REF: master
  * CONTEXT_DIR: quarkus-quickstarts/getting-started-3.9.2-uberjar
  * APPNAME: quarkus-quickstart
+ * TARGET_PORT: 8080
+ * SERVICE_PORT: 8080
 
         oc process \
             -p JDK_VERSION=17 \
@@ -64,6 +66,8 @@ Some suitable test values for the parameters are
             -p REF=master \
             -p CONTEXT_DIR=quarkus-quickstarts/getting-started-3.9.2-uberjar \
             -p APPNAME=quarkus-quickstart \
+            -p TARGET_PORT=8080 \
+            -p SERVICE_PORT=8080 \
             templates/jlink-app-template \
             | oc create -f -
 

--- a/templates/jlink/README.md
+++ b/templates/jlink/README.md
@@ -7,6 +7,8 @@ you need:
 2. UBI9 OpenJDK ImageStreams that include `jlink-dev` changes (see below)
 3. The template [jlinked-app.yaml](jlinked-app.yaml).
 
+DISCLAIMER: This template requires OpenShift to be able to resolve ImageStreams, as such it can only be used in projects where the openshift.io/run-level label set to 0 or 1. This means it cannot be used with default, kube-public, kube-system, openshift, openshift-infra, openshift-node, and other system-created projects.
+
 ## Stage 0: UBI9 OpenJDK ImageStreams with jlink-dev changes
 
 Until the `jlink-dev` work is merged, prior to trying out the template, we must first
@@ -18,11 +20,16 @@ prepare UBI9 OpenJDK ImageStreams with `jlink-dev` support.
 
         cekit --descriptor ubi9-openjdk-17.yaml build docker
 
-2. Within your OpenShift project,
+2. Create an OpenShift project and namespace
+
+        oc new-project jlink-dev
+        oc create namespace jlink
+
+3. Within your OpenShift project,
 
         oc create imagestream openjdk-17-jlink-tech-preview
 
-3. You may need to configure your container engine to not TLS-verify the OpenShift
+4. You may need to configure your container engine to not TLS-verify the OpenShift
    registry. For Docker, add the following to `/etc/docker/daemon.json` and restart
    the daemon:
 
@@ -30,11 +37,11 @@ prepare UBI9 OpenJDK ImageStreams with `jlink-dev` support.
           "insecure-registries": [ "default-route-openshift-image-registry.apps-crc.testing" ]
         }
 
-4. Log into the OpenShift registry, e.g.
+5. Log into the OpenShift registry, e.g.
 
         REGISTRY_AUTH_PREFERENCE=docker oc registry login
 
-5. tag and push the dev image into it. The OpenShift console gives you the
+6. tag and push the dev image into it. The OpenShift console gives you the
    exact URI for your instance
 
         docker tag openjdk-tech-preview/openjdk-17-jlink-rhel9:1.18 default-route-openshift-image-registry.apps-crc.testing/jlink1/openjdk-17-jlink-tech-preview:1.18
@@ -52,7 +59,7 @@ Process it to create the needed objects. You can list the parameters using
 
 Some suitable test values for the parameters are
 
- * JDK_VERSION: 17
+ * JDK_VERSION: 21
  * APP_URI: https://github.com/jboss-container-images/openjdk-test-applications
  * REF: master
  * CONTEXT_DIR: quarkus-quickstarts/getting-started-3.9.2-uberjar

--- a/templates/jlink/README.md
+++ b/templates/jlink/README.md
@@ -18,16 +18,15 @@ prepare UBI9 OpenJDK ImageStreams with `jlink-dev` support.
    repository](https://github.com/jboss-container-images/openjdk),
    branch `jlink-dev`. e.g.
 
-        cekit --descriptor ubi9-openjdk-17.yaml build docker
+        cekit --descriptor ubi9-openjdk-21.yaml build podman
 
-2. Create an OpenShift project and namespace
+2. Create an OpenShift project
 
-        oc new-project jlink-dev
-        oc create namespace jlink
+        oc new-project $PROJECT
 
 3. Within your OpenShift project,
 
-        oc create imagestream openjdk-17-jlink-tech-preview
+        oc create imagestream openjdk-21-jlink-tech-preview
 
 4. You may need to configure your container engine to not TLS-verify the OpenShift
    registry. For Docker, add the following to `/etc/docker/daemon.json` and restart
@@ -44,8 +43,8 @@ prepare UBI9 OpenJDK ImageStreams with `jlink-dev` support.
 6. tag and push the dev image into it. The OpenShift console gives you the
    exact URI for your instance
 
-        docker tag openjdk-tech-preview/openjdk-17-jlink-rhel9:1.18 default-route-openshift-image-registry.apps-crc.testing/jlink1/openjdk-17-jlink-tech-preview:1.18
-        docker push default-route-openshift-image-registry.apps-crc.testing/jlink1/ubi9-openjdk-17:1.18
+        podman tag openjdk-tech-preview/openjdk-21-jlink-rhel9:1.18 default-route-openshift-image-registry.apps-crc.testing/$PROJECT/openjdk-21-jlink-tech-preview:1.18
+        podman push default-route-openshift-image-registry.apps-crc.testing/$PROJECT/openjdk-21-jlink-tech-preview:1.18
 
 ## Stage 1: Load the template into OpenShift and instantiate it
 

--- a/templates/jlink/README.md
+++ b/templates/jlink/README.md
@@ -20,7 +20,7 @@ prepare UBI9 OpenJDK ImageStreams with `jlink-dev` support.
 
 2. Within your OpenShift project,
 
-        oc create imagestream ubi9-openjdk-17
+        oc create imagestream openjdk-17-jlink-tech-preview
 
 3. You may need to configure your container engine to not TLS-verify the OpenShift
    registry. For Docker, add the following to `/etc/docker/daemon.json` and restart
@@ -37,7 +37,7 @@ prepare UBI9 OpenJDK ImageStreams with `jlink-dev` support.
 5. tag and push the dev image into it. The OpenShift console gives you the
    exact URI for your instance
 
-        docker tag ubi9/openjdk-17:1.18 default-route-openshift-image-registry.apps-crc.testing/jlink1/ubi9-openjdk-17:1.18
+        docker tag openjdk-tech-preview/openjdk-17-jlink-rhel9:1.18 default-route-openshift-image-registry.apps-crc.testing/jlink1/openjdk-17-jlink-tech-preview:1.18
         docker push default-route-openshift-image-registry.apps-crc.testing/jlink1/ubi9-openjdk-17:1.18
 
 ## Stage 1: Load the template into OpenShift and instantiate it

--- a/templates/jlink/jlinked-app.yaml
+++ b/templates/jlink/jlinked-app.yaml
@@ -29,6 +29,9 @@ parameters:
   generate: expression
   from: "[a-zA-Z0-9]{16}"
   required: true
+- description: Target port for the created Route
+  name: TARGET_PORT
+  required: true
 message: "... The GitHub webhook secret is ${GITHUB_WEBHOOK_SECRET} ..."
 ##############################################################################
 # Following are the objects(imagestream and buildconfigs) for all the 3-stages
@@ -217,27 +220,32 @@ objects:
             kind: ImageStreamTag
             name: ${APPNAME}-ubimicro:latest  # ImageStreamTag for registry.access.redhat.com/ubi9/ubi-micro
 ##############################################################################
-# Deployment and Route object specs
-- apiVersion: apps/v1
-  kind: Deployment
+# DeploymentConfig and Route object specs
+# DeploymentConfigs are discouraged, however the documentation sugggests to still
+# use them if features are missing from Deployments, which in our case they are.
+- apiVersion: apps.openshift.io/v1
+  kind: DeploymentConfig
   metadata:
-    name: ${APPNAME}-jlinked-app
+    name: ${APPNAME}-jlinked-app-deployment
+    annotations:
+      template.alpha.openshift.io/wait-for-ready: "true"
   spec:
     replicas: 1
     selector:
       matchLabels:
         app: ${APPNAME}-jlinked-app
-    template:
-      metadata:
-        labels:
-          app: ${APPNAME}-jlinked-app
-      spec:
-        containers:
-          - name: ${APPNAME}-jlinked-app-container
-            image: ${APPNAME}-lightweight-image:latest
-            imagePullPolicy: IfNotPresent
-            ports:
-              - containerPort: 8080
+    triggers:
+    - type: ConfigChange
+    - imageChangeParams:
+        automatic: true
+        containerNames:
+        - ${APPNAME}-jlinked-app-container
+        from: 
+          kind: ImageStreamTag
+          name: ${APPNAME}-lightweight-image:latest
+      type: ImageChange
+    strategy:
+      type: Rolling
 - apiVersion: v1
   kind: Service
   metadata:
@@ -257,3 +265,5 @@ objects:
     to:
       kind: Service
       name: ${APPNAME}-jlinked-app-service
+    port:
+      targetPort: ${TARGET_PORT}

--- a/templates/jlink/jlinked-app.yaml
+++ b/templates/jlink/jlinked-app.yaml
@@ -213,3 +213,43 @@ objects:
           from:
             kind: ImageStreamTag
             name: ubimicro:latest  # ImageStreamTag for registry.access.redhat.com/ubi9/ubi-micro
+##############################################################################
+# Deployment and Route object specs
+- apiVersion: apps.openshift.io/v1
+  kind: Deployment
+  metadata:
+    name: jlinked-app
+  spec:
+    replicas: 1
+    selector:
+      matchLabels:
+        app: jlinked-app
+    template:
+      metadata:
+        labels:
+          app: jlinked-app
+      spec:
+        containers:
+          - name: jlinked-app-container
+            image: 'openshift/jlinked-app:latest'
+            ports:
+              - containerPort: 8080
+- apiVersion: v1
+  kind: Service
+  metadata:
+    name: jlinked-app-service
+  spec:
+    selector:
+      app: jlinked-app
+    ports:
+      - protocol: TCP
+        port: 80
+        targetPort: 8080
+- apiVersion: route.openshift.io/v1
+  kind: Route
+  metadata:
+    name: jlinked-app-route
+  spec:
+    to:
+      kind: Service
+      name: jlinked-app-service

--- a/templates/jlink/jlinked-app.yaml
+++ b/templates/jlink/jlinked-app.yaml
@@ -221,30 +221,30 @@ objects:
 - apiVersion: apps/v1
   kind: Deployment
   metadata:
-    name: jlinked-app
+    name: ${APPNAME}-jlinked-app
   spec:
     replicas: 1
     selector:
       matchLabels:
-        app: jlinked-app
+        app: ${APPNAME}-jlinked-app
     template:
       metadata:
         labels:
-          app: jlinked-app
+          app: ${APPNAME}-jlinked-app
       spec:
         containers:
-          - name: jlinked-app-container
-            image: lightweight-image:latest
+          - name: ${APPNAME}-jlinked-app-container
+            image: ${APPNAME}-lightweight-image:latest
             imagePullPolicy: IfNotPresent
             ports:
               - containerPort: 8080
 - apiVersion: v1
   kind: Service
   metadata:
-    name: jlinked-app-service
+    name: ${APPNAME}-jlinked-app-service
   spec:
     selector:
-      app: jlinked-app
+      app: ${APPNAME}-jlinked-app
     ports:
       - protocol: TCP
         port: 80
@@ -252,8 +252,8 @@ objects:
 - apiVersion: route.openshift.io/v1
   kind: Route
   metadata:
-    name: jlinked-app-route
+    name: ${APPNAME}-jlinked-app-route
   spec:
     to:
       kind: Service
-      name: jlinked-app-service
+      name: ${APPNAME}-jlinked-app-service

--- a/templates/jlink/jlinked-app.yaml
+++ b/templates/jlink/jlinked-app.yaml
@@ -10,7 +10,7 @@ metadata:
 parameters:
 - description: JDK version to produce a jmods image and imagestream for
   name: JDK_VERSION
-  value: "11"
+  value: "21"
   required: true
 - description: OpenJDK builder image version tag
   name: BUILDER_IMAGE_TAG
@@ -182,7 +182,8 @@ objects:
       app.kubernetes.io/part-of: ${APPNAME}
   spec:
     lookupPolicy:
-      local: false
+      # Must be true for the Deployment to resolve the ImageStream
+      local: true
 ##############################################################################
 # stage-3: BuildConfig
 - apiVersion: build.openshift.io/v1
@@ -248,24 +249,26 @@ objects:
 # DeploymentConfig and Route object specs
 # DeploymentConfigs are discouraged, however the documentation sugggests to still
 # use them if features are missing from Deployments, which in our case they are.
-- apiVersion: apps.openshift.io/v1
-  kind: DeploymentConfig
+- apiVersion: apps/v1
+  kind: Deployment
   metadata:
     name: ${APPNAME}-jlinked-app-deployment
-    annotations:
-      template.alpha.openshift.io/wait-for-ready: "true"
     labels:
       app: ${APPNAME}
       app.kubernetes.io/part-of: ${APPNAME}
   spec:
     replicas: 1
     selector:
-      app: ${APPNAME}
+      matchLabels:
+        app: ${APPNAME}
     template:
       metadata:
         labels:
           app: ${APPNAME}
           app.kubernetes.io/part-of: ${APPNAME}
+        annotations:
+          # Allows Deployments to use ImageStreams
+          alpha.image.policy.openshift.io/resolve-names: '*'
       spec:
         containers:
           - name: ${APPNAME}-jlinked-app-container
@@ -274,18 +277,7 @@ objects:
               - containerPort: ${{TARGET_PORT}}
                 protocol: TCP
     strategy:
-      type: Rolling
-    triggers:
-    - type: ImageChange
-      imageChangeParams:
-        automatic: true
-        containerNames:
-          - ${APPNAME}-jlinked-app-container
-        from:
-          kind: ImageStreamTag
-          name: '${APPNAME}-lightweight-image:latest'
-          namespace: default
-    - type: ConfigChange
+      type: RollingUpdate
 - apiVersion: v1
   kind: Service
   metadata:

--- a/templates/jlink/jlinked-app.yaml
+++ b/templates/jlink/jlinked-app.yaml
@@ -5,6 +5,8 @@ metadata:
   annotations:
     description: Template to produce imagestreams and buildconfigs for jlinked application 
   name: jlink-app-template
+  labels:
+    jlink-app-name: ${APPNAME}
 ##############################################################################
 # List of parameters required to create template
 parameters:
@@ -47,6 +49,8 @@ objects:
   kind: ImageStream
   metadata:
     name: ${APPNAME}-ubi9-openjdk-${JDK_VERSION}-jlink
+    labels:
+      jlink-app-name: ${APPNAME}
   spec:
     lookupPolicy:
       local: false
@@ -58,6 +62,7 @@ objects:
     name: ${APPNAME}-jlink-builder-jdk-${JDK_VERSION}
     labels:
       app: ${APPNAME}-jlink-builder-jdk-${JDK_VERSION}
+      jlink-app-name: ${APPNAME}
   spec:
     source:
       dockerfile: |
@@ -97,6 +102,8 @@ objects:
   kind: ImageStream
   metadata:
     name: ${APPNAME}-intermediate
+    labels:
+      jlink-app-name: ${APPNAME}
   spec:
     lookupPolicy:
       local: false
@@ -108,6 +115,7 @@ objects:
     name: ${APPNAME}-jlink-s2i-jdk-${JDK_VERSION}
     labels:
       app: ${APPNAME}-jlink-s2i-jdk-${JDK_VERSION}
+      jlink-app-name: ${APPNAME}
   spec:
     source:
       type: Git
@@ -147,6 +155,8 @@ objects:
   kind: ImageStream
   metadata:
     name: ${APPNAME}-ubimicro
+    labels:
+      jlink-app-name: ${APPNAME}
   spec:
     lookupPolicy:
       local: true
@@ -234,6 +244,8 @@ objects:
     name: ${APPNAME}-jlinked-app-deployment
     annotations:
       template.alpha.openshift.io/wait-for-ready: "true"
+    labels:
+      jlink-app-name: ${APPNAME}
   spec:
     replicas: 1
     selector:
@@ -267,6 +279,8 @@ objects:
   kind: Service
   metadata:
     name: ${APPNAME}-jlinked-app-service
+    labels:
+      jlink-app-name: ${APPNAME}
   spec:
     selector:
       app: ${APPNAME}-jlinked-app
@@ -279,6 +293,8 @@ objects:
   kind: Route
   metadata:
     name: ${APPNAME}-jlinked-app-route
+    labels:
+      jlink-app-name: ${APPNAME}
   spec:
     to:
       kind: Service
@@ -289,6 +305,8 @@ objects:
   kind: Pod
   metadata:
     name: ${APPNAME}-jlinked-app-pod
+    labels:
+      jlink-app-name: ${APPNAME}
   spec:
     containers:
     - image: ${APPNAME}-lightweight-image:latest

--- a/templates/jlink/jlinked-app.yaml
+++ b/templates/jlink/jlinked-app.yaml
@@ -285,3 +285,14 @@ objects:
       name: ${APPNAME}-jlinked-app-service
     port:
       targetPort: ${TARGET_PORT}
+- apiVersion: v1
+  kind: Pod
+  metadata:
+    name: ${APPNAME}-jlinked-app-pod
+  spec:
+    containers:
+    - image: ${APPNAME}-lightweight-image:latest
+      name: ${APPNAME}-jlinked-app-container
+      ports:
+      - containerPort: ${{TARGET_PORT}}
+        protocol: TCP

--- a/templates/jlink/jlinked-app.yaml
+++ b/templates/jlink/jlinked-app.yaml
@@ -86,7 +86,7 @@ objects:
       dockerStrategy:
         from: 
           kind: ImageStreamTag
-          name: openjdk-${JDK_VERSION}-jlink-tech-preview:latest  # Refer README.md to create this ImageStream
+          name: openjdk-${JDK_VERSION}-jlink-tech-preview:${BUILDER_IMAGE_TAG}  # Refer README.md to create this ImageStream
     output:
       to:
         kind: ImageStreamTag

--- a/templates/jlink/jlinked-app.yaml
+++ b/templates/jlink/jlinked-app.yaml
@@ -31,6 +31,11 @@ parameters:
   required: true
 - description: Target port for the created Route
   name: TARGET_PORT
+  value: "8080"
+  required: true
+- description: Port for the created Service to listen on
+  name: SERVICE_PORT
+  value: "8181"
   required: true
 message: "... The GitHub webhook secret is ${GITHUB_WEBHOOK_SECRET} ..."
 ##############################################################################
@@ -267,8 +272,9 @@ objects:
       app: ${APPNAME}-jlinked-app
     ports:
       - protocol: TCP
-        port: 80
-        targetPort: 8080
+        name: target-${TARGET_PORT}-tcp
+        port: ${{SERVICE_PORT}}
+        targetPort: ${{TARGET_PORT}}
 - apiVersion: route.openshift.io/v1
   kind: Route
   metadata:

--- a/templates/jlink/jlinked-app.yaml
+++ b/templates/jlink/jlinked-app.yaml
@@ -86,7 +86,7 @@ objects:
       dockerStrategy:
         from: 
           kind: ImageStreamTag
-          name: openjdk-${JDK_VERSION}-jlink-tech-preview:1.18  # Refer README.md to create this ImageStream
+          name: openjdk-${JDK_VERSION}-jlink-tech-preview:latest  # Refer README.md to create this ImageStream
     output:
       to:
         kind: ImageStreamTag

--- a/templates/jlink/jlinked-app.yaml
+++ b/templates/jlink/jlinked-app.yaml
@@ -215,7 +215,7 @@ objects:
             name: ubimicro:latest  # ImageStreamTag for registry.access.redhat.com/ubi9/ubi-micro
 ##############################################################################
 # Deployment and Route object specs
-- apiVersion: apps.openshift.io/v1
+- apiVersion: apps/v1
   kind: Deployment
   metadata:
     name: jlinked-app

--- a/templates/jlink/jlinked-app.yaml
+++ b/templates/jlink/jlinked-app.yaml
@@ -49,7 +49,7 @@ objects:
 - apiVersion: image.openshift.io/v1
   kind: ImageStream
   metadata:
-    name: ${APPNAME}-ubi9-openjdk-${JDK_VERSION}-jlink
+    name: ${APPNAME}-openjdk-${JDK_VERSION}-jlink-tech-preview
     labels:
       app: ${APPNAME}
       app.kubernetes.io/part-of: ${APPNAME}
@@ -86,18 +86,18 @@ objects:
       dockerStrategy:
         from: 
           kind: ImageStreamTag
-          name: ubi9-openjdk-${JDK_VERSION}:${BUILDER_IMAGE_TAG}  # Refer README.md to create this ImageStream
+          name: openjdk-${JDK_VERSION}-jlink-tech-preview:1.18  # Refer README.md to create this ImageStream
     output:
       to:
         kind: ImageStreamTag
-        name: ${APPNAME}-ubi9-openjdk-${JDK_VERSION}-jlink:latest
+        name: ${APPNAME}-openjdk-${JDK_VERSION}-jlink-tech-preview:latest
     triggers:
       - type: ConfigChange
       - type: ImageChange
         imageChange:
           from:
             kind: ImageStreamTag
-            name: ubi9-openjdk-${JDK_VERSION}:${BUILDER_IMAGE_TAG}
+            name: openjdk-${JDK_VERSION}-jlink-tech-preview:${BUILDER_IMAGE_TAG}
 ##############################################################################
 # stage-2: Output ImageStream
 - apiVersion: image.openshift.io/v1
@@ -130,7 +130,7 @@ objects:
       sourceStrategy:
         from:
           kind: ImageStreamTag
-          name: ${APPNAME}-ubi9-openjdk-${JDK_VERSION}-jlink:latest # Output Imagestream from stage-1
+          name: ${APPNAME}-openjdk-${JDK_VERSION}-jlink-tech-preview:latest # Output Imagestream from stage-1
           pullPolicy: Always
         env:
           - name: S2I_ENABLE_JLINK
@@ -147,7 +147,7 @@ objects:
         imageChange:
           from:
             kind: ImageStreamTag
-            name: ${APPNAME}-ubi9-openjdk-${JDK_VERSION}-jlink:latest  # Output of stage-1 which serves as input to stage-2
+            name: ${APPNAME}-openjdk-${JDK_VERSION}-jlink-tech-preview:latest  # Output of stage-1 which serves as input to stage-2
       - type: GitHub
         github:
           secret: ${GITHUB_WEBHOOK_SECRET}

--- a/templates/jlink/jlinked-app.yaml
+++ b/templates/jlink/jlinked-app.yaml
@@ -232,20 +232,32 @@ objects:
   spec:
     replicas: 1
     selector:
-      matchLabels:
-        app: ${APPNAME}-jlinked-app
-    triggers:
-    - type: ConfigChange
-    - imageChangeParams:
-        automatic: true
-        containerNames:
-        - ${APPNAME}-jlinked-app-container
-        from: 
-          kind: ImageStreamTag
-          name: ${APPNAME}-lightweight-image:latest
-      type: ImageChange
+      app: ${APPNAME}-jlinked-app
+    template:
+      metadata:
+        labels:
+          app: ${APPNAME}-jlinked-app
+      spec:
+        containers:
+          - name: ${APPNAME}-jlinked-app-container
+            image: >-
+              ${APPNAME}-lightweight-image:latest
+            ports:
+              - containerPort: 8080
+                protocol: TCP
     strategy:
       type: Rolling
+    triggers:
+    - type: ImageChange
+      imageChangeParams:
+        automatic: true
+        containerNames:
+          - ${APPNAME}-jlinked-app-container
+        from:
+          kind: ImageStreamTag
+          name: '${APPNAME}-lightweight-image:latest'
+          namespace: default
+    - type: ConfigChange
 - apiVersion: v1
   kind: Service
   metadata:

--- a/templates/jlink/jlinked-app.yaml
+++ b/templates/jlink/jlinked-app.yaml
@@ -5,8 +5,6 @@ metadata:
   annotations:
     description: Template to produce imagestreams and buildconfigs for jlinked application 
   name: jlink-app-template
-  labels:
-    jlink-app-name: ${APPNAME}
 ##############################################################################
 # List of parameters required to create template
 parameters:
@@ -50,7 +48,8 @@ objects:
   metadata:
     name: ${APPNAME}-ubi9-openjdk-${JDK_VERSION}-jlink
     labels:
-      jlink-app-name: ${APPNAME}
+      app: ${APPNAME}
+      app.kubernetes.io/part-of: ${APPNAME}
   spec:
     lookupPolicy:
       local: false
@@ -61,8 +60,8 @@ objects:
   metadata: 
     name: ${APPNAME}-jlink-builder-jdk-${JDK_VERSION}
     labels:
-      app: ${APPNAME}-jlink-builder-jdk-${JDK_VERSION}
-      jlink-app-name: ${APPNAME}
+      app: ${APPNAME}
+      app.kubernetes.io/part-of: ${APPNAME}
   spec:
     source:
       dockerfile: |
@@ -103,7 +102,8 @@ objects:
   metadata:
     name: ${APPNAME}-intermediate
     labels:
-      jlink-app-name: ${APPNAME}
+      app: ${APPNAME}
+      app.kubernetes.io/part-of: ${APPNAME}
   spec:
     lookupPolicy:
       local: false
@@ -114,8 +114,8 @@ objects:
   metadata:
     name: ${APPNAME}-jlink-s2i-jdk-${JDK_VERSION}
     labels:
-      app: ${APPNAME}-jlink-s2i-jdk-${JDK_VERSION}
-      jlink-app-name: ${APPNAME}
+      app: ${APPNAME}
+      app.kubernetes.io/part-of: ${APPNAME}
   spec:
     source:
       type: Git
@@ -156,7 +156,8 @@ objects:
   metadata:
     name: ${APPNAME}-ubimicro
     labels:
-      jlink-app-name: ${APPNAME}
+      app: ${APPNAME}
+      app.kubernetes.io/part-of: ${APPNAME}
   spec:
     lookupPolicy:
       local: true
@@ -173,6 +174,9 @@ objects:
   kind: ImageStream
   metadata:
     name: ${APPNAME}-lightweight-image
+    labels:
+      app: ${APPNAME}
+      app.kubernetes.io/part-of: ${APPNAME}
   spec:
     lookupPolicy:
       local: false
@@ -182,6 +186,9 @@ objects:
   kind: BuildConfig
   metadata: 
     name: ${APPNAME}-multistage-buildconfig
+    labels:
+      app: ${APPNAME}
+      app.kubernetes.io/part-of: ${APPNAME}
   spec:
     source:
       images:
@@ -245,22 +252,23 @@ objects:
     annotations:
       template.alpha.openshift.io/wait-for-ready: "true"
     labels:
-      jlink-app-name: ${APPNAME}
+      app: ${APPNAME}
+      app.kubernetes.io/part-of: ${APPNAME}
   spec:
     replicas: 1
     selector:
-      app: ${APPNAME}-jlinked-app
+      app: ${APPNAME}
     template:
       metadata:
         labels:
-          app: ${APPNAME}-jlinked-app
+          app: ${APPNAME}
+          app.kubernetes.io/part-of: ${APPNAME}
       spec:
         containers:
           - name: ${APPNAME}-jlinked-app-container
-            image: >-
-              ${APPNAME}-lightweight-image:latest
+            image: ${APPNAME}-lightweight-image:latest
             ports:
-              - containerPort: 8080
+              - containerPort: ${{TARGET_PORT}}
                 protocol: TCP
     strategy:
       type: Rolling
@@ -280,10 +288,11 @@ objects:
   metadata:
     name: ${APPNAME}-jlinked-app-service
     labels:
-      jlink-app-name: ${APPNAME}
+      app: ${APPNAME}
+      app.kubernetes.io/part-of: ${APPNAME}
   spec:
     selector:
-      app: ${APPNAME}-jlinked-app
+      app: ${APPNAME}
     ports:
       - protocol: TCP
         name: target-${TARGET_PORT}-tcp
@@ -294,23 +303,11 @@ objects:
   metadata:
     name: ${APPNAME}-jlinked-app-route
     labels:
-      jlink-app-name: ${APPNAME}
+      app: ${APPNAME}
+      app.kubernetes.io/part-of: ${APPNAME}
   spec:
     to:
       kind: Service
       name: ${APPNAME}-jlinked-app-service
     port:
-      targetPort: ${TARGET_PORT}
-- apiVersion: v1
-  kind: Pod
-  metadata:
-    name: ${APPNAME}-jlinked-app-pod
-    labels:
-      jlink-app-name: ${APPNAME}
-  spec:
-    containers:
-    - image: ${APPNAME}-lightweight-image:latest
-      name: ${APPNAME}-jlinked-app-container
-      ports:
-      - containerPort: ${{TARGET_PORT}}
-        protocol: TCP
+      targetPort: ${{TARGET_PORT}}

--- a/templates/jlink/jlinked-app.yaml
+++ b/templates/jlink/jlinked-app.yaml
@@ -231,7 +231,8 @@ objects:
       spec:
         containers:
           - name: jlinked-app-container
-            image: 'openshift/jlinked-app:latest'
+            image: lightweight-image:latest
+            imagePullPolicy: IfNotPresent
             ports:
               - containerPort: 8080
 - apiVersion: v1


### PR DESCRIPTION
Addresses https://issues.redhat.com/browse/OPENJDK-2992

Cleanup/Continuation of https://github.com/rh-openjdk/redhat-openjdk-containers/pull/500/

This cleans up the original PR, bringing it in line with the new naming convention for created objects, adding in the missing target port, and converting the Deployment to a DeploymentConfig to work with ImageStreamTags
