### PR TITLE
Use singleton-jdk for JDK25 images

### DIFF
--- a/modules/jdk/latest/module.yaml
+++ b/modules/jdk/latest/module.yaml
@@ -16,7 +16,7 @@ envs:
 - name: "JAVA_HOME"
   value: "/usr/lib/jvm/java-25"
 - name: "JAVA_VENDOR"
-  value: "openjdk"
+  value: "epel"
 - name: "JAVA_VERSION"
   value: *jdkver
 - name: JBOSS_CONTAINER_OPENJDK_JDK_MODULE

--- a/modules/singleton-jdk/configure.sh
+++ b/modules/singleton-jdk/configure.sh
@@ -14,11 +14,3 @@ fi
 # Clean up any java-* packages that have been installed that do not match
 # our stated JAVA_VERSION-JAVA_VENDOR (e.g.: 11-openjdk; 1.8.0-openj9)
 rpm -e --nodeps $(rpm -qa java-* | grep -v "^java-${JAVA_VERSION}-${JAVA_VENDOR}")
-
-# workaround for <https://issues.redhat.com/browse/RHEL-3437>
-# The alternative link groups touched here need to match up with those set in
-# modules/jdk/*/configure.sh
-_arch="$(uname -i)"
-for alt in java javac java_sdk_openjdk jre_openjdk; do
-  alternatives --set "$alt" "java-${JAVA_VERSION}-${JAVA_VENDOR}.${_arch}"
-done

--- a/modules/singleton-jdk/configure.sh
+++ b/modules/singleton-jdk/configure.sh
@@ -1,6 +1,6 @@
-#!/bin/sh
-set -u
-set -e
+#!/bin/bash
+set -ueo pipefail
+set -x
 
 if [ -z "$JAVA_VERSION" ]; then
   echo "JAVA_VERSION needs to be defined to use this module" >&2
@@ -11,6 +11,15 @@ if [ -z "$JAVA_VENDOR" ]; then
   exit 1
 fi
 
+# java-latest/EPEL does not follow the pattern expected
+if [ "$JAVA_VENDOR" = "epel" ]; then
+  JAVA_VERSION=latest
+  JAVA_VENDOR=openjdk
+fi
+
 # Clean up any java-* packages that have been installed that do not match
 # our stated JAVA_VERSION-JAVA_VENDOR (e.g.: 11-openjdk; 1.8.0-openj9)
 rpm -e --nodeps $(rpm -qa java-* | grep -v "^java-${JAVA_VERSION}-${JAVA_VENDOR}")
+
+# sanity check: there should still be a java installed
+command -v java

--- a/ubi9-openjdk-25.yaml
+++ b/ubi9-openjdk-25.yaml
@@ -56,7 +56,7 @@ modules:
     version: "latest"
   - name: jboss.container.maven
     version: "3.9.21"
-  - name: jboss.container.util.tzdata
+  - name: jboss.container.java.singleton-jdk
   - name: jboss.container.java.s2i.bash
   - name: jboss.container.util.tzdata
 


### PR DESCRIPTION
It's not clear yet that we will have `maven-openjdk25` available at the time we want to ship. So, we may need to pull `maven-openjdk21` in the build phase and clean up multiple JDKs.