### PR TITLE
[OPENJDK-3652] don't try to set alternatives for JDK

### DIFF
--- a/modules/jdk/21/configure.sh
+++ b/modules/jdk/21/configure.sh
@@ -13,13 +13,6 @@ pushd ${ARTIFACTS_DIR}
 cp -pr * /
 popd
 
-# Set this JDK as the alternative in use
-_arch="$(uname -i)"
-alternatives --set java java-21-openjdk.${_arch}
-alternatives --set javac java-21-openjdk.${_arch}
-alternatives --set java_sdk_openjdk java-21-openjdk.${_arch}
-alternatives --set jre_openjdk java-21-openjdk.${_arch}
-
 # Update securerandom.source for quicker starts (must be done after removing jdk 8, or it will hit the wrong files)
 JAVA_SECURITY_FILE=/usr/lib/jvm/java/conf/security/java.security
 SECURERANDOM=securerandom.source


### PR DESCRIPTION
The exact invocation has changed for RHEL10. This no longer works:

    alternatives --set java java-21-openjdk.${_arch}

This works, but doesn't in earlier RHELs:

    alternatives --set java /usr/lib/jvm/java-21-openjdk/bin/java

Some background in RHEL-68848

However, there is only one JDK in RHEL10 at the moment anyway, so simply avoid adjusting alternatives.

https://issues.redhat.com/browse/OPENJDK-3652