### PR TITLE
[OPENJDK-4568] permit overriding maven_init_var_MAVEN_SETTINGS_XML

### DIFF
--- a/modules/maven/s2i/artifacts/opt/jboss/container/maven/s2i/maven-overrides
+++ b/modules/maven/s2i/artifacts/opt/jboss/container/maven/s2i/maven-overrides
@@ -5,14 +5,19 @@ function maven_init_var_MAVEN_LOCAL_REPO() {
 
 # if not already defined, look for settings.xml in <source>/configuration
 function maven_init_var_MAVEN_SETTINGS_XML() {
-  if [ -f "${MAVEN_SETTINGS_XML}" ]; then
-    :
-  elif [ -f "${S2I_SOURCE_DIR}/configuration/settings.xml" ]; then
-    MAVEN_SETTINGS_XML="${S2I_SOURCE_DIR}/configuration/settings.xml"
+  if [ -n "$(type -t maven_init_var_MAVEN_SETTINGS_XML_overrides)" ]; then
+    eval maven_init_var_MAVEN_SETTINGS_XML_overrides $*
+    return $?
   else
-    MAVEN_SETTINGS_XML="${_MAVEN_S2I_SETTINGS_XML}"
-    mkdir -p $(dirname "${MAVEN_SETTINGS_XML}")
-    cp "${JBOSS_CONTAINER_MAVEN_DEFAULT_MODULE}/jboss-settings.xml" "${MAVEN_SETTINGS_XML}"
+      if [ -f "${MAVEN_SETTINGS_XML}" ]; then
+        :
+      elif [ -f "${S2I_SOURCE_DIR}/configuration/settings.xml" ]; then
+        MAVEN_SETTINGS_XML="${S2I_SOURCE_DIR}/configuration/settings.xml"
+      else
+        MAVEN_SETTINGS_XML="${_MAVEN_S2I_SETTINGS_XML}"
+        mkdir -p $(dirname "${MAVEN_SETTINGS_XML}")
+        cp "${JBOSS_CONTAINER_MAVEN_DEFAULT_MODULE}/jboss-settings.xml" "${MAVEN_SETTINGS_XML}"
+      fi
   fi
 }
 

--- a/modules/maven/s2i/tests/features/java_s2i.feature
+++ b/modules/maven/s2i/tests/features/java_s2i.feature
@@ -186,6 +186,13 @@ Feature: Openshift OpenJDK S2I tests
        | MAVEN_SETTINGS_XML | /tmp/src/settings.xml |
       Then s2i build log should contain Rule 0: org.apache.maven.enforcer.rules.RequireActiveProfile passed
 
+  Scenario: Ensure maven_init_var_MAVEN_SETTINGS_XML can be overridden via maven_init_var_MAVEN_SETTINGS_XML_overrides function (Issue #629)
+      Given s2i build https://github.com/rh-openjdk/openjdk-container-test-applications.git from issue-629-maven-settings-xml-override with env
+       | variable   | value    |
+       | MAVEN_ARGS | validate |
+      Then s2i build log should contain Using custom MAVEN_SETTINGS_XML override
+      And s2i build log should contain Rule 0: org.apache.maven.enforcer.rules.RequireActiveProfile passed
+
   Scenario: Ensure that run-env.sh placed in the JAVA_APP_DIR is sourced in the run script before launching java
       Given s2i build https://github.com/rh-openjdk/openjdk-container-test-applications.git from quarkus-quickstarts/getting-started-3.0.1.Final-nos2i
        | variable            | value        |


### PR DESCRIPTION
This is a fix for #629 

_edit: https://issues.redhat.com/browse/OPENJDK-4568_