### PR TITLE
Update cekit/actions-setup-cekit to v1.1.7

### DIFF
--- a/.github/workflows/image-workflow-template.yml
+++ b/.github/workflows/image-workflow-template.yml
@@ -20,7 +20,7 @@ jobs:
         run:  docker pull registry.access.redhat.com/ubi9/ubi-minimal:latest
 
       - name: Install CEKit
-        uses: cekit/actions-setup-cekit@v1.1.5
+        uses: cekit/actions-setup-cekit@v1.1.7
 
       - name: Build
         run: |


### PR DESCRIPTION
Hoping this resolves GHA failures e.g. https://github.com/rh-openjdk/redhat-openjdk-containers/actions/runs/12669650047/job/35307596061?pr=530

JIRA waiver: this change is only to the GHA configuration, not product source.