### PR TITLE
[OPENJDK-4847] installWeakDeps: false for rpm lockfile generation

### DIFF
--- a/redhat/ubi10-openjdk-21-runtime.yaml
+++ b/redhat/ubi10-openjdk-21-runtime.yaml
@@ -10,3 +10,4 @@ konflux:
       - aarch64
       - ppc64le
       - s390x
+    installWeakDeps: false

--- a/redhat/ubi10-openjdk-21.yaml
+++ b/redhat/ubi10-openjdk-21.yaml
@@ -10,3 +10,4 @@ konflux:
       - aarch64
       - ppc64le
       - s390x
+    installWeakDeps: false

--- a/redhat/ubi10-openjdk-25-runtime.yaml
+++ b/redhat/ubi10-openjdk-25-runtime.yaml
@@ -10,3 +10,4 @@ konflux:
       - aarch64
       - ppc64le
       - s390x
+    installWeakDeps: false

--- a/redhat/ubi10-openjdk-25.yaml
+++ b/redhat/ubi10-openjdk-25.yaml
@@ -10,3 +10,4 @@ konflux:
       - aarch64
       - ppc64le
       - s390x
+    installWeakDeps: false


### PR DESCRIPTION

[OPENJDK-4847] installWeakDeps: false for rpm lockfile generation

This file is consumed by
<https://github.com/konflux-ci/rpm-lockfile-prototype> which resolves
the transitive dependencies of the specified RPMs. Without this, the
tool will generate a lockfile containing all transitive weak
dependencies, which results in the security scanning tools flagging
containers erroneously, and merge request churn to update the NVRs
for the unnecessary packages.


https://redhat.atlassian.net/browse/OPENJDK-4847

Note: we are building and shipping images with the effect of this change downstream of cekit.