### PR TITLE
[OPENJDK-3646] clean up jdeps *.txt files unless S2I_DELETE_SOURCE is set

### DIFF
--- a/modules/jlink/artifacts/opt/jboss/container/java/jlink/generatejdkdeps.sh
+++ b/modules/jlink/artifacts/opt/jboss/container/java/jlink/generatejdkdeps.sh
@@ -2,8 +2,8 @@
 
 function generatejdkdeps() {
   echo "Generating JDK deps"
-  $JAVA_HOME/bin/java --list-modules > java-modules.txt
-  < java-modules.txt sed "s/\\@.*//" > modules.txt
-  grep -Fx -f stripped-deps.txt modules.txt | tr '\n' ',' | tr -d "[:space:]" > module-deps.txt
-  echo "jdk.zipfs" >> module-deps.txt
+  $JAVA_HOME/bin/java --list-modules > $S2I_JLINK_TEMP_PATH/java-modules.txt
+  < $S2I_JLINK_TEMP_PATH/java-modules.txt sed "s/\\@.*//" > $S2I_JLINK_TEMP_PATH/modules.txt
+  grep -Fx -f $S2I_JLINK_TEMP_PATH/stripped-deps.txt $S2I_JLINK_TEMP_PATH/modules.txt | tr '\n' ',' | tr -d "[:space:]" > $S2I_JLINK_TEMP_PATH/module-deps.txt
+  echo "jdk.zipfs" >> $S2I_JLINK_TEMP_PATH/module-deps.txt
 }

--- a/modules/jlink/artifacts/opt/jboss/container/java/jlink/mkdeps.sh
+++ b/modules/jlink/artifacts/opt/jboss/container/java/jlink/mkdeps.sh
@@ -21,12 +21,12 @@ function generate_deps() {
         --module-path dependencies \
         "$JAVA_APP_JAR" \
         "$JAVA_LIB_DIR"/**/*.jar \
-        > deps.txt
+        > $S2I_JLINK_TEMP_PATH/deps.txt
   else 
     $JAVA_HOME/bin/jdeps --multi-release $JAVA_VERSION -R -s \
       --module-path dependencies \
       "$JAVA_APP_JAR" \
-      > deps.txt
-    cat deps.txt
+      > $S2I_JLINK_TEMP_PATH/deps.txt
+    cat $S2I_JLINK_TEMP_PATH/deps.txt
   fi
 }

--- a/modules/jlink/artifacts/opt/jboss/container/java/jlink/mkjreimage.sh
+++ b/modules/jlink/artifacts/opt/jboss/container/java/jlink/mkjreimage.sh
@@ -2,7 +2,7 @@
 # TODO: Still Needed?
 set -euo pipefail
 
-depsfile="module-deps.txt"
+depsfile="$S2I_JLINK_TEMP_PATH/module-deps.txt"
 
 function generate_jre_image() {
 	test -f $depsfile

--- a/modules/jlink/artifacts/opt/jboss/container/java/jlink/mkstrippeddeps.sh
+++ b/modules/jlink/artifacts/opt/jboss/container/java/jlink/mkstrippeddeps.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 function mkstrippeddeps() {
-  if [ -f "deps.txt" ]; then 
+  if [ -f "$S2I_JLINK_TEMP_PATH/deps.txt" ]; then 
     echo "deps exists, filtering"
     <deps.txt \
       grep 'java\|jdk\.'  | # mostly removes target/, but also jdk8internals
@@ -11,7 +11,7 @@ function mkstrippeddeps() {
       sed -E "s/.*\.jar//" | # remove extraneous dependencies
       sed "s#/.*##"       | # delete anything after a slash. in practice target/..
       sort | uniq |
-      tee stripped-deps.txt
+      tee $S2I_JLINK_TEMP_PATH/stripped-deps.txt
     echo "Stripping dependencies complete"
   else
     echo "deps does not exist"

--- a/modules/jlink/artifacts/opt/jboss/container/java/jlink/mkstrippeddeps.sh
+++ b/modules/jlink/artifacts/opt/jboss/container/java/jlink/mkstrippeddeps.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 function mkstrippeddeps() {
   if [ -f "$S2I_JLINK_TEMP_PATH/deps.txt" ]; then 
     echo "deps exists, filtering"
-    <deps.txt \
+    < $S2I_JLINK_TEMP_PATH/deps.txt \
       grep 'java\|jdk\.'  | # mostly removes target/, but also jdk8internals
       sed -E "s/Warning: .*//" | #remove extraneous warnings
       sed -E "s/.*-> //"  | # remove src of src -> dep

--- a/modules/jlink/module.yaml
+++ b/modules/jlink/module.yaml
@@ -14,6 +14,8 @@ envs:
   value: /opt/jboss/container/java/jlink
 - name: S2I_JLINK_OUTPUT_PATH
   value: /tmp/jre
+- name: S2I_JLINK_TEMP_PATH
+  value: /tmp/jlink
 
 modules:
   install: 

--- a/modules/jlink/tests/features/jlink.feature
+++ b/modules/jlink/tests/features/jlink.feature
@@ -18,3 +18,11 @@ Scenario: Check that /tmp/jre/bin/java and /tmp/jre/lib/modules exist post s2i b
        | S2I_ENABLE_JLINK    | true         |
       Then file /tmp/jre/bin/java should exist and be a file
        And file /tmp/jre/lib/modules should exist and be a file
+
+Scenario: Check that /tmp/jlink is deleted when S2I_DELETE_SOURCE is set
+    Given s2i build https://github.com/rh-openjdk/openjdk-container-test-applications from quarkus-quickstarts/getting-started-3.9.2-uberjar
+       | variable            | value        |
+       | S2I_ENABLE_JLINK    | true         |
+       | S2I_DELETE_SOURCE   | true         |
+      Then s2i build log should contain Cleaning up temporary file directory /tmp/jlink
+       And file /tmp/jlink should not exist

--- a/modules/jlink/tests/features/jlink.feature
+++ b/modules/jlink/tests/features/jlink.feature
@@ -26,3 +26,11 @@ Scenario: Check that /tmp/jlink is deleted when S2I_DELETE_SOURCE is set
        | S2I_DELETE_SOURCE   | true         |
       Then s2i build log should contain Cleaning up temporary file directory /tmp/jlink
        And file /tmp/jlink should not exist
+
+Scenario: Check that /tmp/jlink is not deleted when S2I_DELETE_SOURCE is set to false
+    Given s2i build https://github.com/rh-openjdk/openjdk-container-test-applications from quarkus-quickstarts/getting-started-3.9.2-uberjar
+       | variable            | value        |
+       | S2I_ENABLE_JLINK    | true         |
+       | S2I_DELETE_SOURCE   | false         |
+      Then s2i build log should not contain Cleaning up temporary file directory /tmp/jlink
+       And file /tmp/jlink should exist

--- a/modules/s2i/bash/artifacts/usr/local/s2i/assemble
+++ b/modules/s2i/bash/artifacts/usr/local/s2i/assemble
@@ -29,7 +29,7 @@ if [ "$S2I_ENABLE_JLINK" = "true" ]; then
         log_info "S2I_JLINK_TEMP_PATH does not exist, creating ${S2I_JLINK_TEMP_PATH}"
         mkdir -pm 775 "${S2I_JLINK_TEMP_PATH}"
     fi
-    
+
     source "${JBOSS_CONTAINER_JAVA_JLINK_MODULE}/mkdeps.sh"
     echo "Invoking mkdeps"
     generate_deps || {
@@ -61,8 +61,8 @@ if [ "$S2I_ENABLE_JLINK" = "true" ]; then
 fi
 
 if [ "$S2I_DELETE_SOURCE" == "true" ]; then
-  if [ -n "$(find /tmp/jlink -maxdepth 0 -type d ! -empty 2> /dev/null)" ]; then
-    log_info "Cleaning up temporary file directory /tmp/jlink"
-    rm -rf /tmp/jlink
+  if [ -n "$(find $S2I_JLINK_TEMP_PATH -maxdepth 0 -type d ! -empty 2> /dev/null)" ]; then
+    log_info "Cleaning up temporary file directory $S2I_JLINK_TEMP_PATH"
+    rm -rf $S2I_JLINK_TEMP_PATH
   fi
 fi

--- a/modules/s2i/bash/artifacts/usr/local/s2i/assemble
+++ b/modules/s2i/bash/artifacts/usr/local/s2i/assemble
@@ -25,6 +25,11 @@ if [ "$S2I_ENABLE_JLINK" = "true" ]; then
     jlink_techpreview_warning
     jlink_preflight_check
 
+    if [ ! -d "${S2I_JLINK_TEMP_PATH}" ]; then
+        log_info "S2I_JLINK_TEMP_PATH does not exist, creating ${S2I_JLINK_TEMP_PATH}"
+        mkdir -pm 775 "${S2I_JLINK_TEMP_PATH}"
+    fi
+    
     source "${JBOSS_CONTAINER_JAVA_JLINK_MODULE}/mkdeps.sh"
     echo "Invoking mkdeps"
     generate_deps || {
@@ -53,4 +58,11 @@ if [ "$S2I_ENABLE_JLINK" = "true" ]; then
         exit 1
     }
 
+fi
+
+if [ "$S2I_DELETE_SOURCE" == "true" ]; then
+  if [ -n "$(find /tmp/jlink -maxdepth 0 -type d ! -empty 2> /dev/null)" ]; then
+    log_info "Cleaning up temporary file directory /tmp/jlink"
+    rm -rf /tmp/jlink
+  fi
 fi

--- a/modules/s2i/bash/artifacts/usr/local/s2i/assemble
+++ b/modules/s2i/bash/artifacts/usr/local/s2i/assemble
@@ -58,11 +58,11 @@ if [ "$S2I_ENABLE_JLINK" = "true" ]; then
         exit 1
     }
 
+    if [ "$S2I_DELETE_SOURCE" == "true" ]; then
+      if [ -n "$(find $S2I_JLINK_TEMP_PATH -maxdepth 0 -type d ! -empty 2> /dev/null)" ]; then
+        log_info "Cleaning up temporary file directory $S2I_JLINK_TEMP_PATH"
+        rm -rf $S2I_JLINK_TEMP_PATH
+      fi
+    fi
 fi
 
-if [ "$S2I_DELETE_SOURCE" == "true" ]; then
-  if [ -n "$(find $S2I_JLINK_TEMP_PATH -maxdepth 0 -type d ! -empty 2> /dev/null)" ]; then
-    log_info "Cleaning up temporary file directory $S2I_JLINK_TEMP_PATH"
-    rm -rf $S2I_JLINK_TEMP_PATH
-  fi
-fi


### PR DESCRIPTION
Addresses https://issues.redhat.com/browse/OPENJDK-3646

Creates all of the temporary files used by the jlink workflow (deps.txt, etc) under /tmp/jlink, this can be controlled by the S2I_JLINK_TEMP_PATH variable. Once the jlink workflow completes it then checks S2I_DELETE_SOURCE and removes /tmp/jlink if set.

To test:

- Set S2I_DELETE_SOURCE to default to true for testing
```
diff --git a/modules/s2i/core/module.yaml b/modules/s2i/core/module.yaml
index af3123c..c74e57d 100644
--- a/modules/s2i/core/module.yaml
+++ b/modules/s2i/core/module.yaml
@@ -110,7 +110,7 @@ envs:
 - name: S2I_DELETE_SOURCE
   description: ^
     Delete source files at the end of build.  Defaults to true.
-  example: "false"
+  example: "true"
 
 - name: S2I_ENABLE_JLINK
   description: ^
```
- Build the tech preview image:
```
cekit --descriptor ubi9-openjdk-21.yaml build podman
```
- Set up a new Openshift Project
```
oc new-project jlink-dev
oc project jlink-dev
oc create imagestream openjdk-21-jlink-tech-preview
```
- Push the tech preview images to the created imagestream
```
podman tag openjdk-tech-preview/openjdk-21-jlink-rhel9:latest default-route-openshift-image-registry.apps-crc.testing/jlink-dev/openjdk-21-jlink-tech-preview:latest
podman push default-route-openshift-image-registry.apps-crc.testing/jlink-dev/openjdk-21-jlink-tech-preview:latest
```
- Run the template and observe the builds
```
oc create -f templates/jlink/jlinked-app.yaml
oc process -n jlink -f templates/jlink/jlinked-app.yaml -p APP_URI=https://github.com/jboss-container-images/openjdk-test-applications -p JDK_VERSION=21 -p REF=master -p CONTEXT_DIR=quarkus-quickstarts/getting-started-3.9.2-uberjar -p TARGET_PORT=8080 -p SERVICE_PORT=8080 -p APPNAME=quarkus-3646 | oc create -f -
```
- Check the logs for quarkus-3646-jlink-s2i-jdk-21-2. Look at the end of the build and check for the logging indicating that the temp directory was removed:
```
++ find /tmp/jlink -maxdepth 0 -type d '!' -empty
+ '[' -n /tmp/jlink ']'
+ log_info 'Cleaning up temporary file directory /tmp/jlink'
+ local 'message=Cleaning up temporary file directory /tmp/jlink'
+ echo -e 'INFO Cleaning up temporary file directory /tmp/jlink'
INFO Cleaning up temporary file directory /tmp/jlink
+ rm -rf /tmp/jlink
```