### PR TITLE
OPENJDK-3650 centos streams

### DIFF
--- a/.github/workflows/image-workflow-template.yml
+++ b/.github/workflows/image-workflow-template.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Verify latest UBI image is present
-        run:  docker pull registry.access.redhat.com/ubi9/ubi-minimal:latest
+        run:  docker pull quay.io/centos/centos:stream10-minimal
 
       - name: Install CEKit
         uses: cekit/actions-setup-cekit@v1.1.7

--- a/ubi10-openjdk-21-runtime.yaml
+++ b/ubi10-openjdk-21-runtime.yaml
@@ -2,7 +2,7 @@
 
 schema_version: 1
 
-from: "registry.access.redhat.com/ubi9/ubi-minimal"
+from: "quay.io/centos/centos:stream10-minimal"
 name: &name "ubi10/openjdk-21-runtime"
 version: &version "1.21"
 description: "Image for Red Hat OpenShift providing OpenJDK 21 runtime"

--- a/ubi10-openjdk-21.yaml
+++ b/ubi10-openjdk-21.yaml
@@ -2,7 +2,7 @@
 
 schema_version: 1
 
-from: "registry.access.redhat.com/ubi9/ubi-minimal"
+from: "quay.io/centos/centos:stream10-minimal"
 name: &name "ubi10/openjdk-21"
 version: &version "1.21"
 description: "Source To Image (S2I) image for Red Hat OpenShift providing OpenJDK 21"


### PR DESCRIPTION
This allows us to work close to RHEL cutting edge (whereas RHEL 10 beta is frozen in time) and to work in public, with e.g. GHA able to build and (behave) test images.

https://issues.redhat.com/browse/OPENJDK-3650