### PR TITLE
[OPENJDK-3379] use a consistent app label across OpenShift objects

### DIFF
--- a/templates/jlink/jlinked-app.yaml
+++ b/templates/jlink/jlinked-app.yaml
@@ -42,6 +42,9 @@ objects:
   kind: ImageStream
   metadata:
     name: ${APPNAME}-ubi9-openjdk-${JDK_VERSION}-jlink
+    labels:
+      app: ${APPNAME}
+      app.kubernetes.io/part-of: ${APPNAME}
   spec:
     lookupPolicy:
       local: false
@@ -52,7 +55,8 @@ objects:
   metadata: 
     name: ${APPNAME}-jlink-builder-jdk-${JDK_VERSION}
     labels:
-      app: ${APPNAME}-jlink-builder-jdk-${JDK_VERSION}
+      app: ${APPNAME}
+      app.kubernetes.io/part-of: ${APPNAME}
   spec:
     source:
       dockerfile: |
@@ -102,7 +106,8 @@ objects:
   metadata:
     name: ${APPNAME}-jlink-s2i-jdk-${JDK_VERSION}
     labels:
-      app: ${APPNAME}-jlink-s2i-jdk-${JDK_VERSION}
+      app: ${APPNAME}
+      app.kubernetes.io/part-of: ${APPNAME}
   spec:
     source:
       type: Git
@@ -142,6 +147,9 @@ objects:
   kind: ImageStream
   metadata:
     name: ${APPNAME}-ubimicro
+    labels:
+      app: ${APPNAME}
+      app.kubernetes.io/part-of: ${APPNAME}
   spec:
     lookupPolicy:
       local: true
@@ -158,6 +166,9 @@ objects:
   kind: ImageStream
   metadata:
     name: ${APPNAME}-lightweight-image
+    labels:
+      app: ${APPNAME}
+      app.kubernetes.io/part-of: ${APPNAME}
   spec:
     lookupPolicy:
       local: false
@@ -167,6 +178,9 @@ objects:
   kind: BuildConfig
   metadata: 
     name: ${APPNAME}-multistage-buildconfig
+    labels:
+      app: ${APPNAME}
+      app.kubernetes.io/part-of: ${APPNAME}
   spec:
     source:
       images:


### PR DESCRIPTION
Resolves https://issues.redhat.com/browse/OPENJDK-3379

Splitting this out from https://github.com/rh-openjdk/redhat-openjdk-containers/pull/514

This adds a consistent label ($APPNAME) to the created openshift objects, allowing for easy filtering/deletion.