### PR TITLE
Align versions

### DIFF
--- a/.github/workflows/gendocs.yml
+++ b/.github/workflows/gendocs.yml
@@ -29,7 +29,7 @@ jobs:
           fetch-depth: 0 # all branches and tags
 
       - name: Install CEKit
-        uses: cekit/actions-setup-cekit@v1.1.5
+        uses: cekit/actions-setup-cekit@v1.1.7
 
       - name: Setup required packages for docs
         run: |

--- a/ubi9-openjdk-17-runtime.yaml
+++ b/ubi9-openjdk-17-runtime.yaml
@@ -4,7 +4,7 @@ schema_version: 1
 
 from: "registry.access.redhat.com/ubi9/ubi-minimal"
 name: &name "ubi9/openjdk-17-runtime"
-version: &version "1.21"
+version: &version "1.22"
 description: "Image for Red Hat OpenShift providing OpenJDK 17 runtime"
 
 labels:

--- a/ubi9-openjdk-17.yaml
+++ b/ubi9-openjdk-17.yaml
@@ -4,7 +4,7 @@ schema_version: 1
 
 from: "registry.access.redhat.com/ubi9/ubi-minimal"
 name: &name "ubi9/openjdk-17"
-version: &version "1.21"
+version: &version "1.22"
 description: "Source To Image (S2I) image for Red Hat OpenShift providing OpenJDK 17"
 
 labels:

--- a/ubi9-openjdk-21-runtime.yaml
+++ b/ubi9-openjdk-21-runtime.yaml
@@ -4,7 +4,7 @@ schema_version: 1
 
 from: "registry.access.redhat.com/ubi9/ubi-minimal"
 name: &name "ubi9/openjdk-21-runtime"
-version: &version "1.21"
+version: &version "1.22"
 description: "Image for Red Hat OpenShift providing OpenJDK 21 runtime"
 
 labels:

--- a/ubi9-openjdk-21.yaml
+++ b/ubi9-openjdk-21.yaml
@@ -4,7 +4,7 @@ schema_version: 1
 
 from: "registry.access.redhat.com/ubi9/ubi-minimal"
 name: &name "ubi9/openjdk-21"
-version: &version "1.21"
+version: &version "1.22"
 description: "Source To Image (S2I) image for Red Hat OpenShift providing OpenJDK 21"
 
 labels:


### PR DESCRIPTION
Catch up jlink-dev with recent ubi9 branch changes; some GHA fixes, and bump the image version.