### PR TITLE
[OPENJDK-4031] remove test for tzdata RPM

### DIFF
--- a/modules/jdk/tests/features/openjdk.feature
+++ b/modules/jdk/tests/features/openjdk.feature
@@ -49,10 +49,3 @@ Feature: Miscellaneous OpenJDK-related unit tests
     | arg     | value |
     | command | tar   |
     Then available container log should not contain command not found
-
-  @ubi10
-  Scenario: Ensure tzdata RPM is properly installed (OPENJDK-2519)
-    When container is started with args
-    | arg     | value         |
-    | command | rpm -V tzdata |
-    Then available container log should not contain missing


### PR DESCRIPTION
https://issues.redhat.com/browse/OPENJDK-4031

until we decide whether to install tzdata, we need not check it's installed.