### PR TITLE
[OPENJDK-4106] Enable compact object headers

### DIFF
--- a/modules/jdk/21/module.yaml
+++ b/modules/jdk/21/module.yaml
@@ -28,5 +28,7 @@ packages:
 
 modules:
   install:
+  - name: jboss.container.openjdk.jre
+    version: *jdkver
   - name: jboss.container.user
   - name: jboss.container.openjdk

--- a/modules/jdk/25/module.yaml
+++ b/modules/jdk/25/module.yaml
@@ -28,5 +28,7 @@ packages:
 
 modules:
   install:
+  - name: jboss.container.openjdk.jre
+    version: *jdkver
   - name: jboss.container.user
   - name: jboss.container.openjdk

--- a/modules/jre/25/artifacts/opt/jboss/container/openjdk/jre/jvm-options
+++ b/modules/jre/25/artifacts/opt/jboss/container/openjdk/jre/jvm-options
@@ -1,0 +1,9 @@
+#!/bin/bash
+# this is a script library and is intended to be sourced, not executed.
+
+# OPENJDK-4106
+jvm_specific_options() {
+  if [ "$JAVA_COMPACT_OBJECT_HEADERS" != "false" ]; then
+    echo "-XX:+UseCompactObjectHeaders"
+  fi
+}

--- a/modules/jre/25/configure.sh
+++ b/modules/jre/25/configure.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+set -euo pipefail
+
+SCRIPT_DIR=$(dirname $0)
+ARTIFACTS_DIR=${SCRIPT_DIR}/artifacts
+
+install -m 0644 -D {${ARTIFACTS_DIR},}${JBOSS_CONTAINER_OPENJDK_JRE_MODULE}/jvm-options

--- a/modules/jre/25/module.yaml
+++ b/modules/jre/25/module.yaml
@@ -21,6 +21,9 @@ envs:
   value: *jdkver
 - name: JBOSS_CONTAINER_OPENJDK_JRE_MODULE
   value: /opt/jboss/container/openjdk/jre
+- name:         JAVA_COMPACT_OBJECT_HEADERS
+  description:  Whether to enable compact object headers (JEP519) for JDK24 and newer. Enabled by default.
+  example:      "false"
 
 packages:
   install:
@@ -30,3 +33,6 @@ modules:
   install:
   - name: jboss.container.user
   - name: jboss.container.openjdk
+
+execute:
+- script: configure.sh

--- a/modules/jre/25/module.yaml
+++ b/modules/jre/25/module.yaml
@@ -22,7 +22,7 @@ envs:
 - name: JBOSS_CONTAINER_OPENJDK_JRE_MODULE
   value: /opt/jboss/container/openjdk/jre
 - name:         JAVA_COMPACT_OBJECT_HEADERS
-  description:  Whether to enable compact object headers (JEP519) for JDK24 and newer. Enabled by default.
+  description:  Whether to enable compact object headers (JEP519) for JDK25 and newer. Enabled by default.
   example:      "false"
 
 packages:

--- a/modules/jre/25/tests/features/openjdk.feature
+++ b/modules/jre/25/tests/features/openjdk.feature
@@ -1,0 +1,15 @@
+Feature: Tests around compact object headers
+
+  @ubi10/openjdk-25
+  @ubi10/openjdk-25-runtime
+  Scenario: UseCompactObjectHeaders is on by default
+    When container is ready
+    Then available container log should contain -XX:+UseCompactObjectHeaders
+
+  @ubi10/openjdk-25
+  @ubi10/openjdk-25-runtime
+  Scenario: UseCompactObjectHeaders can be disabled
+    Given container is started with env
+     | variable                    | value |
+     | JAVA_COMPACT_OBJECT_HEADERS | false |
+    Then available container log should not contain -XX:+UseCompactObjectHeaders

--- a/modules/jvm/artifacts/opt/jboss/container/java/jvm/java-default-options
+++ b/modules/jvm/artifacts/opt/jboss/container/java/jvm/java-default-options
@@ -11,8 +11,8 @@ jvm_specific_options() {
 }
 
 # Include overridden jvm_specific_*() functions
-if [ -f "${JBOSS_CONTAINER_OPENJDK_JDK_MODULE}/jvm-options" ]; then
-  source "${JBOSS_CONTAINER_OPENJDK_JDK_MODULE}/jvm-options"
+if [ -f "${JBOSS_CONTAINER_OPENJDK_JRE_MODULE}/jvm-options" ]; then
+  source "${JBOSS_CONTAINER_OPENJDK_JRE_MODULE}/jvm-options"
 fi
 
 # Check for memory options and calculate a sane default if not given
@@ -60,7 +60,7 @@ gc_config() {
     fi
   fi
 
-  local allOptions="$(jvm_specific_options) "
+  local allOptions=""
   allOptions+="${gcOptions} "
   allOptions+="-XX:MinHeapFreeRatio=${minHeapFreeRatio} "
   allOptions+="-XX:MaxHeapFreeRatio=${maxHeapFreeRatio} "
@@ -81,5 +81,7 @@ error_handling() {
   echo "-XX:+ExitOnOutOfMemoryError"
 }
 
-## Echo options, trimming trailing and multiple spaces
-echo "$(max_memory) $(gc_config) $(diagnostics) $(error_handling)" | awk '$1=$1'
+echo "$(max_memory) $(gc_config) $(diagnostics) $(error_handling)\
+  $(jvm_specific_options)
+
+" | awk '$1=$1' # trim leading/trailing spaces and squash multi

--- a/modules/jvm/artifacts/opt/jboss/container/java/jvm/java-default-options
+++ b/modules/jvm/artifacts/opt/jboss/container/java/jvm/java-default-options
@@ -84,4 +84,4 @@ error_handling() {
 echo "$(max_memory) $(gc_config) $(diagnostics) $(error_handling)\
   $(jvm_specific_options)
 
-" | awk '$1=$1' # trim leading/trailing spaces and squash multi
+" | awk '$1=$1' # trim leading/trailing spaces and squash multiple spaces


### PR DESCRIPTION
Enabled by default

https://issues.redhat.com/browse/OPENJDK-4106

Depends upon: #616
