### PR TITLE
[OPENJDK-3975] tests for custom configuration and data

### DIFF
--- a/modules/s2i/bash/artifacts/opt/jboss/container/java/s2i/maven-s2i-overrides
+++ b/modules/s2i/bash/artifacts/opt/jboss/container/java/s2i/maven-s2i-overrides
@@ -1,5 +1,6 @@
 
 source "${JBOSS_CONTAINER_UTIL_LOGGING_MODULE}/logging.sh"
+source "${JBOSS_CONTAINER_S2I_CORE_MODULE}/s2i-core"
 
 # inject our overridden maven_*() functions
 function maven_s2i_source_maven_overrides() {
@@ -30,11 +31,7 @@ function maven_s2i_custom_binary_build() {
   fi
   log_info "Copying binaries from ${binary_dir} to ${S2I_TARGET_DEPLOYMENTS_DIR} ..."
 
-  ( # OPENJDK-2850: use glob (dotglob to match hidden files) to stop rsync altering
-    # timestamps of S2I_TARGET_DEPLOYMENTS_DIR. Don't alter parent shell's dotglob.
-    shopt -s dotglob
-    rsync --archive --out-format='%n' "${binary_dir}"/* "${S2I_TARGET_DEPLOYMENTS_DIR}"
-  )
+  recursive_copy_files "${binary_dir}" "${S2I_TARGET_DEPLOYMENTS_DIR}"
 }
 
 function maven_s2i_deploy_artifacts_override() {

--- a/modules/s2i/bash/module.yaml
+++ b/modules/s2i/bash/module.yaml
@@ -16,6 +16,7 @@ modules:
   - name: jboss.container.maven.s2i
   - name: jboss.container.java.run
   - name: jboss.container.util.logging
+  - name: jboss.container.s2i.core
 
 packages:
   install:

--- a/modules/s2i/core/artifacts/opt/jboss/container/s2i/core/s2i-core
+++ b/modules/s2i/core/artifacts/opt/jboss/container/s2i/core/s2i-core
@@ -41,6 +41,20 @@ function s2i_core_env_init_hook() {
   : 
 }
 
+# Copy files from a source path to a destination path
+# Do not attempt to change metadata of the destination path, which we
+# may not own
+function recursive_copy_files() {
+  src="$1"
+  dst="$2"
+  ( # OPENJDK-2850: use glob (dotglob to match hidden files) to stop rsync altering
+    # timestamps of $dst, which we might not own. Subshell to not alter parent shell's
+    # dotglob setting.
+    shopt -s dotglob
+    rsync --archive --out-format='%n' "${src}"/* "${dst}"
+  )
+}
+
 # copy configuration files
 # $1 - the base directory to which $S2I_SOURCE_CONFIGURATION_DIR is appended
 function s2i_core_copy_configuration() {
@@ -53,7 +67,7 @@ function s2i_core_copy_configuration() {
         mkdir -pm 775 "${S2I_TARGET_CONFIGURATION_DIR}"
       fi
       log_info "Copying configuration from $(realpath --relative-to ${S2I_SOURCE_DIR} ${1}/${S2I_SOURCE_CONFIGURATION_DIR}) to ${S2I_TARGET_CONFIGURATION_DIR}..."
-      rsync --archive --out-format='%n' "${1}/${S2I_SOURCE_CONFIGURATION_DIR}"/ "${S2I_TARGET_CONFIGURATION_DIR}"
+      recursive_copy_files "${1}/${S2I_SOURCE_CONFIGURATION_DIR}" "${S2I_TARGET_CONFIGURATION_DIR}"
     fi
   fi 
 }
@@ -70,7 +84,7 @@ function s2i_core_copy_data() {
         mkdir -pm 775 "${S2I_TARGET_DATA_DIR}"
       fi
       log_info "Copying app data from $(realpath --relative-to ${S2I_SOURCE_DIR} ${1}/${S2I_SOURCE_DATA_DIR}) to ${S2I_TARGET_DATA_DIR}..."
-      rsync --archive --out-format='%n' "${1}/${S2I_SOURCE_DATA_DIR}"/ "${S2I_TARGET_DATA_DIR}"
+      recursive_copy_files "${1}/${S2I_SOURCE_DATA_DIR}" "${S2I_TARGET_DATA_DIR}"
       # s2i used to be more forgiving, but the build will fail if this call
       # fails.  emit a warning and allow the build to succeed
       chmod -R g+rwX "${S2I_TARGET_DATA_DIR}" || log_warning "Errors occurred while adding read/write permissions to S2I_TARGET_DATA_DIR ($S2I_TARGET_DATA_DIR)."

--- a/modules/s2i/core/tests/features/s2i-core.feature
+++ b/modules/s2i/core/tests/features/s2i-core.feature
@@ -18,3 +18,21 @@ Feature: Openshift S2I tests
      Then s2i build log should not contain rsync: [generator] failed to set permissions on "/var/tmp/.": Operation not permitted
      And  s2i build log should contain appsrc-provided s2i assemble script executed
      And  run stat /var/tmp/spring-boot-sample-simple-1.5.0.BUILD-SNAPSHOT.jar in container and check its output for Access:
+
+  # as above, for OPENJDK-3975: handling configuration
+  Scenario: Ensure copying custom configuration doesn't fail trying to chmod destination directory (OPENJDK-3975)
+    Given s2i build https://github.com/rh-openjdk/openjdk-container-test-applications.git from OPENJDK-2408-bin-custom-s2i-assemble with env
+       | variable                     | value    |
+       | S2I_TARGET_CONFIGURATION_DIR | /var/tmp |
+    Then s2i build log should not contain rsync: [generator] failed to set permissions on "/var/tmp/.": Operation not permitted
+    And  s2i build log should contain appsrc-provided s2i assemble script executed
+    And  run stat /var/tmp/example.ini in container and check its output for Access:
+
+  # as above, for OPENJDK-3975: handling data
+  Scenario: Ensure copying custom data doesn't fail trying to chmod destination directory (OPENJDK-3975)
+    Given s2i build https://github.com/rh-openjdk/openjdk-container-test-applications.git from OPENJDK-2408-bin-custom-s2i-assemble with env
+       | variable                     | value    |
+       | S2I_TARGET_DATA_DIR          | /var/tmp |
+    Then s2i build log should not contain rsync: [generator] failed to set permissions on "/var/tmp/.": Operation not permitted
+    And  s2i build log should contain appsrc-provided s2i assemble script executed
+    And  run stat /var/tmp/sample.txt in container and check its output for Access:


### PR DESCRIPTION
https://issues.redhat.com/browse/OPENJDK-3975

Adjust the remaining `rsync` calls to avoid trying to change permissions on the destination directories.

First, tests.