### PR TITLE
[OPENJDK-3634] update image name in jlink template

### DIFF
--- a/templates/jlink/README.md
+++ b/templates/jlink/README.md
@@ -16,11 +16,11 @@ prepare UBI9 OpenJDK ImageStreams with `jlink-dev` support.
    repository](https://github.com/jboss-container-images/openjdk),
    branch `jlink-dev`. e.g.
 
-        cekit --descriptor ubi9-openjdk-17.yaml build docker
+        cekit --descriptor ubi9-openjdk-21.yaml build docker
 
 2. Within your OpenShift project,
 
-        oc create imagestream ubi9-openjdk-17
+        oc create imagestream ubi9-openjdk-21-jlink-tech-preview
 
 3. You may need to configure your container engine to not TLS-verify the OpenShift
    registry. For Docker, add the following to `/etc/docker/daemon.json` and restart
@@ -37,8 +37,8 @@ prepare UBI9 OpenJDK ImageStreams with `jlink-dev` support.
 5. tag and push the dev image into it. The OpenShift console gives you the
    exact URI for your instance
 
-        docker tag ubi9/openjdk-17:1.18 default-route-openshift-image-registry.apps-crc.testing/jlink1/ubi9-openjdk-17:1.18
-        docker push default-route-openshift-image-registry.apps-crc.testing/jlink1/ubi9-openjdk-17:1.18
+        docker tag openjdk-tech-preview/openjdk-21-jlink-rhel9:1.18 default-route-openshift-image-registry.apps-crc.testing/jlink1/ubi9-openjdk-21-jlink-tech-preview:1.18
+        docker push default-route-openshift-image-registry.apps-crc.testing/jlink1/ubi9-openjdk-21:1.18
 
 ## Stage 1: Load the template into OpenShift and instantiate it
 
@@ -52,14 +52,14 @@ Process it to create the needed objects. You can list the parameters using
 
 Some suitable test values for the parameters are
 
- * JDK_VERSION: 17
+ * JDK_VERSION: 21
  * APP_URI: https://github.com/jboss-container-images/openjdk-test-applications
  * REF: master
  * CONTEXT_DIR: quarkus-quickstarts/getting-started-3.9.2-uberjar
  * APPNAME: quarkus-quickstart
 
         oc process \
-            -p JDK_VERSION=17 \
+            -p JDK_VERSION=21 \
             -p APP_URI=https://github.com/jboss-container-images/openjdk-test-applications \
             -p REF=master \
             -p CONTEXT_DIR=quarkus-quickstarts/getting-started-3.9.2-uberjar \
@@ -77,8 +77,8 @@ See all the OpenShift objects that were created:
 
 There will be three BuildConfigs, called something like
 
-1. jlink-builder-jdk-17
-2. jlink-s2i-jdk-17
+1. jlink-builder-jdk-21
+2. jlink-s2i-jdk-21
 3. multistage-buildconfig
 
 Start a build for (1). Once complete, builds for (2) and (3) should be

--- a/templates/jlink/README.md
+++ b/templates/jlink/README.md
@@ -20,7 +20,7 @@ prepare UBI9 OpenJDK ImageStreams with `jlink-dev` support.
 
 2. Within your OpenShift project,
 
-        oc create imagestream ubi9-openjdk-21-jlink-tech-preview
+        oc create imagestream openjdk-${JDK_VERSION}-jlink-tech-preview
 
 3. You may need to configure your container engine to not TLS-verify the OpenShift
    registry. For Docker, add the following to `/etc/docker/daemon.json` and restart
@@ -37,8 +37,8 @@ prepare UBI9 OpenJDK ImageStreams with `jlink-dev` support.
 5. tag and push the dev image into it. The OpenShift console gives you the
    exact URI for your instance
 
-        docker tag openjdk-tech-preview/openjdk-21-jlink-rhel9:latest default-route-openshift-image-registry.apps-crc.testing/jlink1/ubi9-openjdk-21-jlink-tech-preview:latest
-        docker push default-route-openshift-image-registry.apps-crc.testing/jlink1/ubi9-openjdk-21:latest
+        docker tag openjdk-tech-preview/openjdk-21-jlink-rhel9:latest default-route-openshift-image-registry.apps-crc.testing/jlink1/openjdk-21-jlink-tech-preview:latest
+        docker push default-route-openshift-image-registry.apps-crc.testing/jlink1/openjdk-21-jlink-tech-preview:latest
 
 ## Stage 1: Load the template into OpenShift and instantiate it
 

--- a/templates/jlink/README.md
+++ b/templates/jlink/README.md
@@ -37,8 +37,8 @@ prepare UBI9 OpenJDK ImageStreams with `jlink-dev` support.
 5. tag and push the dev image into it. The OpenShift console gives you the
    exact URI for your instance
 
-        docker tag openjdk-tech-preview/openjdk-21-jlink-rhel9:1.18 default-route-openshift-image-registry.apps-crc.testing/jlink1/ubi9-openjdk-21-jlink-tech-preview:1.18
-        docker push default-route-openshift-image-registry.apps-crc.testing/jlink1/ubi9-openjdk-21:1.18
+        docker tag openjdk-tech-preview/openjdk-21-jlink-rhel9:latest default-route-openshift-image-registry.apps-crc.testing/jlink1/ubi9-openjdk-21-jlink-tech-preview:latest
+        docker push default-route-openshift-image-registry.apps-crc.testing/jlink1/ubi9-openjdk-21:latest
 
 ## Stage 1: Load the template into OpenShift and instantiate it
 
@@ -77,16 +77,18 @@ See all the OpenShift objects that were created:
 
 There will be three BuildConfigs, called something like
 
-1. jlink-builder-jdk-21
-2. jlink-s2i-jdk-21
-3. multistage-buildconfig
+1. $APPNAME-jlink-builder-jdk-21
+2. $APPNAME-jlink-s2i-jdk-21
+3. $APPNAME-multistage-buildconfig
+
+Where $APPNAME is the parameter initially passed to the template.
 
 Start a build for (1). Once complete, builds for (2) and (3) should be
 automatically triggered in sequence.
 
 ## Stage 4: create deployment
 
-The ImageStreamTag `lightweight-image:latest` will be populated with the new
+The ImageStreamTag `$APPNAME-lightweight-image:latest` will be populated with the new
 application container image.
 
 Create a deployment to see it work. E.g., in the Developer Perspective, select

--- a/templates/jlink/jlinked-app.yaml
+++ b/templates/jlink/jlinked-app.yaml
@@ -41,7 +41,7 @@ objects:
 - apiVersion: image.openshift.io/v1
   kind: ImageStream
   metadata:
-    name: ${APPNAME}-ubi9-openjdk-${JDK_VERSION}-jlink
+    name: ${APPNAME}-openjdk-${JDK_VERSION}-jlink-tech-preview
     labels:
       app: ${APPNAME}
       app.kubernetes.io/part-of: ${APPNAME}
@@ -78,18 +78,18 @@ objects:
       dockerStrategy:
         from: 
           kind: ImageStreamTag
-          name: ubi9-openjdk-${JDK_VERSION}:${BUILDER_IMAGE_TAG}  # Refer README.md to create this ImageStream
+          name: openjdk-${JDK_VERSION}-jlink-tech-preview:${BUILDER_IMAGE_TAG}  # Refer README.md to create this ImageStream
     output:
       to:
         kind: ImageStreamTag
-        name: ${APPNAME}-ubi9-openjdk-${JDK_VERSION}-jlink:latest
+        name: ${APPNAME}-openjdk-${JDK_VERSION}-jlink-tech-preview:latest
     triggers:
       - type: ConfigChange
       - type: ImageChange
         imageChange:
           from:
             kind: ImageStreamTag
-            name: ubi9-openjdk-${JDK_VERSION}:${BUILDER_IMAGE_TAG}
+            name: openjdk-${JDK_VERSION}-jlink-tech-preview:${BUILDER_IMAGE_TAG}
 ##############################################################################
 # stage-2: Output ImageStream
 - apiVersion: image.openshift.io/v1
@@ -119,7 +119,7 @@ objects:
       sourceStrategy:
         from:
           kind: ImageStreamTag
-          name: ${APPNAME}-ubi9-openjdk-${JDK_VERSION}-jlink:latest # Output Imagestream from stage-1
+          name: ${APPNAME}-openjdk-${JDK_VERSION}-jlink-tech-preview:latest # Output Imagestream from stage-1
           pullPolicy: Always
         env:
           - name: S2I_ENABLE_JLINK
@@ -136,7 +136,7 @@ objects:
         imageChange:
           from:
             kind: ImageStreamTag
-            name: ${APPNAME}-ubi9-openjdk-${JDK_VERSION}-jlink:latest  # Output of stage-1 which serves as input to stage-2
+            name: ${APPNAME}-openjdk-${JDK_VERSION}-jlink-tech-preview:latest  # Output of stage-1 which serves as input to stage-2
       - type: GitHub
         github:
           secret: ${GITHUB_WEBHOOK_SECRET}


### PR DESCRIPTION
Addresses https://issues.redhat.com/browse/OPENJDK-3634

Brings over the work done in https://github.com/rh-openjdk/redhat-openjdk-containers/pull/514/commits/884c6212c36324118dc8198572917fe2175cec11 , Updates the image name in jlink template to reflect it's tech-preview status and the new name of the jlink container. Also bumps up the recommended/example JDK version to 21.

