### PR TITLE
[OPENJDK-3661] don't set alternatives for runtime images

### DIFF
--- a/modules/jre/21/configure.sh
+++ b/modules/jre/21/configure.sh
@@ -14,7 +14,3 @@ chmod ug+x ${ARTIFACTS_DIR}/opt/jboss/container/openjdk/jre/*
 pushd ${ARTIFACTS_DIR}
 cp -pr * /
 popd
-
-# Set this JDK as the alternative in use
-_arch="$(uname -i)"
-alternatives --set java java-21-openjdk.${_arch}


### PR DESCRIPTION
The method for setting alternatives in RHEL10 has changed (see RHEL-80074) but we don't (currently) need to set them anyway.
https://issues.redhat.com/browse/OPENJDK-3661