### PR TITLE
[OPENJDK-4600] Replace redhat/* with konflux metadata

### DIFF
--- a/redhat/ubi10-openjdk-21-runtime.yaml
+++ b/redhat/ubi10-openjdk-21-runtime.yaml
@@ -1,27 +1,12 @@
-osbs:
-  configuration:
-    container:
-      compose:
-        pulp_repos: true
-        packages:
-        - java-21-openjdk-headless
-        signing_intent: release
+konflux:
   repository:
-    name: containers/openjdk
-    branch: openjdk-21-runtime-ubi10
-
-packages:
-  manager: microdnf
-  content_sets:
-    x86_64:
-    - rhel-9-for-x86_64-baseos-rpms
-    - rhel-9-for-x86_64-appstream-rpms
-    ppc64le:
-    - rhel-9-for-ppc64le-baseos-rpms
-    - rhel-9-for-ppc64le-appstream-rpms
-    aarch64:
-    - rhel-9-for-aarch64-baseos-rpms
-    - rhel-9-for-aarch64-appstream-rpms
-    s390x:
-    - rhel-9-for-s390x-baseos-rpms
-    - rhel-9-for-s390x-appstream-rpms
+    uri: git@gitlab.cee.redhat.com:openjdk/openjdk-container-konflux.git
+    ref: openjdk-21-runtime-ubi10-container
+  rpms.in.yaml:
+    contentOrigin:
+      repofiles: ['./ubi.repo']
+    arches:
+      - x86_64
+      - aarch64
+      - ppc64le
+      - s390x

--- a/redhat/ubi10-openjdk-21.yaml
+++ b/redhat/ubi10-openjdk-21.yaml
@@ -1,29 +1,12 @@
-osbs:
-  configuration:
-    container:
-      compose:
-        pulp_repos: true
-        packages:
-        - java-21-openjdk
-        - java-21-openjdk-devel
-        - java-21-openjdk-headless
-        signing_intent: release
+konflux:
   repository:
-    name: containers/openjdk
-    branch: openjdk-21-ubi10
-
-packages:
-  manager: microdnf
-  content_sets:
-    x86_64:
-    - rhel-9-for-x86_64-baseos-rpms
-    - rhel-9-for-x86_64-appstream-rpms
-    ppc64le:
-    - rhel-9-for-ppc64le-baseos-rpms
-    - rhel-9-for-ppc64le-appstream-rpms
-    aarch64:
-    - rhel-9-for-aarch64-baseos-rpms
-    - rhel-9-for-aarch64-appstream-rpms
-    s390x:
-    - rhel-9-for-s390x-baseos-rpms
-    - rhel-9-for-s390x-appstream-rpms
+    uri: git@gitlab.cee.redhat.com:openjdk/openjdk-container-konflux.git
+    ref: openjdk-21-ubi10-container
+  rpms.in.yaml:
+    contentOrigin:
+      repofiles: ['./ubi.repo']
+    arches:
+      - x86_64
+      - aarch64
+      - ppc64le
+      - s390x

--- a/redhat/ubi10-openjdk-25-runtime.yaml
+++ b/redhat/ubi10-openjdk-25-runtime.yaml
@@ -1,28 +1,12 @@
-osbs:
-  configuration:
-    container:
-      compose:
-        pulp_repos: false
-        packages:
-        - java-25-openjdk-headless
-        - maven-openjdk25
-        signing_intent: unsigned
+konflux:
   repository:
-    name: containers/openjdk
-    branch: openjdk-25-runtime-ubi10
-
-packages:
-  manager: microdnf
-  content_sets:
-    x86_64:
-    - rhel-10-for-x86_64-baseos-rpms
-    - rhel-10-for-x86_64-appstream-rpms
-    ppc64le:
-    - rhel-10-for-ppc64le-baseos-rpms
-    - rhel-10-for-ppc64le-appstream-rpms
-    aarch64:
-    - rhel-10-for-aarch64-baseos-rpms
-    - rhel-10-for-aarch64-appstream-rpms
-    s390x:
-    - rhel-10-for-s390x-baseos-rpms
-    - rhel-10-for-s390x-appstream-rpms
+    uri: git@gitlab.cee.redhat.com:openjdk/openjdk-container-konflux.git
+    ref: openjdk-25-runtime-ubi10-container
+  rpms.in.yaml:
+    contentOrigin:
+      repofiles: ['./ubi.repo']
+    arches:
+      - x86_64
+      - aarch64
+      - ppc64le
+      - s390x

--- a/redhat/ubi10-openjdk-25.yaml
+++ b/redhat/ubi10-openjdk-25.yaml
@@ -1,29 +1,12 @@
-osbs:
-  configuration:
-    container:
-      compose:
-        pulp_repos: false
-        packages:
-        - java-25-openjdk
-        - java-25-openjdk-devel
-        - java-25-openjdk-headless
-        signing_intent: unsigned
+konflux:
   repository:
-    name: containers/openjdk
-    branch: openjdk-25-ubi10
-
-packages:
-  manager: microdnf
-  content_sets:
-    x86_64:
-    - rhel-10-for-x86_64-baseos-rpms
-    - rhel-10-for-x86_64-appstream-rpms
-    ppc64le:
-    - rhel-10-for-ppc64le-baseos-rpms
-    - rhel-10-for-ppc64le-appstream-rpms
-    aarch64:
-    - rhel-10-for-aarch64-baseos-rpms
-    - rhel-10-for-aarch64-appstream-rpms
-    s390x:
-    - rhel-10-for-s390x-baseos-rpms
-    - rhel-10-for-s390x-appstream-rpms
+    uri: git@gitlab.cee.redhat.com:openjdk/openjdk-container-konflux.git
+    ref: openjdk-25-ubi10-container
+  rpms.in.yaml:
+    contentOrigin:
+      repofiles: ['./ubi.repo']
+    arches:
+      - x86_64
+      - aarch64
+      - ppc64le
+      - s390x


### PR DESCRIPTION
The data in redhat/* is relevant only for OSBS builds, which we cannot use for UBI10 images. Replace it with data that is useful for Konflux builds instead.

The metadata is not valid for upstream cekit: it's used by my konflux branch https://github.com/jmtd/cekit/tree/konflux

https://issues.redhat.com/browse/OPENJDK-4600