### PR TITLE
OPENJDK-4822, OPENJDK-4823: install java 25 (not latest), maven-openjdk25 (not 21), remove singleton-jdk

### DIFF
--- a/modules/maven/25/configure.sh
+++ b/modules/maven/25/configure.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+set -e
+
+# This file is shipped by a Maven package and sets JAVA_HOME to
+# an OpenJDK-specific path. This causes problems for OpenJ9 containers
+# as the path is not correct for them.  We don't need this in any of
+# the containers because we set JAVA_HOME in the container metadata.
+# Blank the file rather than removing it, to avoid a warning message
+# from /usr/bin/mvn.
+if [ -f /etc/java/maven.conf ]; then
+  :> /etc/java/maven.conf
+fi

--- a/modules/maven/25/module.yaml
+++ b/modules/maven/25/module.yaml
@@ -1,0 +1,21 @@
+schema_version: 1
+name: jboss.container.maven
+version: '3.9.25'
+description: Provides Maven v3.9 capabilities to an image.
+
+envs:
+- name: JBOSS_CONTAINER_MAVEN_39_MODULE
+  value: /opt/jboss/container/maven/39/
+- name: MAVEN_VERSION
+  value: '3.9'
+
+modules:
+  install:
+  - name: jboss.container.maven.module
+
+packages:
+  install:
+  - maven-openjdk25
+
+execute:
+- script: configure.sh

--- a/ubi9-openjdk-25-runtime.yaml
+++ b/ubi9-openjdk-25-runtime.yaml
@@ -52,7 +52,7 @@ modules:
   - name: jboss.container.util.pkg-update
   - name: jboss.container.tar
   - name: jboss.container.openjdk.jre
-    version: "latest"
+    version: "25"
   - name: jboss.container.util.tzdata
   - name: jboss.container.java.jre.run
 

--- a/ubi9-openjdk-25.yaml
+++ b/ubi9-openjdk-25.yaml
@@ -55,8 +55,7 @@ modules:
   - name: jboss.container.openjdk.jdk
     version: "25"
   - name: jboss.container.maven
-    version: "3.9.21"
-  - name: jboss.container.java.singleton-jdk
+    version: "3.9.25"
   - name: jboss.container.java.s2i.bash
   - name: jboss.container.util.tzdata
 

--- a/ubi9-openjdk-25.yaml
+++ b/ubi9-openjdk-25.yaml
@@ -53,7 +53,7 @@ modules:
   install:
   - name: jboss.container.util.pkg-update
   - name: jboss.container.openjdk.jdk
-    version: "latest"
+    version: "25"
   - name: jboss.container.maven
     version: "3.9.21"
   - name: jboss.container.java.singleton-jdk


### PR DESCRIPTION
The build started to fail due to missing java.security with the `java-latest-*` packages.

A clean-up of the build: use `java-25-*` not `java-latest-*`; use `maven-openjdk25` not `maven-openjdk21`; remove `singleton-jdk` (no longer needed):

https://redhat.atlassian.net/browse/OPENJDK-4822
https://redhat.atlassian.net/browse/OPENJDK-4823