### PR TITLE
Bump cekit/actions-setup-cekit to v1.1.7

### DIFF
--- a/.github/workflows/gendocs.yml
+++ b/.github/workflows/gendocs.yml
@@ -29,7 +29,7 @@ jobs:
           fetch-depth: 0 # all branches and tags
 
       - name: Install CEKit
-        uses: cekit/actions-setup-cekit@v1.1.5
+        uses: cekit/actions-setup-cekit@v1.1.7
 
       - name: Setup required packages for docs
         run: |


### PR DESCRIPTION
This should fix the gendocs action. Although since we don't run that on PRs, just on commits to `ubi9` or tags, that's hard to demonstrate…
