### PR TITLE
[OPENJDK-3653] fix s2i path in tests

### DIFF
--- a/modules/maven/s2i/tests/features/files.feature
+++ b/modules/maven/s2i/tests/features/files.feature
@@ -4,6 +4,6 @@ Feature: test file properties for Maven S2I module
   @ubi10/openjdk-21
   Scenario: Ensure save-artifacts script is executable (OPENJDK-3935)
     When container is started with args
-    | arg     | value                                         |
-    | command | find /usr/local/s2i -type f -printf "%f %M\n" |
+    | arg     | value                                           |
+    | command | find /usr/libexec/s2i -type f -printf "%f %M\n" |
     Then available container log should contain save-artifacts -rwxr-xr-x

--- a/modules/s2i/bash/tests/features/files.feature
+++ b/modules/s2i/bash/tests/features/files.feature
@@ -4,8 +4,8 @@ Feature: OpenJDK S2I bash module tests
 
   Scenario: Ensure image scripts are executable (OPENJDK-3935)
     When container is started with args
-    | arg     | value                                                        |
-    | command | find /usr/local/s2i/ -type f -printf "%h/%f %M\n" |
+    | arg     | value                                               |
+    | command | find /usr/libexec/s2i/ -type f -printf "%h/%f %M\n" |
     Then available container log should contain run -rwxr-xr-x
     And available container log should contain assemble -rwxr-xr-x
     And available container log should contain usage -rwxr-xr-x


### PR DESCRIPTION
The new location is /usr/libexec/s2i

https://issues.redhat.com/browse/OPENJDK-3653
