### PR TITLE
[OPENJDK-3682] Correct org.opencontainers.image.source

### DIFF
--- a/ubi9-openjdk-11-runtime.yaml
+++ b/ubi9-openjdk-11-runtime.yaml
@@ -23,7 +23,7 @@ labels:
 - name: "com.redhat.license_terms"
   value: "https://www.redhat.com/en/about/red-hat-end-user-license-agreements#UBI"
 - name: "org.opencontainers.image.source"
-  value: "https://github.com/jboss-container-images/openjdk"
+  value: "https://github.com/rh-openjdk/redhat-openjdk-containers"
 - name: "org.opencontainers.image.documentation"
   value: *docs
 - name: "name"

--- a/ubi9-openjdk-11.yaml
+++ b/ubi9-openjdk-11.yaml
@@ -23,7 +23,7 @@ labels:
 - name: "com.redhat.license_terms"
   value: "https://www.redhat.com/en/about/red-hat-end-user-license-agreements#UBI"
 - name: "org.opencontainers.image.source"
-  value: "https://github.com/jboss-container-images/openjdk"
+  value: "https://github.com/rh-openjdk/redhat-openjdk-containers"
 - name: "org.opencontainers.image.documentation"
   value: *docs
 - name: "name"

--- a/ubi9-openjdk-17-runtime.yaml
+++ b/ubi9-openjdk-17-runtime.yaml
@@ -23,7 +23,7 @@ labels:
 - name: "com.redhat.license_terms"
   value: "https://www.redhat.com/en/about/red-hat-end-user-license-agreements#UBI"
 - name: "org.opencontainers.image.source"
-  value: "https://github.com/jboss-container-images/openjdk"
+  value: "https://github.com/rh-openjdk/redhat-openjdk-containers"
 - name: "org.opencontainers.image.documentation"
   value: *docs
 - name: "name"

--- a/ubi9-openjdk-17.yaml
+++ b/ubi9-openjdk-17.yaml
@@ -23,7 +23,7 @@ labels:
 - name: "com.redhat.license_terms"
   value: "https://www.redhat.com/en/about/red-hat-end-user-license-agreements#UBI"
 - name: "org.opencontainers.image.source"
-  value: "https://github.com/jboss-container-images/openjdk"
+  value: "https://github.com/rh-openjdk/redhat-openjdk-containers"
 - name: "org.opencontainers.image.documentation"
   value: *docs
 - name: "name"


### PR DESCRIPTION
Addresses https://issues.redhat.com/browse/OPENJDK-3682

Corrects the org.opencontainers.image.source label to point to the correct repository.