### PR TITLE
Bump JDK11 container versions

### DIFF
--- a/ubi9-openjdk-11-runtime.yaml
+++ b/ubi9-openjdk-11-runtime.yaml
@@ -4,7 +4,7 @@ schema_version: 1
 
 from: "registry.access.redhat.com/ubi9/ubi-minimal:9.4"
 name: &name "ubi9/openjdk-11-runtime"
-version: &version "1.20"
+version: &version "1.21"
 description: "Image for Red Hat OpenShift providing OpenJDK 11 runtime"
 
 labels:

--- a/ubi9-openjdk-11.yaml
+++ b/ubi9-openjdk-11.yaml
@@ -4,7 +4,7 @@ schema_version: 1
 
 from: "registry.access.redhat.com/ubi9/ubi-minimal:9.4"
 name: &name "ubi9/openjdk-11"
-version: &version "1.20"
+version: &version "1.21"
 description: "Source To Image (S2I) image for Red Hat OpenShift providing OpenJDK 11"
 
 labels:


### PR DESCRIPTION
Omitted from last version bump. This streamlines the set.