### PR TITLE
[OPENJDK-2815] stop creating '*' symlink

### DIFF
--- a/modules/maven/default/configure.sh
+++ b/modules/maven/default/configure.sh
@@ -15,12 +15,6 @@ pushd ${ARTIFACTS_DIR}
 cp -pr * /
 popd
 
-MAVEN_VERSION_SQUASHED=${MAVEN_VERSION/./}
-
-# pull in specific maven version to serve as default
-ln -s /opt/jboss/container/maven/${MAVEN_VERSION_SQUASHED}/* /opt/jboss/container/maven/default
-chown -h $USER:root /opt/jboss/container/maven/default/*
-
 # install default settings.xml file in user home
 mkdir -p $HOME/.m2
 ln -s /opt/jboss/container/maven/default/jboss-settings.xml $HOME/.m2/settings.xml


### PR DESCRIPTION
This was an attempt at creating a fixed path irrespective of Maven version but it has never worked, and instead it created a symlink with the basename '*'.

https://issues.redhat.com/browse/OPENJDK-2815
