### PR TITLE
[OPENJDK-4284] Shrink JDK modules, re-use env vars from JRE modules

### DIFF
--- a/modules/jdk/21/module.yaml
+++ b/modules/jdk/21/module.yaml
@@ -4,21 +4,7 @@ name: "jboss.container.openjdk.jdk"
 description: "Installs the JDK for OpenJDK 21."
 version: &jdkver "21"
 
-labels:
-- name: "org.jboss.product"
-  value: "openjdk"
-- name: "org.jboss.product.version"
-  value: *jdkver
-- name: "org.jboss.product.openjdk.version"
-  value: *jdkver
-
 envs:
-- name: "JAVA_HOME"
-  value: "/usr/lib/jvm/java-21"
-- name: "JAVA_VENDOR"
-  value: "openjdk"
-- name: "JAVA_VERSION"
-  value: *jdkver
 - name: JBOSS_CONTAINER_OPENJDK_JDK_MODULE
   value: /opt/jboss/container/openjdk/jdk
 

--- a/modules/jdk/25/module.yaml
+++ b/modules/jdk/25/module.yaml
@@ -4,21 +4,7 @@ name: "jboss.container.openjdk.jdk"
 description: "Installs the JDK for OpenJDK 25."
 version: &jdkver "25"
 
-labels:
-- name: "org.jboss.product"
-  value: "openjdk"
-- name: "org.jboss.product.version"
-  value: *jdkver
-- name: "org.jboss.product.openjdk.version"
-  value: *jdkver
-
 envs:
-- name: "JAVA_HOME"
-  value: "/usr/lib/jvm/java-25"
-- name: "JAVA_VENDOR"
-  value: "openjdk"
-- name: "JAVA_VERSION"
-  value: *jdkver
 - name: JBOSS_CONTAINER_OPENJDK_JDK_MODULE
   value: /opt/jboss/container/openjdk/jdk
 

--- a/modules/jre/21/module.yaml
+++ b/modules/jre/21/module.yaml
@@ -14,7 +14,7 @@ labels:
 
 envs:
 - name: "JAVA_HOME"
-  value: "/usr/lib/jvm/jre"
+  value: "/usr/lib/jvm/java-21-openjdk"
 - name: "JAVA_VENDOR"
   value: "openjdk"
 - name: "JAVA_VERSION"

--- a/modules/jre/25/module.yaml
+++ b/modules/jre/25/module.yaml
@@ -14,7 +14,7 @@ labels:
 
 envs:
 - name: "JAVA_HOME"
-  value: "/usr/lib/jvm/jre"
+  value: "/usr/lib/jvm/java-25-openjdk"
 - name: "JAVA_VENDOR"
   value: "openjdk"
 - name: "JAVA_VERSION"


### PR DESCRIPTION
In the JRE modules, set JAVA_HOME to a path which is valid for both the builder and runtime images.

In the JDK modules, stop defining JAVA_HOME, JAVA_VENDOR and JAVA_VERSION: inherit the values from the JRE modules instead.

https://issues.redhat.com/browse/OPENJDK-4284
