### PR TITLE
[OPENJDK-3645] Remove jmods rpm installation from stage 1

### DIFF
--- a/templates/jlink/jlinked-app.yaml
+++ b/templates/jlink/jlinked-app.yaml
@@ -71,7 +71,6 @@ objects:
         FROM -
         RUN if [ ! -f "/opt/jboss/container/java/jlink/preflight.sh" ]; then echo "jlink scripts doesn't exist" 2>&1; exit 1; fi
         USER 0
-        RUN microdnf --setopt=install_weak_deps=0 --setopt=tsflags=nodocs install -y java-${JDK_VERSION}-openjdk-jmods
         RUN mkdir -p /mnt/jrootfs
         RUN microdnf install --installroot /mnt/jrootfs --releasever 9 --setopt install_weak_deps=0 --nodocs -y \
         --config=/etc/dnf/dnf.conf \


### PR DESCRIPTION
Fixes https://issues.redhat.com/browse/OPENJDK-3645

Removes the installation of the jmods rpm from stage 1 of the jlink build. Since it's already installed in the tech-preview image it's no longer needed here and can be safely removed.

To test:

- Build the tech preview image
```
cekit --descriptor ubi9-openjdk-21.yaml build podman
```
- Set up a new Openshift Project
```
oc new-project jlink-dev
oc project jlink-dev
oc create imagestream openjdk-21-jlink-tech-preview
```
- Push the tech preview images to the created imagestream
```
podman tag openjdk-tech-preview/openjdk-21-jlink-rhel9:latest default-route-openshift-image-registry.apps-crc.testing/jlink-dev/openjdk-21-jlink-tech-preview:latest
        podman push default-route-openshift-image-registry.apps-crc.testing/jlink-dev/openjdk-21-jlink-tech-preview:latest
```
- Run the template and observe the builds
```
oc create -f templates/jlink/jlinked-app.yaml
oc process -n jlink -f templates/jlink/jlinked-app.yaml -p APP_URI=https://github.com/jboss-container-images/openjdk-test-applications -p JDK_VERSION=21 -p REF=master -p CONTEXT_DIR=quarkus-quickstarts/getting-started-3.9.2-uberjar -p TARGET_PORT=8080 -p SERVICE_PORT=8080 -p APPNAME=quarkus-3645 | oc create -f -
```
- Check the logs of quarkus-3645-jlink-builder-jdk-21-1, the jmods rpm should not be pulled in.