### PR TITLE
[OPENJDK-3647] adjust jlink  tests

### DIFF
--- a/modules/jlink/tests/features/jlink.feature
+++ b/modules/jlink/tests/features/jlink.feature
@@ -1,21 +1,20 @@
-@ubi9/openjdk-17
 @openjdk-tech-preview/openjdk-21-jlink-rhel9
 Feature: Openshift OpenJDK S2I tests (jlink specific)
 
   Scenario: tech preview warning is printed (OPENJDK-3038)
-      Given failing s2i build https://github.com/jboss-container-images/openjdk-test-applications from spring-boot-sample-simple/target using master
+    Given s2i build https://github.com/rh-openjdk/openjdk-container-test-applications from spring-boot-sample-simple/target using master
        | variable            | value        |
        | S2I_ENABLE_JLINK    | true         |
       Then s2i build log should contain Jlink integration is a Tech Preview feature
 
 Scenario: Ensure S2I_ENABLE_JLINK is not set to true
-      Given s2i build https://github.com/jboss-container-images/openjdk-test-applications from quarkus-quickstarts/getting-started-3.0.1.Final-nos2i
-      Then container log should not contain S2I_ENABLE_JLINK=true
-      And run bash -c "test ! -d /tmp/jre && echo PASS" in container and immediately check its output for PASS
+    Given s2i build https://github.com/rh-openjdk/openjdk-container-test-applications from spring-boot-sample-simple/target using master
+     Then s2i build log should not contain Jlink integration is a Tech Preview feature
+      And file /tmp/jre should not exist
 
 Scenario: Check that /tmp/jre/bin/java and /tmp/jre/lib/modules exist post s2i build if jlink is enabled.
-      Given s2i build https://github.com/jboss-container-images/openjdk-test-applications from quarkus-quickstarts/getting-started-3.9.2-uberjar
+    Given s2i build https://github.com/rh-openjdk/openjdk-container-test-applications from quarkus-quickstarts/getting-started-3.9.2-uberjar
        | variable            | value        |
        | S2I_ENABLE_JLINK    | true         |
-      Then container log should contain S2I_ENABLE_JLINK=true
-      and run bash -c "test -d /tmp/jre/bin/java && test -d /tmp/jre/lib/modules && echo PASS" in container and immediately check its output for PASS
+      Then file /tmp/jre/bin/java should exist and be a file
+       And file /tmp/jre/lib/modules should exist and be a file


### PR DESCRIPTION
Some behavioural change (S2I_ENABLE_JLINK is not echoed in the logs); fix syntax of final test; adjust approach used to check for the presence or absence of files and directories.

https://issues.redhat.com/browse/OPENJDK-3647