### PR TITLE
[OPENJDK-2994] Cleanup: Fail the build if jdeps fails

### DIFF
--- a/modules/jlink/artifacts/opt/jboss/container/java/jlink/mkdeps.sh
+++ b/modules/jlink/artifacts/opt/jboss/container/java/jlink/mkdeps.sh
@@ -21,10 +21,7 @@ function generate_deps() {
         --module-path dependencies \
         "$JAVA_APP_JAR" \
         "$JAVA_LIB_DIR"/**/*.jar \
-        > deps.txt || {
-        echo "jdeps failed: return code $?"
-        exit $?
-      }
+        > deps.txt
   else 
     $JAVA_HOME/bin/jdeps --multi-release $JAVA_VERSION -R -s \
       --module-path dependencies \

--- a/modules/s2i/bash/artifacts/usr/local/s2i/assemble
+++ b/modules/s2i/bash/artifacts/usr/local/s2i/assemble
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-set -e
+set -eo pipefail
 
 source "${JBOSS_CONTAINER_UTIL_LOGGING_MODULE}/logging.sh"
 source "${JBOSS_CONTAINER_MAVEN_S2I_MODULE}/maven-s2i"
@@ -26,18 +26,30 @@ if [ "$S2I_ENABLE_JLINK" = "true" ]; then
 
     source "${JBOSS_CONTAINER_JAVA_JLINK_MODULE}/mkdeps.sh"
     echo "Invoking mkdeps"
-    generate_deps
+    generate_deps || {
+        log_error "mkdeps failed, return code: $1"
+        exit $1
+    }
 
     source "${JBOSS_CONTAINER_JAVA_JLINK_MODULE}/mkstrippeddeps.sh"
     echo "Stripping dependencies"
-    mkstrippeddeps
+    mkstrippeddeps || {
+        log_error "stripping dependencies failed, return code: $1"
+        exit $1
+    }
 
     source "${JBOSS_CONTAINER_JAVA_JLINK_MODULE}/generatejdkdeps.sh"
     echo "Generating JDK dependencies"
-    generatejdkdeps
+    generatejdkdeps || {
+        log_error "generating JDK dependencies failed, return code: $1"
+        exit $1
+    }
 
     source "${JBOSS_CONTAINER_JAVA_JLINK_MODULE}/mkjreimage.sh"
     echo "Linking jre"
-    generate_jre_image
+    generate_jre_image || {
+        log_error "Linking JRE failed, return code: $1"
+        exit $1
+    }
 
 fi

--- a/modules/s2i/bash/artifacts/usr/local/s2i/assemble
+++ b/modules/s2i/bash/artifacts/usr/local/s2i/assemble
@@ -28,29 +28,29 @@ if [ "$S2I_ENABLE_JLINK" = "true" ]; then
     source "${JBOSS_CONTAINER_JAVA_JLINK_MODULE}/mkdeps.sh"
     echo "Invoking mkdeps"
     generate_deps || {
-        log_error "mkdeps failed, return code: $1"
-        exit $1
+        log_error "mkdeps failed, return code: $?"
+        exit 1
     }
 
     source "${JBOSS_CONTAINER_JAVA_JLINK_MODULE}/mkstrippeddeps.sh"
     echo "Stripping dependencies"
     mkstrippeddeps || {
-        log_error "stripping dependencies failed, return code: $1"
-        exit $1
+        log_error "stripping dependencies failed, return code: $?"
+        exit 1
     }
 
     source "${JBOSS_CONTAINER_JAVA_JLINK_MODULE}/generatejdkdeps.sh"
     echo "Generating JDK dependencies"
     generatejdkdeps || {
-        log_error "generating JDK dependencies failed, return code: $1"
-        exit $1
+        log_error "generating JDK dependencies failed, return code: $?"
+        exit 1
     }
 
     source "${JBOSS_CONTAINER_JAVA_JLINK_MODULE}/mkjreimage.sh"
     echo "Linking jre"
     generate_jre_image || {
-        log_error "Linking JRE failed, return code: $1"
-        exit $1
+        log_error "Linking JRE failed, return code: $?"
+        exit 1
     }
 
 fi


### PR DESCRIPTION
Addresses https://issues.redhat.com/browse/OPENJDK-2994

This adds some error checking to the s2i assemble script to make sure if any of the subcommands fail (mkdeps, mkstrippeddeps, etc) that the error is communicated and the build fails.

Requires https://github.com/rh-openjdk/redhat-openjdk-containers/pull/535 for manual testing with 21

To test:

Add the following to generate_deps or find an application that otherwise causes jdeps to fail:

```
--- a/modules/jlink/artifacts/opt/jboss/container/java/jlink/mkdeps.sh
+++ b/modules/jlink/artifacts/opt/jboss/container/java/jlink/mkdeps.sh
@@ -3,6 +3,8 @@ set -euo pipefail
 shopt -s globstar
 
 function generate_deps() {
+  echo "I'm going to exit now. Bye!"
+  exit 1
   # Create a temporary directory for a module path
```

Build the image
```
cekit --descriptor ubi9-openjdk-21.yaml build podman
```
Run an S2i build:
```
 s2i build --pull-policy if-not-present --context-dir=getting-started -e S2I_DELETE_SOURCE=false  -e LOGGING_SCRIPT_DEBUG=true -e S2I_ENABLE_JLINK=true -e QUARKUS_PACKAGE_TYPE=uber-jar https://github.com/quarkusio/quarkus-quickstarts.git localhost/ubi9/openjdk-21:latest jlink-appsrc
```
The build will hit the generate_deps failure and exit after that point.