### PR TITLE
[OPENJDK-3434] update references to openjdk-test-applications [ubi8]

### DIFF
--- a/modules/jolokia/8.2/tests/features/jolokia.feature
+++ b/modules/jolokia/8.2/tests/features/jolokia.feature
@@ -8,14 +8,14 @@ Feature: Openshift OpenJDK Jolokia tests
     Then run sh -c 'jar xf /usr/share/java/jolokia-jvm-agent/jolokia-jvm.jar META-INF/maven/org.jolokia/jolokia-jvm/pom.properties && grep ${JOLOKIA_VERSION} META-INF/maven/org.jolokia/jolokia-jvm/pom.properties' in container and check its output for version=
 
   Scenario: Check jolokia port is available
-    Given s2i build https://github.com/jboss-container-images/openjdk-test-applications from undertow-servlet
+    Given s2i build https://github.com/rh-openjdk/openjdk-container-test-applications.git from undertow-servlet
     Then check that port 8778 is open
     And  inspect container
        | path                    | value       |
        | /Config/ExposedPorts    | 8778/tcp    |
 
   Scenario: Ensure Jolokia diagnostic options work correctly
-    Given s2i build https://github.com/jboss-container-images/openjdk-test-applications from undertow-servlet
+    Given s2i build https://github.com/rh-openjdk/openjdk-container-test-applications.git from undertow-servlet
        | variable         | value               |
        | JAVA_ARGS        | Hello from CTF test |
        | JAVA_DIAGNOSTICS | true                |

--- a/modules/jvm/api/tests/features/memory.feature
+++ b/modules/jvm/api/tests/features/memory.feature
@@ -62,5 +62,5 @@ Feature: OPENJDK-559 JVM Memory tests
   @ubi8/openjdk-17
   @ubi8/openjdk-21
   Scenario: Ensure Maven doesn't use MaxRAMPercentage=80
-    Given s2i build https://github.com/jboss-container-images/openjdk-test-applications from spring-boot-sample-simple
+    Given s2i build https://github.com/rh-openjdk/openjdk-container-test-applications.git from spring-boot-sample-simple
     Then s2i build log should match regex INFO Using MAVEN_OPTS.*-XX:MaxRAMPercentage=25.0$

--- a/modules/maven/s2i/tests/features/java_s2i.feature
+++ b/modules/maven/s2i/tests/features/java_s2i.feature
@@ -12,7 +12,7 @@ Feature: Openshift OpenJDK S2I tests
 
   # handles mirror/repository configuration; proxy configuration
   Scenario: run the s2i and check the maven mirror and proxy have been initialised in the default settings.xml, uses http_proxy
-    Given s2i build https://github.com/jboss-container-images/openjdk-test-applications from spring-boot-sample-simple
+    Given s2i build https://github.com/rh-openjdk/openjdk-container-test-applications.git from spring-boot-sample-simple
        | variable           | value                                            |
        | MAVEN_ARGS         | -v                                               |
        | MAVEN_MIRROR_URL   | http://127.0.0.1:8080/repository/internal/       |
@@ -25,7 +25,7 @@ Feature: Openshift OpenJDK S2I tests
 
   # proxy auth configuration (success case) + nonProxyHosts
   Scenario: run the s2i and check the maven mirror, proxy (including username and password) and non proxy have been initialised in the default settings.xml, uses http_proxy
-    Given s2i build https://github.com/jboss-container-images/openjdk-test-applications from spring-boot-sample-simple
+    Given s2i build https://github.com/rh-openjdk/openjdk-container-test-applications.git from spring-boot-sample-simple
        | variable           | value                                            |
        | MAVEN_ARGS         | -v                                               |
        | http_proxy         | myuser:mypass@127.0.0.1:8080                     |
@@ -37,7 +37,7 @@ Feature: Openshift OpenJDK S2I tests
 
   # proxy auth configuration (fail case: no password supplied)
   Scenario: run the s2i and check the maven mirror, proxy (including username) and non proxy have been initialised in the default settings.xml, uses http_proxy
-    Given s2i build https://github.com/jboss-container-images/openjdk-test-applications from spring-boot-sample-simple
+    Given s2i build https://github.com/rh-openjdk/openjdk-container-test-applications.git from spring-boot-sample-simple
        | variable           | value                                            |
        | MAVEN_ARGS         | -v                                               |
        | http_proxy         | myuser@127.0.0.1:8080                            |
@@ -48,7 +48,7 @@ Feature: Openshift OpenJDK S2I tests
 
   # handles mirror/repository configuration; proxy configuration
   Scenario: run the s2i and check the maven mirror and proxy have been initialised in the default settings.xml, uses HTTP_PROXY
-    Given s2i build https://github.com/jboss-container-images/openjdk-test-applications from spring-boot-sample-simple
+    Given s2i build https://github.com/rh-openjdk/openjdk-container-test-applications.git from spring-boot-sample-simple
        | variable           | value                                            |
        | MAVEN_ARGS         | -v                                               |
        | MAVEN_MIRROR_URL   | http://127.0.0.1:8080/repository/internal/       |
@@ -61,7 +61,7 @@ Feature: Openshift OpenJDK S2I tests
 
   # proxy auth configuration (success case) + nonProxyHosts
   Scenario: run the s2i and check the maven mirror, proxy (including username and password) and non proxy have been initialised in the default settings.xml, uses HTTP_PROXY
-    Given s2i build https://github.com/jboss-container-images/openjdk-test-applications from spring-boot-sample-simple
+    Given s2i build https://github.com/rh-openjdk/openjdk-container-test-applications.git from spring-boot-sample-simple
        | variable           | value                                            |
        | MAVEN_ARGS         | -v                                               |
        | HTTP_PROXY         | myuser:mypass@127.0.0.1:8080                     |
@@ -73,7 +73,7 @@ Feature: Openshift OpenJDK S2I tests
 
   # proxy auth configuration (fail case: no password supplied)
   Scenario: run the s2i and check the maven mirror, proxy (including username) and non proxy have been initialised in the default settings.xml, uses HTTP_PROXY
-    Given s2i build https://github.com/jboss-container-images/openjdk-test-applications from spring-boot-sample-simple
+    Given s2i build https://github.com/rh-openjdk/openjdk-container-test-applications.git from spring-boot-sample-simple
        | variable           | value                                            |
        | MAVEN_ARGS         | -v                                               |
        | HTTP_PROXY         | myuser@127.0.0.1:8080                            |
@@ -84,7 +84,7 @@ Feature: Openshift OpenJDK S2I tests
 
   # handles mirror/repository configuration; proxy configuration
   Scenario: run the s2i and check the maven mirror and proxy have been initialised in the default settings.xml, uses http_proxy and HTTP_PROXY
-    Given s2i build https://github.com/jboss-container-images/openjdk-test-applications from spring-boot-sample-simple
+    Given s2i build https://github.com/rh-openjdk/openjdk-container-test-applications.git from spring-boot-sample-simple
        | variable           | value                                            |
        | MAVEN_ARGS         | -v                                               |
        | MAVEN_MIRROR_URL   | http://127.0.0.1:8080/repository/internal/       |
@@ -98,7 +98,7 @@ Feature: Openshift OpenJDK S2I tests
 
   # proxy auth configuration (success case) + nonProxyHosts
   Scenario: run the s2i and check the maven mirror, proxy (including username and password) and non proxy have been initialised in the default settings.xml, uses http_proxy and HTTP_PROXY
-    Given s2i build https://github.com/jboss-container-images/openjdk-test-applications from spring-boot-sample-simple
+    Given s2i build https://github.com/rh-openjdk/openjdk-container-test-applications.git from spring-boot-sample-simple
        | variable           | value                                            |
        | MAVEN_ARGS         | -v                                               |
        | http_proxy         | user2:pass2@127.0.0.2:9090                       |
@@ -111,7 +111,7 @@ Feature: Openshift OpenJDK S2I tests
 
   # proxy auth configuration (fail case: no password supplied)
   Scenario: run the s2i and check the maven mirror, proxy (including username) and non proxy have been initialised in the default settings.xml, uses http_proxy and HTTP_PROXY
-    Given s2i build https://github.com/jboss-container-images/openjdk-test-applications from spring-boot-sample-simple
+    Given s2i build https://github.com/rh-openjdk/openjdk-container-test-applications.git from spring-boot-sample-simple
        | variable           | value                                            |
        | MAVEN_ARGS         | -v                                               |
        | http_proxy         | user2@127.0.0.2:9090                             |
@@ -123,7 +123,7 @@ Feature: Openshift OpenJDK S2I tests
 
   # handles mirror/repository configuration; proxy configuration
   Scenario: run the s2i and check the maven mirror and proxy have been initialised in the default settings.xml, uses https_proxy
-    Given s2i build https://github.com/jboss-container-images/openjdk-test-applications from spring-boot-sample-simple
+    Given s2i build https://github.com/rh-openjdk/openjdk-container-test-applications.git from spring-boot-sample-simple
        | variable           | value                                            |
        | MAVEN_ARGS         | -v                                               |
        | MAVEN_MIRROR_URL   | http://127.0.0.1:8080/repository/internal/       |
@@ -136,7 +136,7 @@ Feature: Openshift OpenJDK S2I tests
 
   # proxy auth configuration (success case) + nonProxyHosts
   Scenario: run the s2i and check the maven mirror, proxy (including username and password) and non proxy have been initialised in the default settings.xml, uses https_proxy
-    Given s2i build https://github.com/jboss-container-images/openjdk-test-applications from spring-boot-sample-simple
+    Given s2i build https://github.com/rh-openjdk/openjdk-container-test-applications.git from spring-boot-sample-simple
        | variable           | value                                            |
        | MAVEN_ARGS         | -v                                               |
        | https_proxy        | myuser:mypass@127.0.0.1:8080                     |
@@ -148,7 +148,7 @@ Feature: Openshift OpenJDK S2I tests
 
   # proxy auth configuration (fail case: no password supplied)
   Scenario: run the s2i and check the maven mirror, proxy (including username) and non proxy have been initialised in the default settings.xml, uses https_proxy
-    Given s2i build https://github.com/jboss-container-images/openjdk-test-applications from spring-boot-sample-simple
+    Given s2i build https://github.com/rh-openjdk/openjdk-container-test-applications.git from spring-boot-sample-simple
        | variable           | value                                            |
        | MAVEN_ARGS         | -v                                               |
        | https_proxy        | myuser@127.0.0.1:8080                            |
@@ -159,7 +159,7 @@ Feature: Openshift OpenJDK S2I tests
 
   # handles mirror/repository configuration; proxy configuration
   Scenario: run the s2i and check the maven mirror and proxy have been initialised in the default settings.xml, uses HTTPS_PROXY
-    Given s2i build https://github.com/jboss-container-images/openjdk-test-applications from spring-boot-sample-simple
+    Given s2i build https://github.com/rh-openjdk/openjdk-container-test-applications.git from spring-boot-sample-simple
        | variable           | value                                            |
        | MAVEN_ARGS         | -v                                               |
        | MAVEN_MIRROR_URL   | http://127.0.0.1:8080/repository/internal/       |
@@ -172,7 +172,7 @@ Feature: Openshift OpenJDK S2I tests
 
   # proxy auth configuration (success case) + nonProxyHosts
   Scenario: run the s2i and check the maven mirror, proxy (including username and password) and non proxy have been initialised in the default settings.xml, uses HTTPS_PROXY
-    Given s2i build https://github.com/jboss-container-images/openjdk-test-applications from spring-boot-sample-simple
+    Given s2i build https://github.com/rh-openjdk/openjdk-container-test-applications.git from spring-boot-sample-simple
        | variable           | value                                            |
        | MAVEN_ARGS         | -v                                               |
        | HTTPS_PROXY        | myuser:mypass@127.0.0.1:8080                     |
@@ -184,7 +184,7 @@ Feature: Openshift OpenJDK S2I tests
 
   # proxy auth configuration (fail case: no password supplied)
   Scenario: run the s2i and check the maven mirror, proxy (including username) and non proxy have been initialised in the default settings.xml, uses HTTPS_PROXY
-    Given s2i build https://github.com/jboss-container-images/openjdk-test-applications from spring-boot-sample-simple
+    Given s2i build https://github.com/rh-openjdk/openjdk-container-test-applications.git from spring-boot-sample-simple
        | variable           | value                                            |
        | MAVEN_ARGS         | -v                                               |
        | HTTPS_PROXY        | myuser@127.0.0.1:8080                            |
@@ -195,7 +195,7 @@ Feature: Openshift OpenJDK S2I tests
 
   # handles mirror/repository configuration; proxy configuration
   Scenario: run the s2i and check the maven mirror and proxy have been initialised in the default settings.xml, uses https_proxy and HTTPS_PROXY
-    Given s2i build https://github.com/jboss-container-images/openjdk-test-applications from spring-boot-sample-simple
+    Given s2i build https://github.com/rh-openjdk/openjdk-container-test-applications.git from spring-boot-sample-simple
        | variable           | value                                            |
        | MAVEN_ARGS         | -v                                               |
        | MAVEN_MIRROR_URL   | http://127.0.0.1:8080/repository/internal/       |
@@ -209,7 +209,7 @@ Feature: Openshift OpenJDK S2I tests
 
   # proxy auth configuration (success case) + nonProxyHosts
   Scenario: run the s2i and check the maven mirror, proxy (including username and password) and non proxy have been initialised in the default settings.xml, uses https_proxy and HTTPS_PROXY
-    Given s2i build https://github.com/jboss-container-images/openjdk-test-applications from spring-boot-sample-simple
+    Given s2i build https://github.com/rh-openjdk/openjdk-container-test-applications.git from spring-boot-sample-simple
        | variable           | value                                            |
        | MAVEN_ARGS         | -v                                               |
        | https_proxy        | user2:pass2@127.0.0.2:9090                       |
@@ -222,7 +222,7 @@ Feature: Openshift OpenJDK S2I tests
 
   # proxy auth configuration (fail case: no password supplied)
   Scenario: run the s2i and check the maven mirror, proxy (including username) and non proxy have been initialised in the default settings.xml, uses https_proxy and HTTPS_PROXY
-    Given s2i build https://github.com/jboss-container-images/openjdk-test-applications from spring-boot-sample-simple
+    Given s2i build https://github.com/rh-openjdk/openjdk-container-test-applications.git from spring-boot-sample-simple
        | variable           | value                                            |
        | MAVEN_ARGS         | -v                                               |
        | https_proxy        | user2@127.0.0.2:9090                             |
@@ -234,7 +234,7 @@ Feature: Openshift OpenJDK S2I tests
 
   # proxy auth configuration (success case) + nonProxyHosts
   Scenario: run the s2i and check the maven mirror, proxy (including username and password) and non proxy have been initialised in the default settings.xml, uses https_proxy and HTTPS_PROXY
-    Given s2i build https://github.com/jboss-container-images/openjdk-test-applications from spring-boot-sample-simple
+    Given s2i build https://github.com/rh-openjdk/openjdk-container-test-applications.git from spring-boot-sample-simple
        | variable           | value                                            |
        | MAVEN_ARGS         | -v                                               |
        | https_proxy        | user3:pass3@127.0.0.3:7070                       |
@@ -247,7 +247,7 @@ Feature: Openshift OpenJDK S2I tests
     Then XML file /tmp/artifacts/configuration/settings.xml should have 1 elements on XPath //ns:proxy[ns:id='genproxy'][ns:active='true'][ns:protocol='https'][ns:host='127.0.0.3'][ns:port='7070'][ns:username='user3'][ns:password='pass3'][ns:nonProxyHosts='*.example.com']
 
   Scenario: run s2i assemble and check HTTP_PROXY_NONPROXYHOSTS is honoured
-    Given s2i build https://github.com/jboss-container-images/openjdk-test-applications from spring-boot-sample-simple
+    Given s2i build https://github.com/rh-openjdk/openjdk-container-test-applications.git from spring-boot-sample-simple
        | variable           | value                                            |
        | MAVEN_ARGS         | -v                                               |
        | MAVEN_MIRROR_URL   | http://127.0.0.1:8080/repository/internal/       |
@@ -259,7 +259,7 @@ Feature: Openshift OpenJDK S2I tests
     Then XML file /tmp/artifacts/configuration/settings.xml should have 1 elements on XPath //ns:proxy[ns:id='genproxy'][ns:active='true'][ns:protocol='http'][ns:host='127.0.0.1'][ns:port='8080'][ns:nonProxyHosts='*.example.com']
 
   Scenario: run s2i assemble and check HTTP_PROXY_NONPROXYHOSTS is honoured with multiple entries
-    Given s2i build https://github.com/jboss-container-images/openjdk-test-applications from spring-boot-sample-simple
+    Given s2i build https://github.com/rh-openjdk/openjdk-container-test-applications.git from spring-boot-sample-simple
        | variable           | value                                            |
        | MAVEN_ARGS         | -v                                               |
        | MAVEN_MIRROR_URL   | http://127.0.0.1:8080/repository/internal/       |
@@ -271,15 +271,15 @@ Feature: Openshift OpenJDK S2I tests
     Then XML file /tmp/artifacts/configuration/settings.xml should have 1 elements on XPath //ns:proxy[ns:id='genproxy'][ns:active='true'][ns:protocol='http'][ns:host='127.0.0.1'][ns:port='8080'][ns:nonProxyHosts='foo.example.com|bar.example.com']
 
   Scenario: run an S2I build that depends on com.redhat.xpaas.repo.redhatga being defined
-    Given s2i build https://github.com/jboss-container-images/openjdk-test-applications from spring-boot-sample-simple
+    Given s2i build https://github.com/rh-openjdk/openjdk-container-test-applications.git from spring-boot-sample-simple
 
   Scenario: run an S2I that should fail as MAVEN_ARGS does not define com.redhat.xpaas.repo.redhatga
-    Given failing s2i build https://github.com/jboss-container-images/openjdk-test-applications from spring-boot-sample-simple using openjdk-enforce-profile
+    Given failing s2i build https://github.com/rh-openjdk/openjdk-container-test-applications.git from spring-boot-sample-simple using openjdk-enforce-profile
        | variable           | value                                            |
        | MAVEN_ARGS         | -e package                                       |
 
   Scenario: Ensure legacy ARTIFACT_COPY_ARGS works as it used to
-    Given s2i build https://github.com/jboss-container-images/openjdk-test-applications from undertow-servlet
+    Given s2i build https://github.com/rh-openjdk/openjdk-container-test-applications.git from undertow-servlet
        | variable             | value                |
        | ARTIFACT_COPY_ARGS   | undertow-servlet.jar |
        | JAVA_ARGS            | Hello from CTF test  |
@@ -287,20 +287,20 @@ Feature: Openshift OpenJDK S2I tests
 
   # CLOUD-579
   Scenario: Test that maven is executed in batch mode
-    Given s2i build https://github.com/jboss-container-images/openjdk-test-applications from spring-boot-sample-simple
+    Given s2i build https://github.com/rh-openjdk/openjdk-container-test-applications.git from spring-boot-sample-simple
     Then s2i build log should contain --batch-mode
     And s2i build log should not contain \r
 
   # CLOUD-3095 - context dir should be recursively copied into the image
   # "/target" suffix is important here; it triggers a different code-path (no source build)
   Scenario: Ensure binary-only mode copies binaries into the target image
-    Given s2i build https://github.com/jboss-container-images/openjdk-test-applications from spring-boot-sample-simple/target
+    Given s2i build https://github.com/rh-openjdk/openjdk-container-test-applications.git from spring-boot-sample-simple/target
     Then s2i build log should not contain skipping directory .
     And  run find /deployments in container and check its output for spring-boot-sample-simple-1.5.0.BUILD-SNAPSHOT.jar
 
   # OPENJDK-2069 - MAVEN_REPOS
   Scenario: run the s2i and check the maven mirror and proxy have been initialised in the default settings.xml, uses http_proxy
-    Given s2i build https://github.com/jboss-container-images/openjdk-test-applications from spring-boot-sample-simple/target
+    Given s2i build https://github.com/rh-openjdk/openjdk-container-test-applications.git from spring-boot-sample-simple/target
        | variable                | value                                |
        | MAVEN_REPOS             | TESTREPO,ANOTHER                     |
        | TESTREPO_MAVEN_REPO_URL | http://repo.example.com:8080/maven2/ |
@@ -317,7 +317,7 @@ Feature: Openshift OpenJDK S2I tests
 
   # OPENJDK-2068: MAVEN_REPO_URL and MAVEN_REPO_ID
   Scenario: Check MAVEN_REPO_URL generates Maven settings and profile configuration
-    Given s2i build https://github.com/jboss-container-images/openjdk-test-applications from spring-boot-sample-simple/target
+    Given s2i build https://github.com/rh-openjdk/openjdk-container-test-applications.git from spring-boot-sample-simple/target
        | variable       | value                                |
        | MAVEN_REPO_URL | http://repo.example.com:8080/maven2/ |
        | MAVEN_REPO_ID  | myrepo                               |
@@ -328,12 +328,12 @@ Feature: Openshift OpenJDK S2I tests
     Then XML file /tmp/artifacts/configuration/settings.xml should have 1 elements on XPath //ns:profile[ns:id='myrepo-profile']/ns:repositories/ns:repository[ns:url='http://repo.example.com:8080/maven2/']
 
   Scenario: Ensure the environment is cleaned when executing mvn (OPENJDK-1548)
-      Given s2i build https://github.com/jboss-container-images/openjdk-test-applications from OPENJDK-1549 with env
+      Given s2i build https://github.com/rh-openjdk/openjdk-container-test-applications.git from OPENJDK-1549 with env
        | variable           | value    |
        | MAVEN_ARGS         | validate |
 
   Scenario: Ensure mtime is preserved for build artifacts (OPENJDK-2427)
-      Given s2i build https://github.com/jboss-container-images/openjdk-test-applications from OPENJDK-2408-bin-custom-s2i-assemble with env
+      Given s2i build https://github.com/rh-openjdk/openjdk-container-test-applications.git from OPENJDK-2408-bin-custom-s2i-assemble with env
        | variable          | value |
        | S2I_DELETE_SOURCE | false |
     Then run find /deployments/spring-boot-sample-simple-1.5.0.BUILD-SNAPSHOT.jar ! -newer /tmp/src/spring-boot-sample-simple-1.5.0.BUILD-SNAPSHOT.jar in container and check its output for spring-boot-sample-simple-1.5.0.BUILD-SNAPSHOT.jar

--- a/modules/maven/s2i/tests/features/java_s2i_inc.feature
+++ b/modules/maven/s2i/tests/features/java_s2i_inc.feature
@@ -6,12 +6,12 @@ Feature: Openshift OpenJDK S2I tests
 
   # test incremental builds
   Scenario: Check incremental builds cache .m2
-    Given s2i build https://github.com/jboss-container-images/openjdk-test-applications from undertow-servlet
+    Given s2i build https://github.com/rh-openjdk/openjdk-container-test-applications.git from undertow-servlet
         | variable    | value               |
         | JAVA_ARGS   | Hello from CTF test |
     Then container log should contain /deployments/undertow-servlet.jar Hello from CTF test
      And s2i build log should contain Downloading from central:
-    Given s2i build https://github.com/jboss-container-images/openjdk-test-applications from undertow-servlet with env and incremental
+    Given s2i build https://github.com/rh-openjdk/openjdk-container-test-applications.git from undertow-servlet with env and incremental
         | variable    | value               |
         | JAVA_ARGS   | Hello from CTF test |
     Then container log should contain /deployments/undertow-servlet.jar Hello from CTF test

--- a/modules/maven/s2i/tests/features/java_s2i_quarkus.feature
+++ b/modules/maven/s2i/tests/features/java_s2i_quarkus.feature
@@ -3,7 +3,7 @@
 @ubi8/openjdk-21
 Feature: Openshift OpenJDK S2I tests (Quarkus-based)
   Scenario: Ensure that run-env.sh placed in the JAVA_APP_DIR is sourced in the run script before launching java
-      Given s2i build https://github.com/jboss-container-images/openjdk-test-applications from quarkus-quickstarts/getting-started-3.0.1.Final-nos2i
+      Given s2i build https://github.com/rh-openjdk/openjdk-container-test-applications.git from quarkus-quickstarts/getting-started-3.0.1.Final-nos2i
        | variable            | value        |
        | S2I_SOURCE_DATA_DIR | ./           |
        | S2I_TARGET_DATA_DIR | /deployments |

--- a/modules/run/tests/features/java.runtime.feature
+++ b/modules/run/tests/features/java.runtime.feature
@@ -36,17 +36,17 @@ Feature: Openshift OpenJDK Runtime tests
     | JAVA_APP_DIR | /nope  |
   Then available container log should contain ERROR No directory /nope found for auto detection
   Scenario: Ensure JVM_ARGS is no longer present in the run script
-    Given s2i build https://github.com/jboss-container-images/openjdk-test-applications from undertow-servlet
+    Given s2i build https://github.com/rh-openjdk/openjdk-container-test-applications.git from undertow-servlet
     Then file /usr/local/s2i/run should not contain JVM_ARGS
 
   Scenario: Ensure JAVA_ARGS are passed through to the running java application
-    Given s2i build https://github.com/jboss-container-images/openjdk-test-applications from undertow-servlet
+    Given s2i build https://github.com/rh-openjdk/openjdk-container-test-applications.git from undertow-servlet
        | variable    | value               |
        | JAVA_ARGS   | Hello from CTF test |
     Then container log should contain /deployments/undertow-servlet.jar Hello from CTF test
 
   Scenario: Ensure diagnostic options work correctly
-    Given s2i build https://github.com/jboss-container-images/openjdk-test-applications from undertow-servlet
+    Given s2i build https://github.com/rh-openjdk/openjdk-container-test-applications.git from undertow-servlet
        | variable         | value               |
        | JAVA_ARGS        | Hello from CTF test |
        | JAVA_DIAGNOSTICS | true                |

--- a/modules/run/tests/features/java.security.feature
+++ b/modules/run/tests/features/java.security.feature
@@ -4,5 +4,5 @@
 @ubi8/openjdk-21
 Feature: Openshift S2I tests
   Scenario: Check networkaddress.cache.negative.ttl has been set correctly
-    Given s2i build https://github.com/jboss-container-images/openjdk-test-applications from binary-cli-security-property
+    Given s2i build https://github.com/rh-openjdk/openjdk-container-test-applications.git from binary-cli-security-property
     Then s2i build log should contain networkaddress.cache.negative.ttl=0

--- a/modules/s2i/core/api/tests/features/java_s2i_quarkus.feature
+++ b/modules/s2i/core/api/tests/features/java_s2i_quarkus.feature
@@ -5,11 +5,11 @@
 Feature: Openshift OpenJDK S2I tests (Quarkus-based)
 
   Scenario: Ensure Quarkus CDS doesn't fail due to timestamp mismatch (OPENDJK-1673)
-    Given s2i build https://github.com/jboss-container-images/openjdk-test-applications from getting-started
+    Given s2i build https://github.com/rh-openjdk/openjdk-container-test-applications.git from getting-started
     Then container log should not contain A jar file is not the one used while building the shared archive file
 
   Scenario: quarkus fast-jar layout works out-of-the-box (OPENJDK-1957)
-    Given s2i build https://github.com/jboss-container-images/openjdk-test-applications from quarkus-quickstarts/getting-started-3.0.1.Final-nos2i
+    Given s2i build https://github.com/rh-openjdk/openjdk-container-test-applications.git from quarkus-quickstarts/getting-started-3.0.1.Final-nos2i
     Then container log should contain INFO quarkus fast-jar package type detected
     And  container log should contain -jar /deployments/quarkus-app/quarkus-run.jar
     And  container log should contain (main) getting-started 1.0.0-SNAPSHOT on JVM (powered by Quarkus
@@ -18,7 +18,7 @@ Feature: Openshift OpenJDK S2I tests (Quarkus-based)
     And  container log should not contain no main manifest attribute
 
   Scenario: quarkus uber-jar layout works out-of-the-box (OPENJDK-1957)
-    Given s2i build https://github.com/jboss-container-images/openjdk-test-applications from quarkus-quickstarts/getting-started-3.0.1.Final-nos2i with env
+    Given s2i build https://github.com/rh-openjdk/openjdk-container-test-applications.git from quarkus-quickstarts/getting-started-3.0.1.Final-nos2i with env
        | variable             | value    |
        | QUARKUS_PACKAGE_TYPE | uber-jar |
     Then container log should not contain INFO quarkus fast-jar package type detected

--- a/modules/s2i/core/api/tests/features/s2i-core.feature
+++ b/modules/s2i/core/api/tests/features/s2i-core.feature
@@ -5,7 +5,7 @@
 Feature: Openshift S2I tests
   # OPENJDK-84 - /tmp/src should not be present after build
   Scenario: run an s2i build and check that /tmp/src has been removed afterwards
-    Given s2i build https://github.com/jboss-container-images/openjdk-test-applications from spring-boot-sample-simple
+    Given s2i build https://github.com/rh-openjdk/openjdk-container-test-applications.git from spring-boot-sample-simple
     Then run stat /tmp/src in container and immediately check its output does not contain File:
 
   # OPENJDK-2824 - ensure binary-only s2i doesn't try to change timestamps of
@@ -13,7 +13,7 @@ Feature: Openshift S2I tests
   # will fail. This simulates the s2i process running as a random UID, which can't
   # change timestamps on the default directory, /deployments.
   Scenario: Ensure binary-only build doesn't fail trying to set timestamp of S2I_TARGET_DEPLOYMENTS_DIR (OPENJDK-2850)
-      Given s2i build https://github.com/jboss-container-images/openjdk-test-applications from OPENJDK-2408-bin-custom-s2i-assemble with env
+      Given s2i build https://github.com/rh-openjdk/openjdk-container-test-applications.git from OPENJDK-2408-bin-custom-s2i-assemble with env
        | variable                   | value |
        | S2I_TARGET_DEPLOYMENTS_DIR | /var/tmp  |
      Then s2i build log should not contain rsync: [generator] failed to set permissions on "/var/tmp/.": Operation not permitted

--- a/tests/features/java/ports.feature
+++ b/tests/features/java/ports.feature
@@ -4,7 +4,7 @@
 @ubi8/openjdk-21
 Feature: Openshift OpenJDK port tests
   Scenario: Check ports are available
-    Given s2i build https://github.com/jboss-container-images/openjdk-test-applications from undertow-servlet
+    Given s2i build https://github.com/rh-openjdk/openjdk-container-test-applications.git from undertow-servlet
     Then check that port 8080 is open
     Then check that port 8443 is open
     Then inspect container


### PR DESCRIPTION
The repository has moved.

https://issues.redhat.com/browse/OPENJDK-3434