### PR TITLE
[OPENJDK-3680] drop gha stuff

### DIFF
--- a/.github/workflows/image-workflow-template.yml
+++ b/.github/workflows/image-workflow-template.yml
@@ -7,11 +7,8 @@ on:
         type: string
 env:
   LANG: en_US.UTF-8
-  IMAGE_URI: ghcr.io/jboss-container-images/${{ inputs.image }}:${{ github.ref_name }}
 jobs:
   openjdkci:
-    permissions:
-      packages: write
     name: OpenJDK S2I Build and Test
     timeout-minutes: 60
     runs-on: ubuntu-latest
@@ -27,7 +24,7 @@ jobs:
 
       - name: Build
         run: |
-          cekit -v --descriptor ${{ inputs.image }}.yaml build docker --no-squash --tag localimage
+          cekit -v --descriptor ${{ inputs.image }}.yaml build docker --no-squash
 
       - name: Install and cache S2I CLI tool from GitHub
         uses: redhat-actions/openshift-tools-installer@v1


### PR DESCRIPTION
This reverts commit 4967f2c989089f323aa1a1d3fadc505608abaa52.

Should address [OPENJDK-3680](https://issues.redhat.com/browse/OPENJDK-3680) and get the GHA lights back to green ([OPENJDK-3684](https://issues.redhat.com/browse/OPENJDK-3684))