### PR TITLE
[OPENJDK-3768] Update RHEL9 ELS containers for 2025-04 Security Update

### DIFF
--- a/.github/workflows/gendocs.yml
+++ b/.github/workflows/gendocs.yml
@@ -29,7 +29,7 @@ jobs:
           fetch-depth: 0 # all branches and tags
 
       - name: Install CEKit
-        uses: cekit/actions-setup-cekit@v1.1.5
+        uses: cekit/actions-setup-cekit@v1.1.7
 
       - name: Setup required packages for docs
         run: |

--- a/modules/maven/s2i/artifacts/opt/jboss/container/maven/s2i/maven-s2i
+++ b/modules/maven/s2i/artifacts/opt/jboss/container/maven/s2i/maven-s2i
@@ -76,7 +76,7 @@ function maven_s2i_build() {
   s2i_core_cleanup
 
   # Remove java tmp perf data dir owned by 185
-  rm -rf /tmp/hsperfdata_jboss
+  rm -rf "/tmp/hsperfdata_${USER}"
 }
 
 # perform a maven build, i.e.  mvn ...

--- a/modules/maven/s2i/tests/features/java_s2i.feature
+++ b/modules/maven/s2i/tests/features/java_s2i.feature
@@ -175,6 +175,17 @@ Feature: Openshift OpenJDK S2I tests
        | variable           | value    |
        | MAVEN_ARGS         | validate |
 
+  Scenario: Ensure no custom settings.xml fails for specific application (OPENJDK-3597)
+      Given failing s2i build https://github.com/rh-openjdk/openjdk-container-test-applications.git from OPENJDK-3597-custom-settings-xml using master
+      Then s2i build log should contain [ERROR] Profile "testCustomProfile" is not activated
+
+  Scenario: Ensure custom settings.xml copied in via MAVEN_SETTINGS_XML (OPENJDK-3597)
+      Given s2i build https://github.com/rh-openjdk/openjdk-container-test-applications.git from OPENJDK-3597-custom-settings-xml with env
+       | variable           | value                 |
+       | MAVEN_ARGS         | validate              |
+       | MAVEN_SETTINGS_XML | /tmp/src/settings.xml |
+      Then s2i build log should contain Rule 0: org.apache.maven.enforcer.rules.RequireActiveProfile passed
+
   Scenario: Ensure that run-env.sh placed in the JAVA_APP_DIR is sourced in the run script before launching java
       Given s2i build https://github.com/rh-openjdk/openjdk-container-test-applications.git from quarkus-quickstarts/getting-started-3.0.1.Final-nos2i
        | variable            | value        |

--- a/openjdk-11-rhel9.yaml
+++ b/openjdk-11-rhel9.yaml
@@ -7,7 +7,7 @@ schema_version: 1
 # products. This image is maintained by Red Hat and updated regularly.
 from: "registry.redhat.io/rhel9-osbs/osbs-ubi9-minimal"
 name: &name "openjdk-els/openjdk-11-rhel9"
-version: &version "1.21"
+version: &version "1.22"
 description: "Source To Image (S2I) image for Red Hat OpenShift providing OpenJDK 11"
 
 labels:

--- a/openjdk-11-runtime-rhel9.yaml
+++ b/openjdk-11-runtime-rhel9.yaml
@@ -7,7 +7,7 @@ schema_version: 1
 # products. This image is maintained by Red Hat and updated regularly.
 from: "registry.redhat.io/rhel9-osbs/osbs-ubi9-minimal"
 name: &name "openjdk-els/openjdk-11-runtime-rhel9"
-version: &version "1.21"
+version: &version "1.22"
 description: "Image for Red Hat OpenShift providing OpenJDK 11 runtime"
 
 labels:

--- a/ubi9-openjdk-17-runtime.yaml
+++ b/ubi9-openjdk-17-runtime.yaml
@@ -4,7 +4,7 @@ schema_version: 1
 
 from: "registry.access.redhat.com/ubi9/ubi-minimal"
 name: &name "ubi9/openjdk-17-runtime"
-version: &version "1.21"
+version: &version "1.22"
 description: "Image for Red Hat OpenShift providing OpenJDK 17 runtime"
 
 labels:

--- a/ubi9-openjdk-17.yaml
+++ b/ubi9-openjdk-17.yaml
@@ -4,7 +4,7 @@ schema_version: 1
 
 from: "registry.access.redhat.com/ubi9/ubi-minimal"
 name: &name "ubi9/openjdk-17"
-version: &version "1.21"
+version: &version "1.22"
 description: "Source To Image (S2I) image for Red Hat OpenShift providing OpenJDK 17"
 
 labels:

--- a/ubi9-openjdk-21-runtime.yaml
+++ b/ubi9-openjdk-21-runtime.yaml
@@ -4,7 +4,7 @@ schema_version: 1
 
 from: "registry.access.redhat.com/ubi9/ubi-minimal"
 name: &name "ubi9/openjdk-21-runtime"
-version: &version "1.21"
+version: &version "1.22"
 description: "Image for Red Hat OpenShift providing OpenJDK 21 runtime"
 
 labels:

--- a/ubi9-openjdk-21.yaml
+++ b/ubi9-openjdk-21.yaml
@@ -4,7 +4,7 @@ schema_version: 1
 
 from: "registry.access.redhat.com/ubi9/ubi-minimal"
 name: &name "ubi9/openjdk-21"
-version: &version "1.21"
+version: &version "1.22"
 description: "Source To Image (S2I) image for Red Hat OpenShift providing OpenJDK 21"
 
 labels:


### PR DESCRIPTION
This brings `jdk11-els-rhel9` on par with `ubi9`. Last commit also bumps ELS/RHEL9 image versions to `1.22`.
