### PR TITLE
[OPENJDK-3536] temporarily disable flaky test

### DIFF
--- a/modules/jvm/tests/features/runtime.feature
+++ b/modules/jvm/tests/features/runtime.feature
@@ -52,7 +52,8 @@ Feature: Openshift OpenJDK Runtime tests
     | JAVA_APP_DIR | .      |
   Then available container log should contain INFO running in /home/default
 
-  @ubi9
+  # temporarily disabled, see https://issues.redhat.com/browse/OPENJDK-3536
+  @ignore
   Scenario: Check non-existent path JAVA_APP_DIR (OPENJDK-2034)
     Given container is started with env
     | variable     | value  |


### PR DESCRIPTION
This test seems to stall, especially for the runtime images.

https://issues.redhat.com/browse/OPENJDK-3536