### PR TITLE
[OPENJDK-4292] migrate away from osbs-built base images

### DIFF
--- a/redhat/ubi9-openjdk-17-runtime.yaml
+++ b/redhat/ubi9-openjdk-17-runtime.yaml
@@ -1,7 +1,3 @@
-# This OSBS Base Image is designed and engineered to be the base layer for
-# Red Hat products. This base image is only supported for approved Red Hat
-# products. This image is maintained by Red Hat and updated regularly.
-from: registry.redhat.io/rhel9-osbs/osbs-ubi9-minimal
 osbs:
   configuration:
     container:

--- a/redhat/ubi9-openjdk-17.yaml
+++ b/redhat/ubi9-openjdk-17.yaml
@@ -1,7 +1,3 @@
-# This OSBS Base Image is designed and engineered to be the base layer for
-# Red Hat products. This base image is only supported for approved Red Hat
-# products. This image is maintained by Red Hat and updated regularly.
-from: registry.redhat.io/rhel9-osbs/osbs-ubi9-minimal
 osbs:
   configuration:
     container:

--- a/redhat/ubi9-openjdk-21-runtime.yaml
+++ b/redhat/ubi9-openjdk-21-runtime.yaml
@@ -1,7 +1,3 @@
-# This OSBS Base Image is designed and engineered to be the base layer for
-# Red Hat products. This base image is only supported for approved Red Hat
-# products. This image is maintained by Red Hat and updated regularly.
-from: registry.redhat.io/rhel9-osbs/osbs-ubi9-minimal
 osbs:
   configuration:
     container:

--- a/redhat/ubi9-openjdk-21.yaml
+++ b/redhat/ubi9-openjdk-21.yaml
@@ -1,7 +1,3 @@
-# This OSBS Base Image is designed and engineered to be the base layer for
-# Red Hat products. This base image is only supported for approved Red Hat
-# products. This image is maintained by Red Hat and updated regularly.
-from: registry.redhat.io/rhel9-osbs/osbs-ubi9-minimal
 osbs:
   configuration:
     container:


### PR DESCRIPTION
https://issues.redhat.com/browse/OPENJDK-4292

This moves (redhat) builds back to using the public UBI image URIs.