### PR TITLE
[OPENJDK-2968] Runtime images don't properly support JAVA_ARGS

### DIFF
--- a/modules/maven/s2i/artifacts/opt/jboss/container/maven/s2i/maven-s2i
+++ b/modules/maven/s2i/artifacts/opt/jboss/container/maven/s2i/maven-s2i
@@ -36,10 +36,6 @@ function maven_s2i_init() {
   # Location of archived local Maven repository.  Used with incremental builds.
   _MAVEN_S2I_ARCHIVED_REPO="${S2I_ARTIFACTS_DIR}/m2"
 
-  # include maven scripts
-  if test -r "${JBOSS_CONTAINER_MAVEN_DEFAULT_MODULE}"/scl-enable-maven; then
-	  source "${JBOSS_CONTAINER_MAVEN_DEFAULT_MODULE}"/scl-enable-maven
-  fi
   source "${JBOSS_CONTAINER_MAVEN_DEFAULT_MODULE}"/maven.sh
 
   # Overrides for use with maven s2i

--- a/modules/run/artifacts/opt/jboss/container/java/run/run-java.sh
+++ b/modules/run/artifacts/opt/jboss/container/java/run/run-java.sh
@@ -247,4 +247,6 @@ startup() {
 
 # =============================================================================
 # Fire up
-startup $*
+
+echo "Starting the Java application using ${JBOSS_CONTAINER_JAVA_RUN_MODULE}/run-java.sh $* ${JAVA_ARGS}…"
+startup $* ${JAVA_ARGS}

--- a/modules/run/tests/features/java.runtime.feature
+++ b/modules/run/tests/features/java.runtime.feature
@@ -16,3 +16,11 @@ Feature: Openshift OpenJDK Runtime tests (OPENJDK-474, OPENJDK-2805)
      And file /usr/libexec/s2i/run should exist
      And file /usr/libexec/s2i/run should not contain JVM_ARGS
      And container log should not contain unique unique
+
+  @ubi9
+  # alternative to one of previous steps, for runtime images
+  Scenario: OPENJDK-2968 Ensure JAVA_ARGS is passed to the running Java application
+    Given container is started with env
+       | variable    | value                 |
+       | JAVA_ARGS   | Hello from Cekit test |
+    Then container log should match regex ^INFO exec -a "java" java.*Hello from Cekit test$

--- a/modules/s2i/bash/artifacts/usr/local/s2i/run
+++ b/modules/s2i/bash/artifacts/usr/local/s2i/run
@@ -11,7 +11,4 @@ source "${JBOSS_CONTAINER_JAVA_S2I_MODULE}/s2i-core-hooks"
 # Global S2I variable setup
 s2i_core_env_init
 
-export JAVA_OPTS
-
-echo "Starting the Java application using ${JBOSS_CONTAINER_JAVA_RUN_MODULE}/run-java.sh $args ${JAVA_ARGS}…"
-exec "${JBOSS_CONTAINER_JAVA_RUN_MODULE}/run-java.sh" $args ${JAVA_ARGS}
+exec "${JBOSS_CONTAINER_JAVA_RUN_MODULE}/run-java.sh" $args


### PR DESCRIPTION
The runtime images do not honour `JAVA_ARGS`, as it is being handled by `s2i/run` instead of `run-java.sh` for some reason.  Move the handling into `run-java.sh` so it is shared with the runtime images.

(Originally an adaptation of WIP work from #492 to ubi9.)

https://issues.redhat.com/browse/OPENJDK-2968