### PR TITLE
[OPENJDK-4024] adjust permissions on jboss-settings.xml

### DIFF
--- a/modules/maven/default/configure.sh
+++ b/modules/maven/default/configure.sh
@@ -4,8 +4,9 @@ set -euo pipefail
 SCRIPT_DIR=$(dirname $0)
 ARTIFACTS_DIR=${SCRIPT_DIR}/artifacts
 
-install -m 0644 -D -t /opt/jboss/container/maven/default \
-    ${ARTIFACTS_DIR}/opt/jboss/container/maven/default/*
+install -m 0644 -D {${ARTIFACTS_DIR},}/opt/jboss/container/maven/default/maven.sh
+# 0664: OPENJDK-4024
+install -m 0664 -D {${ARTIFACTS_DIR},}/opt/jboss/container/maven/default/jboss-settings.xml
 
 MAVEN_VERSION_SQUASHED=${MAVEN_VERSION/./}
 


### PR DESCRIPTION
Wildfly, who use our image sources, require group-write permission to this file.

https://issues.redhat.com/browse/OPENJDK-4024