### PR TITLE
[OPENJDK-3450] Stop using fork of behave-test-steps

### DIFF
--- a/.github/workflows/image-workflow-template.yml
+++ b/.github/workflows/image-workflow-template.yml
@@ -42,4 +42,4 @@ jobs:
       - name: Behave Tests
         run: |
           echo /home/runner/work/_temp/openshift-bin >> $GITHUB_PATH
-          cekit -v --descriptor ${{ inputs.image }}.yaml test behave --steps-url https://github.com/jmtd/behave-test-steps
+          cekit -v --descriptor ${{ inputs.image }}.yaml test behave


### PR DESCRIPTION
The changes in this fork are integrated upstream.

https://issues.redhat.com/browse/OPENJDK-3450