### PR TITLE
[OPENJDK-3935] Fix script permissions for artifacts

### DIFF
--- a/modules/jvm/configure.sh
+++ b/modules/jvm/configure.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+set -euo pipefail
+
+# OPENJDK-3695: force +x for scripts
+chmod 0755 /opt/jboss/container/java/jvm/*

--- a/modules/jvm/module.yaml
+++ b/modules/jvm/module.yaml
@@ -9,6 +9,9 @@ artifacts:
   - path: artifacts/jvm
     dest: /opt/jboss/container/java/jvm
 
+execute:
+- script: configure.sh
+
 modules:
   install:
   - name: jboss.container.user

--- a/modules/jvm/tests/features/files.feature
+++ b/modules/jvm/tests/features/files.feature
@@ -1,0 +1,9 @@
+Feature: test file properties for JVM module
+
+  @ubi9
+  Scenario: Ensure image scripts are executable (OPENJDK-3935)
+    When container is started with args
+    | arg     | value                                                        |
+    | command | find /opt/jboss/container/java/ -type f -printf "%h/%f %M\n" |
+    Then available container log should contain /opt/jboss/container/java/jvm/debug-options -rwxr-xr-x
+    And  available container log should contain /opt/jboss/container/java/jvm/java-default-options -rwxr-xr-x

--- a/modules/maven/s2i/configure.sh
+++ b/modules/maven/s2i/configure.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+set -euo pipefail
+
+# OPENJDK-3695: force +x for scripts
+chmod 0755 /usr/libexec/s2i/save-artifacts

--- a/modules/maven/s2i/module.yaml
+++ b/modules/maven/s2i/module.yaml
@@ -30,6 +30,9 @@ modules:
   - name: jboss.container.maven.default
   - name: jboss.container.util.logging
 
+execute:
+- script: configure.sh
+
 packages:
   install:
   - tar

--- a/modules/maven/s2i/tests/features/files.feature
+++ b/modules/maven/s2i/tests/features/files.feature
@@ -1,0 +1,10 @@
+Feature: test file properties for Maven S2I module
+
+  # builder-only test
+  @ubi9/openjdk-17
+  @ubi9/openjdk-21
+  Scenario: Ensure save-artifacts script is executable (OPENJDK-3935)
+    When container is started with args
+    | arg     | value                                         |
+    | command | find /usr/local/s2i -type f -printf "%f %M\n" |
+    Then available container log should contain save-artifacts -rwxr-xr-x

--- a/modules/run/configure.sh
+++ b/modules/run/configure.sh
@@ -17,3 +17,6 @@ else
     javasecurity="${JAVA_HOME}/conf/security/java.security"
 fi
 sed -i 's/\(networkaddress.cache.negative.ttl\)=[0-9]\+$/\1=0/' "$javasecurity"
+
+# OPENJDK-3695: force +x for scripts
+chmod 0755 /opt/jboss/container/java/run/run-java.sh

--- a/modules/run/tests/features/run.feature
+++ b/modules/run/tests/features/run.feature
@@ -6,3 +6,8 @@ Feature: OpenJDK run script tests
       | JAVA_OPTS_APPEND | -Djavax.net.ssl.trustStorePassword=sensitiveString |
     Then container log should not contain sensitiveString
 
+  Scenario: Ensure image scripts are executable (OPENJDK-3935)
+    When container is started with args
+    | arg     | value                                                        |
+    | command | find /opt/jboss/container/java/ -type f -printf "%h/%f %M\n" |
+    Then available container log should contain /opt/jboss/container/java/run/run-java.sh -rwxr-xr-x

--- a/modules/s2i/bash/configure.sh
+++ b/modules/s2i/bash/configure.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+set -euo pipefail
+
+# OPENJDK-3695: force +x for scripts
+chmod 0755 /usr/local/s2i/{assemble,run,usage}

--- a/modules/s2i/bash/module.yaml
+++ b/modules/s2i/bash/module.yaml
@@ -23,3 +23,6 @@ artifacts:
     dest: /usr/local/s2i
   - path: artifacts/opt
     dest: /opt/jboss/container/java/s2i
+
+execute:
+- script: configure.sh

--- a/modules/s2i/bash/tests/features/files.feature
+++ b/modules/s2i/bash/tests/features/files.feature
@@ -1,0 +1,12 @@
+# builder-only test
+@ubi9/openjdk-17
+@ubi9/openjdk-21
+Feature: OpenJDK S2I bash module tests
+
+  Scenario: Ensure image scripts are executable (OPENJDK-3935)
+    When container is started with args
+    | arg     | value                                                        |
+    | command | find /usr/local/s2i/ -type f -printf "%h/%f %M\n" |
+    Then available container log should contain run -rwxr-xr-x
+    And available container log should contain assemble -rwxr-xr-x
+    And available container log should contain usage -rwxr-xr-x


### PR DESCRIPTION
#583 caused an unintended break for images built on OSBS. For other build types, things worked as expected, but for OSBS builds the file permissions for copied-in files (which are round tripped through the dist-git lookaside cache) lacked +x permissions where they were needed.

This is a -- hopefully temporary -- fix that re-introduces some `configure.sh` scripts to force permissions, and some behave test to check that they applied correctly.

The longer-term fix is to be via https://github.com/cekit/cekit/issues/944

https://issues.redhat.com/browse/OPENJDK-3935

