### PR TITLE
[OPENJDK-3453] Ensure custom s2i script is run in test

### DIFF
--- a/modules/s2i/core/tests/features/s2i-core.feature
+++ b/modules/s2i/core/tests/features/s2i-core.feature
@@ -16,4 +16,5 @@ Feature: Openshift S2I tests
        | variable                   | value |
        | S2I_TARGET_DEPLOYMENTS_DIR | /var/tmp  |
      Then s2i build log should not contain rsync: [generator] failed to set permissions on "/var/tmp/.": Operation not permitted
+     And  s2i build log should contain appsrc-provided s2i assemble script executed
      And  run stat /var/tmp/spring-boot-sample-simple-1.5.0.BUILD-SNAPSHOT.jar in container and check its output for Access:


### PR DESCRIPTION
This test is designed to run a custom s2i/assemble script provided by the application source. That script prints the string "appsrc-provided s2i assemble script executed" during execution. Expand the test to check for this string to ensure the script has been executed.


https://issues.redhat.com/browse/OPENJDK-3453