### PR TITLE
[OPENJDK-4598] stop using pkg-update module

### DIFF
--- a/ubi10-openjdk-21-runtime.yaml
+++ b/ubi10-openjdk-21-runtime.yaml
@@ -54,7 +54,6 @@ modules:
   repositories:
   - path: modules
   install:
-  - name: jboss.container.util.pkg-update
   - name: jboss.container.tar
   - name: jboss.container.openjdk.jre
     version: "21"

--- a/ubi10-openjdk-21.yaml
+++ b/ubi10-openjdk-21.yaml
@@ -54,7 +54,6 @@ modules:
   repositories:
   - path: modules
   install:
-  - name: jboss.container.util.pkg-update
   - name: jboss.container.openjdk.jdk
     version: "21"
   - name: jboss.container.maven

--- a/ubi10-openjdk-25-runtime.yaml
+++ b/ubi10-openjdk-25-runtime.yaml
@@ -52,7 +52,6 @@ modules:
   repositories:
   - path: modules
   install:
-  - name: jboss.container.util.pkg-update
   - name: jboss.container.tar
   - name: jboss.container.openjdk.jre
     version: "25"

--- a/ubi10-openjdk-25.yaml
+++ b/ubi10-openjdk-25.yaml
@@ -52,7 +52,6 @@ modules:
   repositories:
   - path: modules
   install:
-  - name: jboss.container.util.pkg-update
   - name: jboss.container.openjdk.jdk
     version: "25"
   - name: jboss.container.maven


### PR DESCRIPTION
This is a no-op with hermetic builds
https://issues.redhat.com/browse/OPENJDK-4598