### PR TITLE
[OPENJDK-2805] Symlink /usr/libexec/s2i

### DIFF
--- a/modules/run/tests/features/java.runtime.feature
+++ b/modules/run/tests/features/java.runtime.feature
@@ -1,7 +1,7 @@
 @ubi9/openjdk-11
 @ubi9/openjdk-17
 @ubi9/openjdk-21
-Feature: Openshift OpenJDK Runtime tests (OPENJDK-474)
+Feature: Openshift OpenJDK Runtime tests (OPENJDK-474, OPENJDK-2805)
 
   Scenario: Ensure JAVA_ARGS is passed through, diagnostic options work correctly, JVM_ARGS not present in run script, OPENJDK-474 JAVA_ARGS not repeated
     Given s2i build https://github.com/rh-openjdk/openjdk-container-test-applications.git from undertow-servlet
@@ -10,5 +10,8 @@ Feature: Openshift OpenJDK Runtime tests (OPENJDK-474)
        | JAVA_DIAGNOSTICS | true   |
     Then container log should contain /deployments/undertow-servlet.jar unique
      And container log should contain -XX:NativeMemoryTracking=summary
+     And file /usr/local/s2i/run should exist
      And file /usr/local/s2i/run should not contain JVM_ARGS
+     And file /usr/libexec/s2i/run should exist
+     And file /usr/libexec/s2i/run should not contain JVM_ARGS
      And container log should not contain unique unique

--- a/modules/s2i/core/configure.sh
+++ b/modules/s2i/core/configure.sh
@@ -17,6 +17,9 @@ mkdir -p /usr/local/s2i \
  && chmod 775 /usr/local/s2i \
  && chown -R $USER:root /usr/local/s2i
 
+# OPENJDK-2805
+ln -s /usr/local/s2i /usr/libexec/s2i
+
 mkdir -p /deployments \
  && chmod -R "ug+rwX" /deployments \
  && chown -R $USER:root /deployments


### PR DESCRIPTION
The default path within images for S2I scripts is /usr/libexec/s2i. Some tools, in some circumstances, will try to execute scripts in that path. Create a symlink so they work.

For RHEL10, we'll move the scripts to that location.

https://issues.redhat.com/browse/OPENJDK-2805
