### PR TITLE
[OPENJDK-3541] Add Jmods RPM back into the UBI9/JDK21 image

### DIFF
--- a/modules/jdk/21/module.yaml
+++ b/modules/jdk/21/module.yaml
@@ -25,6 +25,7 @@ envs:
 packages:
   install:
   - java-21-openjdk-devel
+  - java-21-openjdk-jmods
 
 modules:
   install:


### PR DESCRIPTION
Addresses https://issues.redhat.com/browse/OPENJDK-3541

This adds the jmods RPM back into the UBI9/JDK21 image for the jlink-dev branch.