### PR TITLE
[OPENJDK-3430] alter FROM line for redhat builds

### DIFF
--- a/redhat/ubi9-openjdk-11-runtime.yaml
+++ b/redhat/ubi9-openjdk-11-runtime.yaml
@@ -1,3 +1,7 @@
+# This OSBS Base Image is designed and engineered to be the base layer for
+# Red Hat products. This base image is only supported for approved Red Hat
+# products. This image is maintained by Red Hat and updated regularly.
+from: registry.redhat.io/rhel9-osbs/osbs-ubi9-minimal
 osbs:
   configuration:
     container:

--- a/redhat/ubi9-openjdk-11.yaml
+++ b/redhat/ubi9-openjdk-11.yaml
@@ -1,3 +1,7 @@
+# This OSBS Base Image is designed and engineered to be the base layer for
+# Red Hat products. This base image is only supported for approved Red Hat
+# products. This image is maintained by Red Hat and updated regularly.
+from: registry.redhat.io/rhel9-osbs/osbs-ubi9-minimal
 osbs:
   configuration:
     container:

--- a/redhat/ubi9-openjdk-17-runtime.yaml
+++ b/redhat/ubi9-openjdk-17-runtime.yaml
@@ -1,3 +1,7 @@
+# This OSBS Base Image is designed and engineered to be the base layer for
+# Red Hat products. This base image is only supported for approved Red Hat
+# products. This image is maintained by Red Hat and updated regularly.
+from: registry.redhat.io/rhel9-osbs/osbs-ubi9-minimal
 osbs:
   configuration:
     container:

--- a/redhat/ubi9-openjdk-17.yaml
+++ b/redhat/ubi9-openjdk-17.yaml
@@ -1,3 +1,7 @@
+# This OSBS Base Image is designed and engineered to be the base layer for
+# Red Hat products. This base image is only supported for approved Red Hat
+# products. This image is maintained by Red Hat and updated regularly.
+from: registry.redhat.io/rhel9-osbs/osbs-ubi9-minimal
 osbs:
   configuration:
     container:

--- a/redhat/ubi9-openjdk-21-runtime.yaml
+++ b/redhat/ubi9-openjdk-21-runtime.yaml
@@ -1,3 +1,7 @@
+# This OSBS Base Image is designed and engineered to be the base layer for
+# Red Hat products. This base image is only supported for approved Red Hat
+# products. This image is maintained by Red Hat and updated regularly.
+from: registry.redhat.io/rhel9-osbs/osbs-ubi9-minimal
 osbs:
   configuration:
     container:

--- a/redhat/ubi9-openjdk-21.yaml
+++ b/redhat/ubi9-openjdk-21.yaml
@@ -1,3 +1,7 @@
+# This OSBS Base Image is designed and engineered to be the base layer for
+# Red Hat products. This base image is only supported for approved Red Hat
+# products. This image is maintained by Red Hat and updated regularly.
+from: registry.redhat.io/rhel9-osbs/osbs-ubi9-minimal
 osbs:
   configuration:
     container:

--- a/ubi9-openjdk-11-runtime.yaml
+++ b/ubi9-openjdk-11-runtime.yaml
@@ -2,7 +2,7 @@
 
 schema_version: 1
 
-from: "registry.access.redhat.com/ubi9/ubi-minimal:9.4"
+from: "registry.access.redhat.com/ubi9/ubi-minimal"
 name: &name "ubi9/openjdk-11-runtime"
 version: &version "1.20"
 description: "Image for Red Hat OpenShift providing OpenJDK 11 runtime"

--- a/ubi9-openjdk-11.yaml
+++ b/ubi9-openjdk-11.yaml
@@ -2,7 +2,7 @@
 
 schema_version: 1
 
-from: "registry.access.redhat.com/ubi9/ubi-minimal:9.4"
+from: "registry.access.redhat.com/ubi9/ubi-minimal"
 name: &name "ubi9/openjdk-11"
 version: &version "1.20"
 description: "Source To Image (S2I) image for Red Hat OpenShift providing OpenJDK 11"

--- a/ubi9-openjdk-17-runtime.yaml
+++ b/ubi9-openjdk-17-runtime.yaml
@@ -2,7 +2,7 @@
 
 schema_version: 1
 
-from: "registry.access.redhat.com/ubi9/ubi-minimal:9.4"
+from: "registry.access.redhat.com/ubi9/ubi-minimal"
 name: &name "ubi9/openjdk-17-runtime"
 version: &version "1.21"
 description: "Image for Red Hat OpenShift providing OpenJDK 17 runtime"

--- a/ubi9-openjdk-17.yaml
+++ b/ubi9-openjdk-17.yaml
@@ -2,7 +2,7 @@
 
 schema_version: 1
 
-from: "registry.access.redhat.com/ubi9/ubi-minimal:9.4"
+from: "registry.access.redhat.com/ubi9/ubi-minimal"
 name: &name "ubi9/openjdk-17"
 version: &version "1.21"
 description: "Source To Image (S2I) image for Red Hat OpenShift providing OpenJDK 17"

--- a/ubi9-openjdk-21-runtime.yaml
+++ b/ubi9-openjdk-21-runtime.yaml
@@ -2,7 +2,7 @@
 
 schema_version: 1
 
-from: "registry.access.redhat.com/ubi9/ubi-minimal:9.4"
+from: "registry.access.redhat.com/ubi9/ubi-minimal"
 name: &name "ubi9/openjdk-21-runtime"
 version: &version "1.21"
 description: "Image for Red Hat OpenShift providing OpenJDK 21 runtime"

--- a/ubi9-openjdk-21.yaml
+++ b/ubi9-openjdk-21.yaml
@@ -2,7 +2,7 @@
 
 schema_version: 1
 
-from: "registry.access.redhat.com/ubi9/ubi-minimal:9.4"
+from: "registry.access.redhat.com/ubi9/ubi-minimal"
 name: &name "ubi9/openjdk-21"
 version: &version "1.21"
 description: "Source To Image (S2I) image for Red Hat OpenShift providing OpenJDK 21"


### PR DESCRIPTION
In the redhat/* overrides files, override "from:" to use the name assigned to RHEL images built via OSBS from 9.5 onwards.

https://issues.redhat.com/browse/OPENJDK-3430