### PR TITLE
[OPENJDK-3654] Remove superseded assemble script

### DIFF
--- a/modules/maven/s2i/artifacts/usr/local/s2i/assemble
+++ b/modules/maven/s2i/artifacts/usr/local/s2i/assemble
@@ -1,9 +1,0 @@
-#!/bin/sh
-
-set -e
-
-source "${JBOSS_CONTAINER_UTIL_LOGGING_MODULE}/logging.sh"
-source "${JBOSS_CONTAINER_MAVEN_S2I_MODULE}/maven-s2i"
-
-# invoke the build
-maven_s2i_build


### PR DESCRIPTION
This script is overwritten by another later in the build stage for all our images. The "winning" script is
"modules/s2i/bash/artifacts/usr/libexec/s2i/assemble".
https://issues.redhat.com/browse/OPENJDK-3654
