### PR TITLE
[OPENJDK-4151, OPENJDK-4152, OPENJDK-4191]  jdk25 image descriptors and Maven modules

### DIFF
--- a/modules/jdk/tests/features/openjdk.feature
+++ b/modules/jdk/tests/features/openjdk.feature
@@ -9,6 +9,18 @@ Feature: Miscellaneous OpenJDK-related unit tests
     Then available container log should not contain java-1.8.0
     Then available container log should not contain java-11
     Then available container log should not contain java-17
+    Then available container log should not contain java-25
+
+  @ubi10/openjdk-25
+  @ubi10/openjdk-25-runtime
+  Scenario: Check that only OpenJDK 25 is installed
+    When container is started with args
+    | arg     | value   |
+    | command | rpm -qa |
+    Then available container log should not contain java-1.8.0
+    Then available container log should not contain java-11
+    Then available container log should not contain java-17
+    Then available container log should not contain java-21
 
   @ubi10
   Scenario: Ensure JAVA_HOME is defined and contains Java
@@ -35,6 +47,18 @@ Feature: Miscellaneous OpenJDK-related unit tests
     Then available container log should not contain java-1.8.0
     Then available container log should not contain java-11
     Then available container log should not contain java-17
+    Then available container log should not contain java-25
+
+  @ubi10/openjdk-25
+  @ubi10/openjdk-25-runtime
+  Scenario: Check that directories from other JDKs are not present (JDK25)
+    When container is started with args
+    | arg     | value   |
+    | command | ls -1 /usr/lib/jvm |
+    Then available container log should not contain java-1.8.0
+    Then available container log should not contain java-11
+    Then available container log should not contain java-17
+    Then available container log should not contain java-21
 
   @ubi10
   Scenario: Ensure LANG is defined and contains UTF-8

--- a/modules/maven/25/configure.sh
+++ b/modules/maven/25/configure.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+set -e
+
+# This file is shipped by a Maven package and sets JAVA_HOME to
+# an OpenJDK-specific path. This causes problems for OpenJ9 containers
+# as the path is not correct for them.  We don't need this in any of
+# the containers because we set JAVA_HOME in the container metadata.
+# Blank the file rather than removing it, to avoid a warning message
+# from /usr/bin/mvn.
+if [ -f /etc/java/maven.conf ]; then
+  :> /etc/java/maven.conf
+fi

--- a/modules/maven/25/module.yaml
+++ b/modules/maven/25/module.yaml
@@ -1,0 +1,21 @@
+schema_version: 1
+name: jboss.container.maven
+version: '3.9.25'
+description: Provides Maven v3.9 capabilities to an image.
+
+envs:
+- name: JBOSS_CONTAINER_MAVEN_39_MODULE
+  value: /opt/jboss/container/maven/39/
+- name: MAVEN_VERSION
+  value: '3.9'
+
+modules:
+  install:
+  - name: jboss.container.maven.module
+
+packages:
+  install:
+  - maven-openjdk25
+
+execute:
+- script: configure.sh

--- a/modules/singleton-jdk/configure.sh
+++ b/modules/singleton-jdk/configure.sh
@@ -14,11 +14,3 @@ fi
 # Clean up any java-* packages that have been installed that do not match
 # our stated JAVA_VERSION-JAVA_VENDOR (e.g.: 11-openjdk; 1.8.0-openj9)
 rpm -e --nodeps $(rpm -qa java-* | grep -v "^java-${JAVA_VERSION}-${JAVA_VENDOR}")
-
-# workaround for <https://issues.redhat.com/browse/RHEL-3437>
-# The alternative link groups touched here need to match up with those set in
-# modules/jdk/*/configure.sh
-_arch="$(uname -i)"
-for alt in java javac java_sdk_openjdk jre_openjdk; do
-  alternatives --set "$alt" "java-${JAVA_VERSION}-${JAVA_VENDOR}.${_arch}"
-done

--- a/redhat/ubi10-openjdk-25-runtime.yaml
+++ b/redhat/ubi10-openjdk-25-runtime.yaml
@@ -1,0 +1,28 @@
+osbs:
+  configuration:
+    container:
+      compose:
+        pulp_repos: false
+        packages:
+        - java-25-openjdk-headless
+        - maven-openjdk25
+        signing_intent: unsigned
+  repository:
+    name: containers/openjdk
+    branch: openjdk-25-runtime-ubi10
+
+packages:
+  manager: microdnf
+  content_sets:
+    x86_64:
+    - rhel-10-for-x86_64-baseos-rpms
+    - rhel-10-for-x86_64-appstream-rpms
+    ppc64le:
+    - rhel-10-for-ppc64le-baseos-rpms
+    - rhel-10-for-ppc64le-appstream-rpms
+    aarch64:
+    - rhel-10-for-aarch64-baseos-rpms
+    - rhel-10-for-aarch64-appstream-rpms
+    s390x:
+    - rhel-10-for-s390x-baseos-rpms
+    - rhel-10-for-s390x-appstream-rpms

--- a/redhat/ubi10-openjdk-25.yaml
+++ b/redhat/ubi10-openjdk-25.yaml
@@ -1,0 +1,29 @@
+osbs:
+  configuration:
+    container:
+      compose:
+        pulp_repos: false
+        packages:
+        - java-25-openjdk
+        - java-25-openjdk-devel
+        - java-25-openjdk-headless
+        signing_intent: unsigned
+  repository:
+    name: containers/openjdk
+    branch: openjdk-25-ubi10
+
+packages:
+  manager: microdnf
+  content_sets:
+    x86_64:
+    - rhel-10-for-x86_64-baseos-rpms
+    - rhel-10-for-x86_64-appstream-rpms
+    ppc64le:
+    - rhel-10-for-ppc64le-baseos-rpms
+    - rhel-10-for-ppc64le-appstream-rpms
+    aarch64:
+    - rhel-10-for-aarch64-baseos-rpms
+    - rhel-10-for-aarch64-appstream-rpms
+    s390x:
+    - rhel-10-for-s390x-baseos-rpms
+    - rhel-10-for-s390x-appstream-rpms

--- a/ubi10-openjdk-25-runtime.yaml
+++ b/ubi10-openjdk-25-runtime.yaml
@@ -1,0 +1,65 @@
+# This is an Image descriptor for Cekit
+
+schema_version: 1
+
+from: "registry.access.redhat.com/ubi10/ubi-minimal"
+name: &name "ubi10/openjdk-25-runtime"
+version: &version "1.23"
+description: "Image for Red Hat OpenShift providing OpenJDK 25 runtime"
+
+labels:
+- name: "io.k8s.description"
+  value: "Platform for running plain Java applications (fat-jar and flat classpath)"
+- name: "io.k8s.display-name"
+  value: "Java Applications"
+- name: "io.openshift.tags"
+  value: "java"
+- name: "maintainer"
+  value: "Red Hat OpenJDK <openjdk@redhat.com>"
+- name: "com.redhat.component"
+  value: "openjdk-25-runtime-ubi10-container"
+- name: "usage"
+  value: &docs "https://rh-openjdk.github.io/redhat-openjdk-containers/"
+- name: "com.redhat.license_terms"
+  value: "https://www.redhat.com/en/about/red-hat-end-user-license-agreements#UBI"
+- name: "org.opencontainers.image.documentation"
+  value: *docs
+- name: "name"
+  value: *name
+- name: "version"
+  value: *version
+- name: "org.opencontainers.image.source"
+  value: "https://github.com/rh-openjdk/redhat-openjdk-containers"
+- name: "org.opencontainers.image.revision"
+  value: "ubi10"
+
+envs:
+  # XXX should this move to an s2i module?
+- name: PATH
+  value: $PATH:"/usr/libexec/s2i"
+- name: "JBOSS_IMAGE_NAME"
+  value: *name
+- name: "JBOSS_IMAGE_VERSION"
+  value: *version
+- name: "LANG"
+  value: "C.utf8"
+
+ports:
+- value: 8080
+- value: 8443
+
+modules:
+  repositories:
+  - path: modules
+  install:
+  - name: jboss.container.util.pkg-update
+  - name: jboss.container.tar
+  - name: jboss.container.openjdk.jre
+    version: "25"
+  - name: jboss.container.java.jre.run
+
+help:
+  add: true
+
+packages:
+  manager: microdnf

--- a/ubi10-openjdk-25.yaml
+++ b/ubi10-openjdk-25.yaml
@@ -1,0 +1,66 @@
+# This is an Image descriptor for Cekit
+
+schema_version: 1
+
+from: "registry.access.redhat.com/ubi10/ubi-minimal"
+name: &name "ubi10/openjdk-25"
+version: &version "1.23"
+description: "Source To Image (S2I) image for Red Hat OpenShift providing OpenJDK 25"
+
+labels:
+- name: "io.k8s.description"
+  value: "Platform for building and running plain Java applications (fat-jar and flat classpath)"
+- name: "io.k8s.display-name"
+  value: "Java Applications"
+- name: "io.openshift.tags"
+  value: "builder,java"
+- name: "maintainer"
+  value: "Red Hat OpenJDK <openjdk@redhat.com>"
+- name: "com.redhat.component"
+  value: "openjdk-25-ubi10-container"
+- name: "usage"
+  value: &docs "https://rh-openjdk.github.io/redhat-openjdk-containers/"
+- name: "com.redhat.license_terms"
+  value: "https://www.redhat.com/en/about/red-hat-end-user-license-agreements#UBI"
+- name: "org.opencontainers.image.documentation"
+  value: *docs
+- name: "name"
+  value: *name
+- name: "version"
+  value: *version
+- name: "org.opencontainers.image.source"
+  value: "https://github.com/rh-openjdk/redhat-openjdk-containers"
+- name: "org.opencontainers.image.revision"
+  value: "ubi10"
+
+envs:
+  # XXX should this move to an s2i module?
+- name: PATH
+  value: $PATH:"/usr/libexec/s2i"
+- name: "JBOSS_IMAGE_NAME"
+  value: *name
+- name: "JBOSS_IMAGE_VERSION"
+  value: *version
+- name: "LANG"
+  value: "C.utf8"
+
+ports:
+- value: 8080
+- value: 8443
+
+modules:
+  repositories:
+  - path: modules
+  install:
+  - name: jboss.container.util.pkg-update
+  - name: jboss.container.openjdk.jdk
+    version: "25"
+  - name: jboss.container.maven
+    version: "3.9.25"
+  - name: jboss.container.java.s2i.bash
+
+help:
+  add: true
+
+packages:
+  manager: microdnf

--- a/ubi10-openjdk-25.yaml
+++ b/ubi10-openjdk-25.yaml
@@ -56,8 +56,9 @@ modules:
   - name: jboss.container.openjdk.jdk
     version: "25"
   - name: jboss.container.maven
-    version: "3.9.25"
+    version: "3.9.21"
   - name: jboss.container.java.s2i.bash
+  - name: jboss.container.java.singleton-jdk
 
 help:
   add: true


### PR DESCRIPTION
https://issues.redhat.com/browse/OPENJDK-4151
https://issues.redhat.com/browse/OPENJDK-4152
https://issues.redhat.com/browse/OPENJDK-4191

To install the right bits and pieces.

Note that `maven-openjdk25` is not available yet, we plan to release before it.