### PR TITLE
[OPENJDK-4363] Update ocp templates (version ranges, JDK25 images)

### DIFF
--- a/templates/community-image-streams.json
+++ b/templates/community-image-streams.json
@@ -267,6 +267,25 @@
                             "kind": "DockerImage",
                             "name": "registry.access.redhat.com/ubi8/openjdk-8:1.21"
                         }
+                    },
+                    {
+                        "name": "1.23",
+                        "annotations": {
+                            "openshift.io/display-name": "Red Hat OpenJDK 8 (UBI8)",
+                            "description": "Build and run Java applications using Maven and OpenJDK 8 upon UBI8.",
+                            "iconClass": "icon-rh-openjdk",
+                            "tags": "builder,java,openjdk,ubi8",
+                            "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts",
+                            "sampleContextDir": "undertow-servlet",
+                            "version": "1.23"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
+                        },
+                        "from": {
+                            "kind": "DockerImage",
+                            "name": "registry.access.redhat.com/ubi8/openjdk-8:1.23"
+                        }
                     }
                 ]
             }
@@ -753,6 +772,25 @@
                             "kind": "DockerImage",
                             "name": "registry.access.redhat.com/ubi8/openjdk-17:1.21"
                         }
+                    },
+                    {
+                        "name": "1.23",
+                        "annotations": {
+                            "openshift.io/display-name": "Red Hat OpenJDK 17 (UBI8)",
+                            "description": "Build and run Java applications using Maven and OpenJDK 17 upon UBI8.",
+                            "iconClass": "icon-rh-openjdk",
+                            "tags": "builder,java,openjdk,ubi8",
+                            "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts",
+                            "sampleContextDir": "undertow-servlet",
+                            "version": "1.23"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
+                        },
+                        "from": {
+                            "kind": "DockerImage",
+                            "name": "registry.access.redhat.com/ubi8/openjdk-17:1.23"
+                        }
                     }
                 ]
             }
@@ -843,6 +881,25 @@
                         "from": {
                             "kind": "DockerImage",
                             "name": "registry.access.redhat.com/ubi8/openjdk-21:1.21"
+                        }
+                    },
+                    {
+                        "name": "1.23",
+                        "annotations": {
+                            "openshift.io/display-name": "Red Hat OpenJDK 21 (UBI8)",
+                            "description": "Build and run Java applications using Maven and OpenJDK 21 upon UBI8.",
+                            "iconClass": "icon-rh-openjdk",
+                            "tags": "builder,java,openjdk,ubi8",
+                            "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts",
+                            "sampleContextDir": "undertow-servlet",
+                            "version": "1.23"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
+                        },
+                        "from": {
+                            "kind": "DockerImage",
+                            "name": "registry.access.redhat.com/ubi8/openjdk-21:1.23"
                         }
                     }
                 ]

--- a/templates/data.yaml
+++ b/templates/data.yaml
@@ -24,8 +24,8 @@ rhel7:
       not: [ 2, 3, 4, 5, 6, 7, 8, 9, 13 ]
 ubi8:
   from: 3
-  to: 21
-  not: [ 4, 5, 6, 7, 8, 9 ]
+  to: 23
+  not: [ 4, 5, 6, 7, 8, 9, 22 ]
   builder: # "ubi8/openjdk-X"
     8:  {}
     11:
@@ -52,12 +52,14 @@ ubi8:
 # ubi9 is not yet being used in any templates
 ubi9:
   from: 13
-  to: 21
+  to: 24
   builder:
     11: {}
     17: {}
     21:
       from: 17
+    25:
+      from: 24
   runtime:
     11:
       name: "ubi9/openjdk-11-runtime"
@@ -66,3 +68,6 @@ ubi9:
     21:
       name: "ubi9/openjdk-21-runtime"
       from: 17
+    25:
+      name: "ubi9/openjdk-25-runtime"
+      from: 24

--- a/templates/image-streams-aarch64.json
+++ b/templates/image-streams-aarch64.json
@@ -267,6 +267,25 @@
                             "kind": "DockerImage",
                             "name": "registry.access.redhat.com/ubi8/openjdk-8:1.21"
                         }
+                    },
+                    {
+                        "name": "1.23",
+                        "annotations": {
+                            "openshift.io/display-name": "Red Hat OpenJDK 8 (UBI8)",
+                            "description": "Build and run Java applications using Maven and OpenJDK 8 upon UBI8.",
+                            "iconClass": "icon-rh-openjdk",
+                            "tags": "builder,java,openjdk,ubi8,hidden",
+                            "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts",
+                            "sampleContextDir": "undertow-servlet",
+                            "version": "1.23"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
+                        },
+                        "from": {
+                            "kind": "DockerImage",
+                            "name": "registry.access.redhat.com/ubi8/openjdk-8:1.23"
+                        }
                     }
                 ]
             }
@@ -753,6 +772,25 @@
                             "kind": "DockerImage",
                             "name": "registry.access.redhat.com/ubi8/openjdk-17:1.21"
                         }
+                    },
+                    {
+                        "name": "1.23",
+                        "annotations": {
+                            "openshift.io/display-name": "Red Hat OpenJDK 17 (UBI8)",
+                            "description": "Build and run Java applications using Maven and OpenJDK 17 upon UBI8.",
+                            "iconClass": "icon-rh-openjdk",
+                            "tags": "builder,java,openjdk,ubi8,hidden",
+                            "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts",
+                            "sampleContextDir": "undertow-servlet",
+                            "version": "1.23"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
+                        },
+                        "from": {
+                            "kind": "DockerImage",
+                            "name": "registry.access.redhat.com/ubi8/openjdk-17:1.23"
+                        }
                     }
                 ]
             }
@@ -843,6 +881,25 @@
                         "from": {
                             "kind": "DockerImage",
                             "name": "registry.access.redhat.com/ubi8/openjdk-21:1.21"
+                        }
+                    },
+                    {
+                        "name": "1.23",
+                        "annotations": {
+                            "openshift.io/display-name": "Red Hat OpenJDK 21 (UBI8)",
+                            "description": "Build and run Java applications using Maven and OpenJDK 21 upon UBI8.",
+                            "iconClass": "icon-rh-openjdk",
+                            "tags": "builder,java,openjdk,ubi8,hidden",
+                            "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts",
+                            "sampleContextDir": "undertow-servlet",
+                            "version": "1.23"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
+                        },
+                        "from": {
+                            "kind": "DockerImage",
+                            "name": "registry.access.redhat.com/ubi8/openjdk-21:1.23"
                         }
                     }
                 ]

--- a/templates/image-streams-ppc64le.json
+++ b/templates/image-streams-ppc64le.json
@@ -695,6 +695,25 @@
                             "kind": "DockerImage",
                             "name": "registry.access.redhat.com/ubi8/openjdk-8:1.21"
                         }
+                    },
+                    {
+                        "name": "1.23",
+                        "annotations": {
+                            "openshift.io/display-name": "Red Hat OpenJDK 8 (UBI8)",
+                            "description": "Build and run Java applications using Maven and OpenJDK 8 upon UBI8.",
+                            "iconClass": "icon-rh-openjdk",
+                            "tags": "builder,java,openjdk,ubi8,hidden",
+                            "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts",
+                            "sampleContextDir": "undertow-servlet",
+                            "version": "1.23"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
+                        },
+                        "from": {
+                            "kind": "DockerImage",
+                            "name": "registry.access.redhat.com/ubi8/openjdk-8:1.23"
+                        }
                     }
                 ]
             }
@@ -1181,6 +1200,25 @@
                             "kind": "DockerImage",
                             "name": "registry.access.redhat.com/ubi8/openjdk-17:1.21"
                         }
+                    },
+                    {
+                        "name": "1.23",
+                        "annotations": {
+                            "openshift.io/display-name": "Red Hat OpenJDK 17 (UBI8)",
+                            "description": "Build and run Java applications using Maven and OpenJDK 17 upon UBI8.",
+                            "iconClass": "icon-rh-openjdk",
+                            "tags": "builder,java,openjdk,ubi8,hidden",
+                            "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts",
+                            "sampleContextDir": "undertow-servlet",
+                            "version": "1.23"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
+                        },
+                        "from": {
+                            "kind": "DockerImage",
+                            "name": "registry.access.redhat.com/ubi8/openjdk-17:1.23"
+                        }
                     }
                 ]
             }
@@ -1271,6 +1309,25 @@
                         "from": {
                             "kind": "DockerImage",
                             "name": "registry.access.redhat.com/ubi8/openjdk-21:1.21"
+                        }
+                    },
+                    {
+                        "name": "1.23",
+                        "annotations": {
+                            "openshift.io/display-name": "Red Hat OpenJDK 21 (UBI8)",
+                            "description": "Build and run Java applications using Maven and OpenJDK 21 upon UBI8.",
+                            "iconClass": "icon-rh-openjdk",
+                            "tags": "builder,java,openjdk,ubi8,hidden",
+                            "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts",
+                            "sampleContextDir": "undertow-servlet",
+                            "version": "1.23"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
+                        },
+                        "from": {
+                            "kind": "DockerImage",
+                            "name": "registry.access.redhat.com/ubi8/openjdk-21:1.23"
                         }
                     }
                 ]

--- a/templates/image-streams-s390x.json
+++ b/templates/image-streams-s390x.json
@@ -695,6 +695,25 @@
                             "kind": "DockerImage",
                             "name": "registry.access.redhat.com/ubi8/openjdk-8:1.21"
                         }
+                    },
+                    {
+                        "name": "1.23",
+                        "annotations": {
+                            "openshift.io/display-name": "Red Hat OpenJDK 8 (UBI8)",
+                            "description": "Build and run Java applications using Maven and OpenJDK 8 upon UBI8.",
+                            "iconClass": "icon-rh-openjdk",
+                            "tags": "builder,java,openjdk,ubi8,hidden",
+                            "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts",
+                            "sampleContextDir": "undertow-servlet",
+                            "version": "1.23"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
+                        },
+                        "from": {
+                            "kind": "DockerImage",
+                            "name": "registry.access.redhat.com/ubi8/openjdk-8:1.23"
+                        }
                     }
                 ]
             }
@@ -1181,6 +1200,25 @@
                             "kind": "DockerImage",
                             "name": "registry.access.redhat.com/ubi8/openjdk-17:1.21"
                         }
+                    },
+                    {
+                        "name": "1.23",
+                        "annotations": {
+                            "openshift.io/display-name": "Red Hat OpenJDK 17 (UBI8)",
+                            "description": "Build and run Java applications using Maven and OpenJDK 17 upon UBI8.",
+                            "iconClass": "icon-rh-openjdk",
+                            "tags": "builder,java,openjdk,ubi8,hidden",
+                            "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts",
+                            "sampleContextDir": "undertow-servlet",
+                            "version": "1.23"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
+                        },
+                        "from": {
+                            "kind": "DockerImage",
+                            "name": "registry.access.redhat.com/ubi8/openjdk-17:1.23"
+                        }
                     }
                 ]
             }
@@ -1271,6 +1309,25 @@
                         "from": {
                             "kind": "DockerImage",
                             "name": "registry.access.redhat.com/ubi8/openjdk-21:1.21"
+                        }
+                    },
+                    {
+                        "name": "1.23",
+                        "annotations": {
+                            "openshift.io/display-name": "Red Hat OpenJDK 21 (UBI8)",
+                            "description": "Build and run Java applications using Maven and OpenJDK 21 upon UBI8.",
+                            "iconClass": "icon-rh-openjdk",
+                            "tags": "builder,java,openjdk,ubi8,hidden",
+                            "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts",
+                            "sampleContextDir": "undertow-servlet",
+                            "version": "1.23"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
+                        },
+                        "from": {
+                            "kind": "DockerImage",
+                            "name": "registry.access.redhat.com/ubi8/openjdk-21:1.23"
                         }
                     }
                 ]

--- a/templates/image-streams.json
+++ b/templates/image-streams.json
@@ -735,6 +735,25 @@
                             "kind": "DockerImage",
                             "name": "registry.access.redhat.com/ubi8/openjdk-8:1.21"
                         }
+                    },
+                    {
+                        "name": "1.23",
+                        "annotations": {
+                            "openshift.io/display-name": "Red Hat OpenJDK 8 (UBI8)",
+                            "description": "Build and run Java applications using Maven and OpenJDK 8 upon UBI8.",
+                            "iconClass": "icon-rh-openjdk",
+                            "tags": "builder,java,openjdk,ubi8,hidden",
+                            "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts",
+                            "sampleContextDir": "undertow-servlet",
+                            "version": "1.23"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
+                        },
+                        "from": {
+                            "kind": "DockerImage",
+                            "name": "registry.access.redhat.com/ubi8/openjdk-8:1.23"
+                        }
                     }
                 ]
             }
@@ -1221,6 +1240,25 @@
                             "kind": "DockerImage",
                             "name": "registry.access.redhat.com/ubi8/openjdk-17:1.21"
                         }
+                    },
+                    {
+                        "name": "1.23",
+                        "annotations": {
+                            "openshift.io/display-name": "Red Hat OpenJDK 17 (UBI8)",
+                            "description": "Build and run Java applications using Maven and OpenJDK 17 upon UBI8.",
+                            "iconClass": "icon-rh-openjdk",
+                            "tags": "builder,java,openjdk,ubi8,hidden",
+                            "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts",
+                            "sampleContextDir": "undertow-servlet",
+                            "version": "1.23"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
+                        },
+                        "from": {
+                            "kind": "DockerImage",
+                            "name": "registry.access.redhat.com/ubi8/openjdk-17:1.23"
+                        }
                     }
                 ]
             }
@@ -1311,6 +1349,25 @@
                         "from": {
                             "kind": "DockerImage",
                             "name": "registry.access.redhat.com/ubi8/openjdk-21:1.21"
+                        }
+                    },
+                    {
+                        "name": "1.23",
+                        "annotations": {
+                            "openshift.io/display-name": "Red Hat OpenJDK 21 (UBI8)",
+                            "description": "Build and run Java applications using Maven and OpenJDK 21 upon UBI8.",
+                            "iconClass": "icon-rh-openjdk",
+                            "tags": "builder,java,openjdk,ubi8,hidden",
+                            "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts",
+                            "sampleContextDir": "undertow-servlet",
+                            "version": "1.23"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
+                        },
+                        "from": {
+                            "kind": "DockerImage",
+                            "name": "registry.access.redhat.com/ubi8/openjdk-21:1.23"
                         }
                     }
                 ]

--- a/templates/runtime-image-streams.json
+++ b/templates/runtime-image-streams.json
@@ -254,6 +254,42 @@
                             "kind": "DockerImage",
                             "name": "registry.access.redhat.com/ubi8/openjdk-8-runtime:1.21"
                         }
+                    },
+                    {
+                        "name": "1.22",
+                        "annotations": {
+                            "openshift.io/display-name": "Red Hat OpenJDK 8 Runtime (UBI8)",
+                            "description": "Run Java applications using OpenJDK 8 upon UBI8.",
+                            "iconClass": "icon-rh-openjdk",
+                            "tags": "java,openjdk,ubi8",
+                            
+                            "version": "1.22"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
+                        },
+                        "from": {
+                            "kind": "DockerImage",
+                            "name": "registry.access.redhat.com/ubi8/openjdk-8-runtime:1.22"
+                        }
+                    },
+                    {
+                        "name": "1.23",
+                        "annotations": {
+                            "openshift.io/display-name": "Red Hat OpenJDK 8 Runtime (UBI8)",
+                            "description": "Run Java applications using OpenJDK 8 upon UBI8.",
+                            "iconClass": "icon-rh-openjdk",
+                            "tags": "java,openjdk,ubi8",
+                            
+                            "version": "1.23"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
+                        },
+                        "from": {
+                            "kind": "DockerImage",
+                            "name": "registry.access.redhat.com/ubi8/openjdk-8-runtime:1.23"
+                        }
                     }
                 ]
             }
@@ -716,6 +752,42 @@
                             "kind": "DockerImage",
                             "name": "registry.access.redhat.com/ubi8/openjdk-17-runtime:1.21"
                         }
+                    },
+                    {
+                        "name": "1.22",
+                        "annotations": {
+                            "openshift.io/display-name": "Red Hat OpenJDK 17 Runtime (UBI8)",
+                            "description": "Run Java applications using OpenJDK 17 upon UBI8.",
+                            "iconClass": "icon-rh-openjdk",
+                            "tags": "java,openjdk,ubi8",
+                            
+                            "version": "1.22"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
+                        },
+                        "from": {
+                            "kind": "DockerImage",
+                            "name": "registry.access.redhat.com/ubi8/openjdk-17-runtime:1.22"
+                        }
+                    },
+                    {
+                        "name": "1.23",
+                        "annotations": {
+                            "openshift.io/display-name": "Red Hat OpenJDK 17 Runtime (UBI8)",
+                            "description": "Run Java applications using OpenJDK 17 upon UBI8.",
+                            "iconClass": "icon-rh-openjdk",
+                            "tags": "java,openjdk,ubi8",
+                            
+                            "version": "1.23"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
+                        },
+                        "from": {
+                            "kind": "DockerImage",
+                            "name": "registry.access.redhat.com/ubi8/openjdk-17-runtime:1.23"
+                        }
                     }
                 ]
             }
@@ -802,6 +874,42 @@
                         "from": {
                             "kind": "DockerImage",
                             "name": "registry.access.redhat.com/ubi8/openjdk-21-runtime:1.21"
+                        }
+                    },
+                    {
+                        "name": "1.22",
+                        "annotations": {
+                            "openshift.io/display-name": "Red Hat OpenJDK 21 Runtime (UBI8)",
+                            "description": "Run Java applications using OpenJDK 21 upon UBI8.",
+                            "iconClass": "icon-rh-openjdk",
+                            "tags": "java,openjdk,ubi8",
+                            
+                            "version": "1.22"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
+                        },
+                        "from": {
+                            "kind": "DockerImage",
+                            "name": "registry.access.redhat.com/ubi8/openjdk-21-runtime:1.22"
+                        }
+                    },
+                    {
+                        "name": "1.23",
+                        "annotations": {
+                            "openshift.io/display-name": "Red Hat OpenJDK 21 Runtime (UBI8)",
+                            "description": "Run Java applications using OpenJDK 21 upon UBI8.",
+                            "iconClass": "icon-rh-openjdk",
+                            "tags": "java,openjdk,ubi8",
+                            
+                            "version": "1.23"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
+                        },
+                        "from": {
+                            "kind": "DockerImage",
+                            "name": "registry.access.redhat.com/ubi8/openjdk-21-runtime:1.23"
                         }
                     }
                 ]


### PR DESCRIPTION
https://issues.redhat.com/browse/OPENJDK-4363