### PR TITLE
    OPENJDK-3655  change script permissions to permit o+x

### DIFF
--- a/modules/jdk/11/configure.sh
+++ b/modules/jdk/11/configure.sh
@@ -7,7 +7,6 @@ ARTIFACTS_DIR=${SCRIPT_DIR}/artifacts
 
 chown -R $USER:root $SCRIPT_DIR
 chmod -R ug+rwX $SCRIPT_DIR
-chmod ug+x ${ARTIFACTS_DIR}/opt/jboss/container/openjdk/jdk/*
 
 pushd ${ARTIFACTS_DIR}
 cp -pr * /

--- a/modules/jdk/17/configure.sh
+++ b/modules/jdk/17/configure.sh
@@ -7,7 +7,6 @@ ARTIFACTS_DIR=${SCRIPT_DIR}/artifacts
 
 chown -R $USER:root $SCRIPT_DIR
 chmod -R ug+rwX $SCRIPT_DIR
-chmod ug+x ${ARTIFACTS_DIR}/opt/jboss/container/openjdk/jdk/*
 
 pushd ${ARTIFACTS_DIR}
 cp -pr * /

--- a/modules/jdk/21/configure.sh
+++ b/modules/jdk/21/configure.sh
@@ -7,7 +7,6 @@ ARTIFACTS_DIR=${SCRIPT_DIR}/artifacts
 
 chown -R $USER:root $SCRIPT_DIR
 chmod -R ug+rwX $SCRIPT_DIR
-chmod ug+x ${ARTIFACTS_DIR}/opt/jboss/container/openjdk/jdk/*
 
 pushd ${ARTIFACTS_DIR}
 cp -pr * /

--- a/modules/jdk/8/configure.sh
+++ b/modules/jdk/8/configure.sh
@@ -7,7 +7,6 @@ ARTIFACTS_DIR=${SCRIPT_DIR}/artifacts
 
 chown -R $USER:root $SCRIPT_DIR
 chmod -R ug+rwX $SCRIPT_DIR
-chmod ug+x ${ARTIFACTS_DIR}/opt/jboss/container/openjdk/jdk/*
 
 pushd ${ARTIFACTS_DIR}
 cp -pr * /

--- a/modules/jre/11/configure.sh
+++ b/modules/jre/11/configure.sh
@@ -9,7 +9,6 @@ echo $ARTIFACTS_DIR
 
 chown -R $USER:root $SCRIPT_DIR
 chmod -R ug+rwX $SCRIPT_DIR
-chmod ug+x ${ARTIFACTS_DIR}/opt/jboss/container/openjdk/jre/*
 
 pushd ${ARTIFACTS_DIR}
 cp -pr * /

--- a/modules/jre/17/configure.sh
+++ b/modules/jre/17/configure.sh
@@ -9,7 +9,6 @@ echo $ARTIFACTS_DIR
 
 chown -R $USER:root $SCRIPT_DIR
 chmod -R ug+rwX $SCRIPT_DIR
-chmod ug+x ${ARTIFACTS_DIR}/opt/jboss/container/openjdk/jre/*
 
 pushd ${ARTIFACTS_DIR}
 cp -pr * /

--- a/modules/jre/21/configure.sh
+++ b/modules/jre/21/configure.sh
@@ -9,7 +9,6 @@ echo $ARTIFACTS_DIR
 
 chown -R $USER:root $SCRIPT_DIR
 chmod -R ug+rwX $SCRIPT_DIR
-chmod ug+x ${ARTIFACTS_DIR}/opt/jboss/container/openjdk/jre/*
 
 pushd ${ARTIFACTS_DIR}
 cp -pr * /

--- a/modules/jre/8/configure.sh
+++ b/modules/jre/8/configure.sh
@@ -7,7 +7,6 @@ ARTIFACTS_DIR=${SCRIPT_DIR}/artifacts
 
 chown -R $USER:root $SCRIPT_DIR
 chmod -R ug+rwX $SCRIPT_DIR
-chmod ug+x ${ARTIFACTS_DIR}/opt/jboss/container/openjdk/jre/*
 
 pushd ${ARTIFACTS_DIR}
 cp -pr * /

--- a/modules/jvm/configure.sh
+++ b/modules/jvm/configure.sh
@@ -7,7 +7,7 @@ ARTIFACTS_DIR=${SCRIPT_DIR}/artifacts
 
 chown -R $USER:root $SCRIPT_DIR
 chmod -R ug+rwX $SCRIPT_DIR
-chmod ug+x ${ARTIFACTS_DIR}/opt/jboss/container/java/jvm/*
+chmod +x ${ARTIFACTS_DIR}/opt/jboss/container/java/jvm/*
 
 pushd ${ARTIFACTS_DIR}
 cp -pr * /

--- a/modules/maven/default/configure.sh
+++ b/modules/maven/default/configure.sh
@@ -8,7 +8,6 @@ ARTIFACTS_DIR=${SCRIPT_DIR}/artifacts
 # configure artifact permissions
 chown -R $USER:root $ARTIFACTS_DIR
 chmod -R ug+rwX $ARTIFACTS_DIR
-chmod ug+x ${ARTIFACTS_DIR}/opt/jboss/container/maven/default/maven.sh
 
 # install artifacts
 pushd ${ARTIFACTS_DIR}

--- a/modules/maven/s2i/configure.sh
+++ b/modules/maven/s2i/configure.sh
@@ -7,7 +7,6 @@ ARTIFACTS_DIR=${SCRIPT_DIR}/artifacts
 
 chown -R $USER:root $SCRIPT_DIR
 chmod -R ug+rwX $SCRIPT_DIR
-chmod ug+x ${ARTIFACTS_DIR}/opt/jboss/container/maven/s2i/*
 chmod ug+x ${ARTIFACTS_DIR}/usr/local/s2i/*
 
 pushd ${ARTIFACTS_DIR}

--- a/modules/run/configure.sh
+++ b/modules/run/configure.sh
@@ -7,7 +7,7 @@ ARTIFACTS_DIR=${SCRIPT_DIR}/artifacts
 
 chown -R $USER:root $SCRIPT_DIR
 chmod -R ug+rwX $SCRIPT_DIR
-chmod ug+x ${ARTIFACTS_DIR}/opt/jboss/container/java/run/*
+chmod +x ${ARTIFACTS_DIR}/opt/jboss/container/java/run/run-java.sh
 
 pushd ${ARTIFACTS_DIR}
 cp -pr * /

--- a/modules/s2i/bash/configure.sh
+++ b/modules/s2i/bash/configure.sh
@@ -7,7 +7,6 @@ ARTIFACTS_DIR=${SCRIPT_DIR}/artifacts
 
 chown -R $USER:root $SCRIPT_DIR
 chmod -R ug+rwX $SCRIPT_DIR
-chmod ug+x ${ARTIFACTS_DIR}/opt/jboss/container/java/s2i/*
 chmod ug+x ${ARTIFACTS_DIR}/usr/local/s2i/*
 
 pushd ${ARTIFACTS_DIR}

--- a/modules/s2i/core/configure.sh
+++ b/modules/s2i/core/configure.sh
@@ -7,7 +7,6 @@ ARTIFACTS_DIR=${SCRIPT_DIR}/artifacts
 
 chown -R $USER:root $SCRIPT_DIR
 chmod -R ug+rwX $SCRIPT_DIR
-chmod ug+x ${ARTIFACTS_DIR}/opt/jboss/container/s2i/core/*
 
 pushd ${ARTIFACTS_DIR}
 cp -pr * /

--- a/modules/util/logging/configure.sh
+++ b/modules/util/logging/configure.sh
@@ -7,7 +7,6 @@ ARTIFACTS_DIR=${SCRIPT_DIR}/artifacts
 
 chown -R $USER:root $SCRIPT_DIR
 chmod -R ug+rwX $SCRIPT_DIR
-chmod ug+x ${ARTIFACTS_DIR}/opt/jboss/container/util/logging/*
 
 pushd ${ARTIFACTS_DIR}
 cp -pr * /

--- a/tests/features/imagebasic.feature
+++ b/tests/features/imagebasic.feature
@@ -15,3 +15,10 @@ Feature: Tests for all openshift images
   Scenario: Check that builder labels are correctly set
     Given image is built
     Then the image should contain label io.openshift.s2i.scripts-url with value image:///usr/local/s2i
+
+  @ubi9
+  Scenario: Check installed scripts are executable by all users (OPENJDK-3655)
+    When container is started with args
+    | arg     | value                                                             |
+    | command | find /opt/jboss/container -type f -perm -g+x ( ! -perm -o+x ) -ls |
+    Then available container log should not contain /opt/jboss/container


### PR DESCRIPTION
https://issues.redhat.com/browse/OPENJDK-3655

This sets o+x for executable scripts and removes x for files that are intended to be sourced but not directly executed.

As it stands this is as small change, but, my preferred approach to addressing this would be the approach taken in #559, which would result in a cleaner and more manageable source. @jerboaa , would you object to a fix like that in `ubi9`?