### PR TITLE
[OPENJDK-3597] test for MAVEN_SETTINGS_XML

### DIFF
--- a/modules/maven/s2i/tests/features/java_s2i.feature
+++ b/modules/maven/s2i/tests/features/java_s2i.feature
@@ -175,6 +175,17 @@ Feature: Openshift OpenJDK S2I tests
        | variable           | value    |
        | MAVEN_ARGS         | validate |
 
+  Scenario: Ensure no custom settings.xml fails for specific application (OPENJDK-3597)
+      Given failing s2i build https://github.com/rh-openjdk/openjdk-container-test-applications.git from OPENJDK-3597-custom-settings-xml using master
+      Then s2i build log should contain [ERROR] Profile "testCustomProfile" is not activated
+
+  Scenario: Ensure custom settings.xml copied in via MAVEN_SETTINGS_XML (OPENJDK-3597)
+      Given s2i build https://github.com/rh-openjdk/openjdk-container-test-applications.git from OPENJDK-3597-custom-settings-xml with env
+       | variable           | value                 |
+       | MAVEN_ARGS         | validate              |
+       | MAVEN_SETTINGS_XML | /tmp/src/settings.xml |
+      Then s2i build log should contain Rule 0: org.apache.maven.enforcer.rules.RequireActiveProfile passed
+
   Scenario: Ensure that run-env.sh placed in the JAVA_APP_DIR is sourced in the run script before launching java
       Given s2i build https://github.com/rh-openjdk/openjdk-container-test-applications.git from quarkus-quickstarts/getting-started-3.0.1.Final-nos2i
        | variable            | value        |


### PR DESCRIPTION
This test checks a custom test application source to ensure that a custom settings.xml, which defines a custom profile, has been activated.

https://issues.redhat.com/browse/OPENJDK-3597

Note: once https://github.com/rh-openjdk/openjdk-container-test-applications/pull/7 is merged, this could be rebased to reference `rh-openjdk` instead of the `jmtd` fork.

Also note: the S2I tests are tagged `@ignore` which prevents their execution on GHA; to run them manually, one has to remove or comment out `@ignore` at the top of the file, and most likely add `@wip` to each of them, in order to select them wtih `cekit … test behave --wip`.