### PR TITLE
[OPENJDK-3856] Remove broken support for appsrc run.sh

### DIFF
--- a/modules/s2i/bash/artifacts/usr/local/s2i/run
+++ b/modules/s2i/bash/artifacts/usr/local/s2i/run
@@ -13,10 +13,5 @@ s2i_core_env_init
 
 export JAVA_OPTS
 
-if [ -f "${S2I_TARGET_DEPLOYMENTS_DIR}/bin/run.sh" ]; then
-    echo "Starting the application using the bundled ${S2I_TARGET_DEPLOYMENTS_DIR}/bin/run.sh ..."
-    exec ${DEPLOYMENTS_DIR}/bin/run.sh $args ${JAVA_ARGS}
-else
-    echo "Starting the Java application using ${JBOSS_CONTAINER_JAVA_RUN_MODULE}/run-java.sh $args..."
-    exec "${JBOSS_CONTAINER_JAVA_RUN_MODULE}/run-java.sh" $args ${JAVA_ARGS}
-fi
+echo "Starting the Java application using ${JBOSS_CONTAINER_JAVA_RUN_MODULE}/run-java.sh $args ${JAVA_ARGS}…"
+exec "${JBOSS_CONTAINER_JAVA_RUN_MODULE}/run-java.sh" $args ${JAVA_ARGS}


### PR DESCRIPTION
https://issues.redhat.com/browse/OPENJDK-3856

Remove the broken implementation of supporting `src/run.sh` as an alternative run script in app sources. The feature was broken accidentally in 2018 and has never worked in a UBI image. Users can override `RUN` (or `ENTRYPOINT`) instead.

The logic for the feature complicates the fix for [OPENJDK-2968] Runtime images don't properly support JAVA_ARGS (#589 ).