### PR TITLE
[OPENJDK-3637] clean up correct hsperfdata path

### DIFF
--- a/modules/maven/s2i/artifacts/opt/jboss/container/maven/s2i/maven-s2i
+++ b/modules/maven/s2i/artifacts/opt/jboss/container/maven/s2i/maven-s2i
@@ -76,7 +76,7 @@ function maven_s2i_build() {
   s2i_core_cleanup
 
   # Remove java tmp perf data dir owned by 185
-  rm -rf /tmp/hsperfdata_jboss
+  rm -rf "/tmp/hsperfdata_${USER}"
 }
 
 # perform a maven build, i.e.  mvn ...


### PR DESCRIPTION
The hsperfdata path is determined by the running user's username. This is no longer "jboss", but "default". Use "${USER}" so that we catch any future changes in username.

----

https://issues.redhat.com/browse/OPENJDK-3637

----

This is quite hard to write a Behave test for. We need to perform an S2I build that invokes maven, which in turn invokes java, to create a `hsperfdata` directory. Then, we need to start a new container instance from the output of S2I, but override CMD so that the payload (java) doesn't start (which would create it's own `hsperfdata`), in order to test for its presence or absence. There aren't the right steps in https://github.com/cekit/behave-test-steps to pull this off. I started writingt some but they'll take some work to get right.