### PR TITLE
[OPENJDK-3683] revert change to GHA image name

### DIFF
--- a/.github/workflows/ubi9-openjdk-21.yml
+++ b/.github/workflows/ubi9-openjdk-21.yml
@@ -2,9 +2,9 @@ name: UBI9 OpenJDK 21 S2I Image CI
 on: [push, pull_request]
 env:
   LANG: en_US.UTF-8
-  IMAGE: openjdk-21-jlink-rhel9
+  IMAGE: ubi9-openjdk-21
 jobs:
   call-openjdkci:
     uses: ./.github/workflows/image-workflow-template.yml
     with:
-      image: openjdk-21-jlink-rhel9
+      image: ubi9-openjdk-21


### PR DESCRIPTION
This variable is used to find the image descriptor which hasn't been renamed. This commit should fix the GHA jobs.

https://issues.redhat.com/browse/OPENJDK-3683