### PR TITLE
Adjust GHA test job to summarize test results in another step

### DIFF
--- a/.github/workflows/image-workflow-template.yml
+++ b/.github/workflows/image-workflow-template.yml
@@ -42,4 +42,7 @@ jobs:
       - name: Behave Tests
         run: |
           echo /home/runner/work/_temp/openshift-bin >> $GITHUB_PATH
-          cekit -v --descriptor ${{ inputs.image }}.yaml test behave
+          script -c "cekit -v --descriptor ${{ inputs.image }}.yaml test behave"
+
+      - name: summarize test results
+        run: sed -ne '/\(Failing scenarios:\|features\? passed,\)/,$p' < typescript


### PR DESCRIPTION
This collects the tail of the test run log in a separate step, which is easier to view at a glance. Future work could echo it into a comment on a PR, or save the test log as an artefact, etc.

Example output, failing test

```
Failing scenarios:
  features/image/imagebasic.feature:5  Check that common labels are correctly set

0 features passed, 1 failed, 18 skipped
2 scenarios passed, 1 failed, 73 skipped
7 steps passed, 1 failed, 213 skipped, 0 undefined
Took 0m10.516s
2026-03-05 10:09:55,015 cli.py:565        ERROR Test execution failed, please consult output above

Script done on 2026-03-05 10:09:55+00:00 [COMMAND_EXIT_CODE="1"]
```

Example output. no failing tests

```
0 features passed, 0 failed, 18 skipped
0 scenarios passed, 0 failed, 75 skipped
0 steps passed, 0 failed, 218 skipped, 0 undefined
Took 0m0.000s
2026-03-05 10:11:24,797 cli.py:550        INFO  Finished!

Script done on 2026-03-05 10:11:24+00:00 [COMMAND_EXIT_CODE="0"]
```